### PR TITLE
Restrict max-parallel matrix testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      max-parallel: 1
       fail-fast: false
       matrix:
         terraform:


### PR DESCRIPTION
I'm seeing a lot of issues where parallel matrix tests
are causing quite a few test failures due to api rate limits.

Hopefully this reduces the issue