### PR TITLE
Refactor majority of tests to optionally require a team

### DIFF
--- a/vercel/data_source_alias_test.go
+++ b/vercel/data_source_alias_test.go
@@ -15,25 +15,7 @@ func TestAcc_AliasDataSource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAliasDataSourceConfig(name, ""),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.vercel_alias.test", "alias", fmt.Sprintf("test-acc-%s.vercel.app", name)),
-					resource.TestCheckResourceAttrSet("data.vercel_alias.test", "id"),
-					resource.TestCheckResourceAttrSet("data.vercel_alias.test", "deployment_id"),
-				),
-			},
-		},
-	})
-}
-
-func TestAcc_AliasDataSourceTeam(t *testing.T) {
-	name := acctest.RandString(16)
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAliasDataSourceConfig(name, fmt.Sprintf("team_id = \"%s\"", testTeam())),
+				Config: testAccAliasDataSourceConfig(name, teamIDConfig()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vercel_alias.test", "alias", fmt.Sprintf("test-acc-%s.vercel.app", name)),
 					resource.TestCheckResourceAttr("data.vercel_alias.test", "team_id", testTeam()),

--- a/vercel/data_source_project_test.go
+++ b/vercel/data_source_project_test.go
@@ -16,7 +16,7 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectDataSourceConfig(name),
+				Config: testAccProjectDataSourceConfig(name, teamIDConfig()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vercel_project.test", "name", "test-acc-"+name),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "build_command", "npm run build"),
@@ -37,7 +37,7 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 	})
 }
 
-func testAccProjectDataSourceConfig(name string) string {
+func testAccProjectDataSourceConfig(name, teamID string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "test-acc-%s"
@@ -48,6 +48,7 @@ resource "vercel_project" "test" {
   output_directory = ".output"
   public_source = true
   root_directory = "ui/src"
+  %s
   environment = [
     {
       key    = "foo"
@@ -59,6 +60,7 @@ resource "vercel_project" "test" {
 
 data "vercel_project" "test" {
     name = vercel_project.test.name
+    %[2]s
 }
-`, name)
+`, name, teamID)
 }

--- a/vercel/provider_test.go
+++ b/vercel/provider_test.go
@@ -1,6 +1,7 @@
 package vercel_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -25,7 +26,6 @@ func testAccPreCheck(t *testing.T) {
 	mustHaveEnv(t, "VERCEL_TERRAFORM_TESTING_GITHUB_REPO")
 	mustHaveEnv(t, "VERCEL_TERRAFORM_TESTING_GITLAB_REPO")
 	mustHaveEnv(t, "VERCEL_TERRAFORM_TESTING_BITBUCKET_REPO")
-	mustHaveEnv(t, "VERCEL_TERRAFORM_TESTING_TEAM")
 	mustHaveEnv(t, "VERCEL_TERRAFORM_TESTING_DOMAIN")
 }
 
@@ -57,6 +57,13 @@ func testBitbucketRepo() string {
 
 func testTeam() string {
 	return os.Getenv("VERCEL_TERRAFORM_TESTING_TEAM")
+}
+
+func teamIDConfig() string {
+	if testTeam() == "" {
+		return ""
+	}
+	return fmt.Sprintf("team_id = \"%s\"", testTeam())
 }
 
 func testDomain() string {

--- a/vercel/resource_alias_test.go
+++ b/vercel/resource_alias_test.go
@@ -46,34 +46,13 @@ func TestAcc_AliasResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:             testCheckAliasDestroyed("vercel_alias.test", ""),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAliasResourceConfig(name, ""),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testCheckAliasExists("", fmt.Sprintf("test-acc-%s.vercel.app", name)),
-					resource.TestCheckResourceAttr("vercel_alias.test", "alias", fmt.Sprintf("test-acc-%s.vercel.app", name)),
-					resource.TestCheckResourceAttrSet("vercel_alias.test", "id"),
-					resource.TestCheckResourceAttrSet("vercel_alias.test", "deployment_id"),
-				),
-			},
-		},
-	})
-}
-
-func TestAcc_AliasResourceTeam(t *testing.T) {
-	name := acctest.RandString(16)
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy:             testCheckAliasDestroyed("vercel_alias.test", testTeam()),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAliasResourceConfig(name, fmt.Sprintf("team_id = \"%s\"", testTeam())),
+				Config: testAccAliasResourceConfig(name, teamIDConfig()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testCheckAliasExists(testTeam(), fmt.Sprintf("test-acc-%s.vercel.app", name)),
 					resource.TestCheckResourceAttr("vercel_alias.test", "alias", fmt.Sprintf("test-acc-%s.vercel.app", name)),
-					resource.TestCheckResourceAttr("vercel_alias.test", "team_id", testTeam()),
 					resource.TestCheckResourceAttrSet("vercel_alias.test", "id"),
 					resource.TestCheckResourceAttrSet("vercel_alias.test", "deployment_id"),
 				),


### PR DESCRIPTION
- If the VERCEL_TESTING_TEAM env var is present, the tests will use this
  team_id and perform tests against this.
- If the VERCEL_TESTING_TEAM env var is omitted, then the tests will be
  run against a personal Vercel account.

In CI, the env var is present.