### PR TITLE
DeleteDeployment: Create a delete deployment method

### DIFF
--- a/client/deployment_delete.go
+++ b/client/deployment_delete.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// DeleteDeploymentResponse defines the response the Vercel API returns when a deployment is deleted.
+type DeleteDeploymentResponse struct {
+	State string `json:"state"`
+	UID   string `json:"uid"`
+}
+
+// DeleteDeployment deletes a deployment within Vercel.
+func (c *Client) DeleteDeployment(ctx context.Context, deploymentID string, teamID string) (r DeleteDeploymentResponse, err error) {
+	url := fmt.Sprintf("%s/v13/deployments/%s", c.baseURL, deploymentID)
+	req, err := http.NewRequest(
+		"DELETE",
+		url,
+		nil,
+	)
+	if err != nil {
+		return r, err
+	}
+
+	// Add query parameters
+	q := req.URL.Query()
+	if teamID != "" {
+		q.Add("teamId", teamID)
+	}
+	req.URL.RawQuery = q.Encode()
+
+	tflog.Trace(ctx, "deleting deployment", map[string]interface{}{
+		"url": url,
+	})
+	err = c.doRequest(req, &r)
+	if err != nil {
+		return r, err
+	}
+
+	return r, nil
+}

--- a/vercel/resource_deployment_model.go
+++ b/vercel/resource_deployment_model.go
@@ -32,6 +32,7 @@ type Deployment struct {
 	ProjectSettings *ProjectSettings  `tfsdk:"project_settings"`
 	TeamID          types.String      `tfsdk:"team_id"`
 	URL             types.String      `tfsdk:"url"`
+	DeleteOnDestroy types.Bool        `tfsdk:"delete_on_destroy"`
 }
 
 // setIfNotUnknown is a helper function to set a value in a map if it is not unknown.
@@ -185,5 +186,6 @@ func convertResponseToDeployment(response client.DeploymentResponse, plan Deploy
 		Files:           plan.Files,
 		PathPrefix:      fillStringNull(plan.PathPrefix),
 		ProjectSettings: plan.ProjectSettings.fillNulls(),
+		DeleteOnDestroy: plan.DeleteOnDestroy,
 	}
 }


### PR DESCRIPTION
For us it is important to delete deployments for terraform consistency

The deletion of the resource worked fine in our tests:
```
Terraform will perform the following actions:

  # vercel_deployment.deployment will be destroyed
  - resource "vercel_deployment" "deployment" {
      - domains    = [
          - "avocado-git-dario-terraform-deployment-test.pollen.run",
        ] -> null
      - git_source = {
          - ref     = "dario-terraform-deployment-test" -> null
          - repo_id = "449314886" -> null
          - type    = "github" -> null
        }
      - id         = "dpl_9gBRCvWiw8ViYzAawNypNfNrLtK2" -> null
      - production = false -> null
      - project_id = "prj_xxxxxxxxxxxxxxxxt" -> null
      - team_id    = "team_xxxxxxxxxxxxxxxxt" -> null
      - url        = "avocado-ibsmgnaua.pollen.run" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Saved the plan to: /tmp/plan.out

To perform exactly these actions, run the following command to apply:
    terraform apply "/tmp/plan.out"
~/dev/pollen/tf_module_vercel_deployment main* ❯ terraform apply /tmp/plan.out                                        
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - vercel/vercel in /terraform-provider-vercel
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
vercel_deployment.deployment: Destroying... [id=dpl_9xxxxxxxxxxxxxxxxtK2]
vercel_deployment.deployment: Destruction complete after 2s

Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
```
The deployment was gone from the vercel console.

If deleted manually in the middle of the operation it fails as expected:
```
 ❯ terraform apply /tmp/plan.out                                        
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - vercel/vercel in /terraform-provider-vercel
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
vercel_deployment.deployment: Destroying... [id=dpl_5xxxxxxxxxxxxxxx]
╷
│ Error: Error deleting deployment
│ 
│ Could not delete deployment xxxxx-iuyda4x0l.pollen.run, unexpected error: not_found - Not found
╵
~/tf_module_vercel_deployment main* ❯ terraform plan --var-file=params.tfvars --out /tmp/plan.out --destroy
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - vercel/vercel in /terraform-provider-vercel
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
vercel_deployment.deployment: Refreshing state... [id=dpl_xxxxxxxxxxxy]

No changes. No objects need to be destroyed.
```