### PR TITLE
Support windows filepaths / line endings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,6 @@ jobs:
 
   test:
     name: Matrix Test
-    needs: build
     timeout-minutes: 15
     strategy:
       max-parallel: 1
@@ -80,4 +79,4 @@ jobs:
           VERCEL_TERRAFORM_TESTING_BITBUCKET_REPO: "dglsparsons-test/test"
           VERCEL_TERRAFORM_TESTING_DOMAIN: "dgls.dev"
         run: |
-          go test -v -cover ./...
+          go test ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,15 +38,18 @@ jobs:
   test:
     name: Matrix Test
     needs: build
-    runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       max-parallel: 1
       fail-fast: false
       matrix:
+        os:
+          - "ubuntu-latest"
+          - "windows-latest"
         terraform:
           - "1.1.*"
           - "1.0.*"
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,11 @@ on:
   # TODO - periodically run on a cron to detect API drift.
   # schedule:
   #   - cron: '0 13 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     name: Build

--- a/vercel/data_source_file.go
+++ b/vercel/data_source_file.go
@@ -13,9 +13,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+/*
+* To have the content hash and file sizes remain consistent between different operating systems
+* (important as this prevents spurious file-changes, and thus spurious file uploads), make sure
+* the file content handles line-endings consistently, regardless of the host platform.
+* The simplest way to achieve this is just to replace CRLF with LF.
+ */
 func removeCRLF(content []byte) []byte {
-	bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
-	return content
+	return bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
 }
 
 type dataSourceFileType struct{}

--- a/vercel/data_source_file.go
+++ b/vercel/data_source_file.go
@@ -1,6 +1,7 @@
 package vercel
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
@@ -11,6 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+func removeCRLF(content []byte) []byte {
+	bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
+	return content
+}
 
 type dataSourceFileType struct{}
 
@@ -81,6 +87,7 @@ func (r dataSourceFile) Read(ctx context.Context, req tfsdk.ReadDataSourceReques
 		)
 		return
 	}
+	content = removeCRLF(content)
 
 	rawSha := sha1.Sum(content)
 	sha := hex.EncodeToString(rawSha[:])

--- a/vercel/data_source_file_test.go
+++ b/vercel/data_source_file_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAcc_FileDataSource(t *testing.T) {
+func TestAcc_DataSourceFile(t *testing.T) {
 	t.Parallel()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/vercel/data_source_project_directory.go
+++ b/vercel/data_source_project_directory.go
@@ -111,6 +111,7 @@ func (r dataSourceProjectDirectory) Read(ctx context.Context, req tfsdk.ReadData
 			)
 			return
 		}
+		content = removeCRLF(content)
 		rawSha := sha1.Sum(content)
 		sha := hex.EncodeToString(rawSha[:])
 

--- a/vercel/data_source_project_directory_test.go
+++ b/vercel/data_source_project_directory_test.go
@@ -1,12 +1,13 @@
 package vercel_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAcc_ProjectDirectoryDataSource(t *testing.T) {
+func TestAcc_DataSourceProjectDirectory(t *testing.T) {
 	t.Parallel()
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -16,8 +17,8 @@ func TestAcc_ProjectDirectoryDataSource(t *testing.T) {
 				Config: testAccProjectDirectoryConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vercel_project_directory.test", "path", "example"),
-					resource.TestCheckResourceAttr("data.vercel_project_directory.test", "files.example/index.html", "60~9d3fedcc87ac72f54e75d4be7e06d0a6f8497e68"),
-					resource.TestCheckNoResourceAttr("data.vercel_project_directory.test", "files.example/file2.html"),
+					resource.TestCheckResourceAttr("data.vercel_project_directory.test", filepath.Join("files.example", "index.html"), "60~9d3fedcc87ac72f54e75d4be7e06d0a6f8497e68"),
+					resource.TestCheckNoResourceAttr("data.vercel_project_directory.test", filepath.Join("files.example", "file2.html")),
 				),
 			},
 		},

--- a/vercel/resource_deployment.go
+++ b/vercel/resource_deployment.go
@@ -274,7 +274,7 @@ func (r resourceDeployment) Create(ctx context.Context, req tfsdk.CreateResource
 			}
 
 			err = r.p.client.CreateFile(ctx, client.CreateFileRequest{
-				Filename: f.File,
+				Filename: normaliseFilename(f.File, plan.PathPrefix),
 				SHA:      f.Sha,
 				Content:  string(content),
 				TeamID:   plan.TeamID.Value,

--- a/vercel/resource_deployment_test.go
+++ b/vercel/resource_deployment_test.go
@@ -173,7 +173,6 @@ func TestAcc_DeploymentWithPathPrefix(t *testing.T) {
 }
 
 func TestAcc_DeploymentWithDeleteOnDestroy(t *testing.T) {
-	t.Parallel()
 	projectSuffix := acctest.RandString(16)
 	extraConfig := "delete_on_destroy = true"
 	deploymentID := ""


### PR DESCRIPTION
This change improves the terraform-provider code by supporting Windows in a more consistent/better manner. 

This is done by: 
- ensuring line-endings are disregarded when considering terraform state,
- ensuring path separators are standardised when uploading to Vercel (Closes #50) and when considering terraform state, and,
- adding windows-latest as an OS to run tests against as part of CI. 

Additional changes: 
- I've added a `concurrency` section to the `test` CI workflow. This will prevent outdated tests running if multiple pushes are done in quick succession, and will cancel old CI runs. 