### PR TITLE
Add sweeper for orphaned test resources

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -87,3 +87,9 @@ tasks:
     desc: "Remove any local overrides for local development"
     cmds:
       - rm ~/.terraformrc
+
+  sweep:
+    desc: "Remove any leftover resources from failed test runs"
+    dir: "sweep"
+    cmds:
+      - go run .

--- a/client/project_list.go
+++ b/client/project_list.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+func (c *Client) ListProjects(ctx context.Context, teamID string) (r []ProjectResponse, err error) {
+	url := fmt.Sprintf("%s/v8/projects?limit=100", c.baseURL)
+	if teamID != "" {
+		url = fmt.Sprintf("%s&teamId=%s", url, teamID)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		"GET",
+		url,
+		strings.NewReader(""),
+	)
+	if err != nil {
+		return r, err
+	}
+
+	pr := struct {
+		Projects []ProjectResponse `json:"projects"`
+	}{}
+	err = c.doRequest(req, &pr)
+	return pr.Projects, err
+}

--- a/sweep/main.go
+++ b/sweep/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/vercel/terraform-provider-vercel/client"
+)
+
+func main() {
+	// We want to clean up any resources in the account.
+	// It's actually pretty easy - everything is tied to a project,
+	// so removing a project will remove everything else.
+	// This means we only need to delete projects.
+	c := client.New(os.Getenv("VERCEL_API_TOKEN"))
+	teamID := os.Getenv("VERCEL_TERRAFORM_TESTING_TEAM")
+	ctx := context.Background()
+
+	// delete both for the testing team, and for without a team
+	err := deleteAllProjects(ctx, c, teamID)
+	if err != nil {
+		panic(err)
+	}
+	err = deleteAllProjects(ctx, c, "")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func deleteAllProjects(ctx context.Context, c *client.Client, teamID string) error {
+	projects, err := c.ListProjects(ctx, teamID)
+	if err != nil {
+		return fmt.Errorf("error listing projects: %w", err)
+	}
+
+	for _, p := range projects {
+		if !strings.HasPrefix(p.Name, "test-acc") {
+			// Don't delete actual projects - only testing ones
+			continue
+		}
+
+		err = c.DeleteProject(ctx, p.ID, teamID)
+		if err != nil {
+			return fmt.Errorf("error deleting project: %w", err)
+		}
+		log.Printf("Deleted project %s", p.Name)
+	}
+
+	return nil
+}

--- a/vercel/data_source_project_test.go
+++ b/vercel/data_source_project_test.go
@@ -18,7 +18,7 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 			{
 				Config: testAccProjectDataSourceConfig(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.vercel_project.test", "name", name),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "name", "test-acc-"+name),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "build_command", "npm run build"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "dev_command", "npm run serve"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "framework", "nextjs"),
@@ -40,7 +40,7 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 func testAccProjectDataSourceConfig(name string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
-  name = "%s"
+  name = "test-acc-%s"
   build_command = "npm run build"
   dev_command = "npm run serve"
   framework = "nextjs"


### PR DESCRIPTION
- Run via `task sweep`
- Will _automatically_ delete all projects beginning with `test-acc`