### PR TITLE
Fix environment variable bug following #20

### DIFF
--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -58,6 +58,7 @@ output "project_id" {
 
 Read-Only:
 
+- **git_branch** (String) The git branch of the environment variable.
 - **id** (String) The ID of the environment variable
 - **key** (String) The name of the environment variable.
 - **target** (Set of String) The environments that the environment variable should be present on. Valid targets are either `production`, `preview`, or `development`.

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -78,6 +78,11 @@ For more detailed information, please see the [Vercel documentation](https://ver
 						Type:        types.StringType,
 						Computed:    true,
 					},
+					"git_branch": {
+						Description: "The git branch of the environment variable.",
+						Type:        types.StringType,
+						Computed:    true,
+					},
 				}, tfsdk.SetNestedAttributesOptions{}),
 			},
 			"framework": {


### PR DESCRIPTION
The Project struct is used by both the data_source
and the resource. However, git_branch for environment_variables
were only added to the resource.