### PR TITLE
GitSource: added git source deployment

### DIFF
--- a/client/deployment_create.go
+++ b/client/deployment_create.go
@@ -20,6 +20,11 @@ type DeploymentFile struct {
 	Sha  string `json:"sha"`
 	Size int    `json:"size"`
 }
+type GitSource struct {
+	RepoId string `json:"repoId"`
+	Ref    string `json:"ref"`
+	Type   string `json:"type"`
+}
 
 // CreateDeploymentRequest defines the request the Vercel API expects in order to create a deployment.
 type CreateDeploymentRequest struct {
@@ -35,6 +40,7 @@ type CreateDeploymentRequest struct {
 	Regions         []string               `json:"regions,omitempty"`
 	Routes          []interface{}          `json:"routes,omitempty"`
 	Target          string                 `json:"target,omitempty"`
+	GitSource       *GitSource             `json:"gitSource,omitempty"`
 }
 
 // DeploymentResponse defines the response the Vercel API returns when a deployment is created or updated.
@@ -59,15 +65,16 @@ type DeploymentResponse struct {
 	Build struct {
 		Environment []string `json:"env"`
 	} `json:"build"`
-	AliasAssigned    bool    `json:"aliasAssigned"`
-	ChecksConclusion string  `json:"checksConclusion"`
-	ErrorCode        string  `json:"errorCode"`
-	ErrorMessage     string  `json:"errorMessage"`
-	ID               string  `json:"id"`
-	ProjectID        string  `json:"projectId"`
-	ReadyState       string  `json:"readyState"`
-	Target           *string `json:"target"`
-	URL              string  `json:"url"`
+	AliasAssigned    bool      `json:"aliasAssigned"`
+	ChecksConclusion string    `json:"checksConclusion"`
+	ErrorCode        string    `json:"errorCode"`
+	ErrorMessage     string    `json:"errorMessage"`
+	ID               string    `json:"id"`
+	ProjectID        string    `json:"projectId"`
+	ReadyState       string    `json:"readyState"`
+	Target           *string   `json:"target"`
+	URL              string    `json:"url"`
+	GitSource        GitSource `json:"gitSource"`
 }
 
 // IsComplete is used to determine whether a deployment is still processing, or whether it is fully done.

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -63,13 +63,14 @@ resource "vercel_deployment" "example" {
 
 ### Required
 
-- `files` (Map of String) A map of files to be uploaded for the deployment. This should be provided by a `vercel_project_directory` or `vercel_file` data source.
 - `project_id` (String) The project ID to add the deployment to.
 
 ### Optional
 
 - `delete_on_destroy` (Boolean) Set to true to hard delete the Vercel deployment when destroying the Terraform resource. If unspecified, deployments are retained indefinitely. Note that deleted deployments are not recoverable.
 - `environment` (Map of String) A map of environment variable names to values. These are specific to a Deployment, and can also be configured on the `vercel_project` resource.
+- `files` (Map of String) A map of files to be uploaded for the deployment. This should be provided by a `vercel_project_directory` or `vercel_file` data source. Required if `git_source` is not set
+- `git_source` (Attributes) A map with the Git repo information. Required if `files` is not set (see [below for nested schema](#nestedatt--git_source))
 - `path_prefix` (String) If specified then the `path_prefix` will be stripped from the start of file paths as they are uploaded to Vercel. If this is omitted, then any leading `../`s will be stripped.
 - `production` (Boolean) true if the deployment is a production deployment, meaning production aliases will be assigned.
 - `project_settings` (Attributes) Project settings that will be applied to the deployment. (see [below for nested schema](#nestedatt--project_settings))
@@ -80,6 +81,16 @@ resource "vercel_deployment" "example" {
 - `domains` (List of String) A list of all the domains (default domains, staging domains and production domains) that were assigned upon deployment creation.
 - `id` (String) The ID of this resource.
 - `url` (String) A unique URL that is automatically generated for a deployment.
+
+<a id="nestedatt--git_source"></a>
+### Nested Schema for `git_source`
+
+Optional:
+
+- `ref` (String) Branch or commit hash
+- `repo_id` (String) Frontend git repo ID
+- `type` (String) Type of git repo, supported values are: github
+
 
 <a id="nestedatt--project_settings"></a>
 ### Nested Schema for `project_settings`

--- a/vercel/resource_deployment_test.go
+++ b/vercel/resource_deployment_test.go
@@ -248,6 +248,24 @@ func testAccDeployment(t *testing.T, tid string) {
 	})
 }
 
+func TestAcc_DeployFromGitSource(t *testing.T) {
+	projectSuffix := acctest.RandString(16)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             noopDestroyCheck,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDeployFromGitSource(projectSuffix),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDeploymentExists("vercel_deployment.test", ""),
+					resource.TestCheckResourceAttr("vercel_deployment.test", "production", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDeploymentConfigWithNoDeployment(projectSuffix string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
@@ -325,5 +343,22 @@ resource "vercel_deployment" "test" {
   project_id    = vercel_project.test.id
   files         = data.vercel_file.index.file
   path_prefix   = "../vercel/example"
+}`, projectSuffix)
+}
+
+func testAccDeployFromGitSource(projectSuffix string) string {
+	return fmt.Sprintf(`
+resource "vercel_project" "test" {
+  name = "test-acc-deployment-%s"
+}
+
+resource "vercel_deployment" "test" {
+  project_id    = vercel_project.test.id
+  git_source = {
+    ref = "main"
+    repo_id = "452772221"
+    type = "github"
+  }
+  path_prefix   = "vercel/example"
 }`, projectSuffix)
 }


### PR DESCRIPTION
Followed the API documentation https://vercel.com/docs/rest-api#endpoints/deployments/create-a-new-deployment

This PR makes able the deployment from Git Source avoiding the need of upload the files to Vercel.

It works passing a new parameter called `git_source`, it is a map and it looks like this:
```
resource "vercel_deployment" "deployment" {
  team_id = var.vercel_team_id
  project_id = var.vercel_project_id
  git_source = {
    ref = var.git_branch
    repo_id = var.fe_github_repo_id
    type = "github"
  }
}
```

Here is an example of output, it just works:
```
vercel_deployment.deployment: Creating...
vercel_deployment.deployment: Still creating... [10s elapsed]
vercel_deployment.deployment: Still creating... [20s elapsed]
vercel_deployment.deployment: Still creating... [30s elapsed]
vercel_deployment.deployment: Still creating... [40s elapsed]
vercel_deployment.deployment: Still creating... [50s elapsed]
vercel_deployment.deployment: Still creating... [1m0s elapsed]
vercel_deployment.deployment: Creation complete after 1m6s [id=dpl_EQBQgeWeo5PXesr1MLSjrQC9MRrZ]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
