### PR TITLE
Remove windows line-ending conversions

### DIFF
--- a/vercel/data_source_file.go
+++ b/vercel/data_source_file.go
@@ -1,7 +1,6 @@
 package vercel
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
@@ -14,16 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
-
-/*
-* To have the content hash and file sizes remain consistent between different operating systems
-* (important as this prevents spurious file-changes, and thus spurious file uploads), make sure
-* the file content handles line-endings consistently, regardless of the host platform.
-* The simplest way to achieve this is just to replace CRLF with LF.
- */
-func removeCRLF(content []byte) []byte {
-	return bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
-}
 
 type dataSourceFileType struct{}
 
@@ -94,7 +83,6 @@ func (r dataSourceFile) Read(ctx context.Context, req datasource.ReadRequest, re
 		)
 		return
 	}
-	content = removeCRLF(content)
 
 	rawSha := sha1.Sum(content)
 	sha := hex.EncodeToString(rawSha[:])

--- a/vercel/data_source_file_test.go
+++ b/vercel/data_source_file_test.go
@@ -1,10 +1,42 @@
 package vercel_test
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+type Checksums struct {
+	windows string
+	unix    string
+}
+
+func testChecksum(n, attribute string, checksums Checksums) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		sizeAndChecksum := rs.Primary.Attributes[attribute]
+		if runtime.GOOS == "windows" {
+			if sizeAndChecksum != checksums.windows {
+				return fmt.Errorf("attribute %s expected %s but got %s", attribute, checksums.unix, sizeAndChecksum)
+			}
+
+			return nil
+		}
+
+		if sizeAndChecksum != checksums.unix {
+			return fmt.Errorf("attribute %s expected %s but got %s", attribute, checksums.unix, sizeAndChecksum)
+		}
+
+		return nil
+	}
+}
 
 func TestAcc_DataSourceFile(t *testing.T) {
 	t.Parallel()
@@ -17,7 +49,10 @@ func TestAcc_DataSourceFile(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vercel_file.test", "path", "example/index.html"),
 					resource.TestCheckResourceAttr("data.vercel_file.test", "id", "example/index.html"),
-					resource.TestCheckResourceAttr("data.vercel_file.test", "file.example/index.html", "60~9d3fedcc87ac72f54e75d4be7e06d0a6f8497e68"),
+					testChecksum("data.vercel_file.test", "file.example/index.html", Checksums{
+						unix:    "60~9d3fedcc87ac72f54e75d4be7e06d0a6f8497e68",
+						windows: "65~c0b8b91602dc7a394354cd9a21460ce2070b9a13",
+					}),
 				),
 			},
 		},

--- a/vercel/data_source_project_directory.go
+++ b/vercel/data_source_project_directory.go
@@ -113,7 +113,6 @@ func (r dataSourceProjectDirectory) Read(ctx context.Context, req datasource.Rea
 			)
 			return
 		}
-		content = removeCRLF(content)
 		rawSha := sha1.Sum(content)
 		sha := hex.EncodeToString(rawSha[:])
 

--- a/vercel/data_source_project_directory_test.go
+++ b/vercel/data_source_project_directory_test.go
@@ -17,8 +17,14 @@ func TestAcc_DataSourceProjectDirectory(t *testing.T) {
 				Config: testAccProjectDirectoryConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vercel_project_directory.test", "path", "example"),
-					resource.TestCheckResourceAttr("data.vercel_project_directory.test", filepath.Join("files.example", "index.html"), "60~9d3fedcc87ac72f54e75d4be7e06d0a6f8497e68"),
-					resource.TestCheckNoResourceAttr("data.vercel_project_directory.test", filepath.Join("files.example", "file2.html")),
+					testChecksum("data.vercel_project_directory.test", filepath.Join("files.example", "index.html"), Checksums{
+						unix:    "60~9d3fedcc87ac72f54e75d4be7e06d0a6f8497e68",
+						windows: "65~c0b8b91602dc7a394354cd9a21460ce2070b9a13",
+					}),
+					resource.TestCheckNoResourceAttr(
+						"data.vercel_project_directory.test",
+						filepath.Join("files.example", "file2.html"),
+					),
 				),
 			},
 		},

--- a/vercel/resource_deployment.go
+++ b/vercel/resource_deployment.go
@@ -274,7 +274,6 @@ func (r resourceDeployment) Create(ctx context.Context, req resource.CreateReque
 				)
 				return
 			}
-			content = removeCRLF(content)
 
 			err = r.p.client.CreateFile(ctx, client.CreateFileRequest{
 				Filename: normaliseFilename(f.File, plan.PathPrefix),


### PR DESCRIPTION
This was originally implemented to prevent spurious diffs when
swapping the same repository between windows and unix systems.

However, due to the lack of detection of binary files, such as png
images, this can cause some files to be corrupted.

Looking at the [file command behaviour](https://github.com/file/file/blob/f2a6e7cb7db9b5fd86100403df6b2f830c7f22ba/src/encoding.c#L151-L228)
it seems like detecting binary/non-binary files is extremely
non-trivial, and heuristic at best (meaning it could be wrong).

In order to prevent hard to detect/analyse issues, I think it's best to
just accept that some spurious changes can occur if swapping between
systems.

This relates to #50 and #53

Closes #61 