### PR TITLE
Fix permissions issue with uploading deployment files

### DIFF
--- a/client/file_create.go
+++ b/client/file_create.go
@@ -9,26 +9,35 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
+type CreateFileRequest struct {
+	Filename string
+	SHA      string
+	Content  string
+	TeamID   string
+}
+
 // CreateFile will upload a file to Vercel so that it can be later used for a Deployment.
-func (c *Client) CreateFile(ctx context.Context, filename, sha, content string) error {
+func (c *Client) CreateFile(ctx context.Context, request CreateFileRequest) error {
 	url := fmt.Sprintf("%s/v2/now/files", c.baseURL)
+	if request.TeamID != "" {
+		url = fmt.Sprintf("%s?teamId=%s", url, request.TeamID)
+	}
 	req, err := http.NewRequestWithContext(
 		ctx,
 		"POST",
 		url,
-		strings.NewReader(content),
+		strings.NewReader(request.Content),
 	)
 	if err != nil {
 		return err
 	}
 
-	req.Header.Add("x-vercel-digest", sha)
+	req.Header.Add("x-vercel-digest", request.SHA)
 	req.Header.Set("Content-Type", "application/octet-stream")
 
 	tflog.Trace(ctx, "uploading file", map[string]interface{}{
-		"url":     url,
-		"payload": mustMarshal(content),
-		"sha":     sha,
+		"url": url,
+		"sha": request.SHA,
 	})
 	err = c.doRequest(req, nil)
 	return err

--- a/vercel/resource_deployment.go
+++ b/vercel/resource_deployment.go
@@ -270,7 +270,12 @@ func (r resourceDeployment) Create(ctx context.Context, req tfsdk.CreateResource
 				return
 			}
 
-			err = r.p.client.CreateFile(ctx, f.File, f.Sha, string(content))
+			err = r.p.client.CreateFile(ctx, client.CreateFileRequest{
+				Filename: f.File,
+				SHA:      f.Sha,
+				Content:  string(content),
+				TeamID:   plan.TeamID.Value,
+			})
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"Error uploading deployment file",


### PR DESCRIPTION
The `CreateFile` API call was omitting the `teamId` parameter, which is required for uploading files as a specific team. This works though, providing the API token has access to the personal account level too. If using a token scoped to a specific team, this would not work. 

Closes #39 