### PR TITLE
Fix DNS Record resource

### DIFF
--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -5,6 +5,7 @@ subcategory: ""
 description: |-
   Provides a DNS Record resource.
   DNS records are instructions that live in authoritative DNS servers and provide information about a domain.
+  ~> The value field must be specified on all DNS record types except SRV. When using SRV DNS records, the srv field must be specified.
   For more detailed information, please see the Vercel documentation https://vercel.com/docs/concepts/projects/custom-domains#dns-records
 ---
 
@@ -13,6 +14,8 @@ description: |-
 Provides a DNS Record resource.
 
 DNS records are instructions that live in authoritative DNS servers and provide information about a domain.
+
+~> The `value` field must be specified on all DNS record types except `SRV`. When using `SRV` DNS records, the `srv` field must be specified.
 
 For more detailed information, please see the [Vercel documentation](https://vercel.com/docs/concepts/projects/custom-domains#dns-records)
 
@@ -97,7 +100,7 @@ resource "vercel_dns_record" "txt" {
 
 - `domain` (String) The domain name, or zone, that the DNS record should be created beneath.
 - `name` (String) The subdomain name of the record. This should be an empty string if the rercord is for the root domain.
-- `type` (String) The type of DNS record.
+- `type` (String) The type of DNS record. Available types: `A`, `AAAA`, `ALIAS`, `CAA`, `CNAME`, `MX`, `NS`, `SRV`, `TXT`.
 
 ### Optional
 

--- a/vercel/resource_dns_record_model.go
+++ b/vercel/resource_dns_record_model.go
@@ -40,6 +40,7 @@ func (d DNSRecord) toCreateDNSRecordRequest() client.CreateDNSRecordRequest {
 			Weight:   d.SRV.Weight.Value,
 		}
 	}
+
 	return client.CreateDNSRecordRequest{
 		Domain:     d.Domain.Value,
 		MXPriority: d.MXPriority.Value,

--- a/vercel/resource_dns_record_test.go
+++ b/vercel/resource_dns_record_test.go
@@ -63,6 +63,7 @@ func TestAcc_DNSRecord(t *testing.T) {
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccDNSRecordDestroy("vercel_dns_record.a_without_ttl", ""),
 			testAccDNSRecordDestroy("vercel_dns_record.a", ""),
 			testAccDNSRecordDestroy("vercel_dns_record.aaaa", ""),
 			testAccDNSRecordDestroy("vercel_dns_record.alias", ""),
@@ -76,6 +77,11 @@ func TestAcc_DNSRecord(t *testing.T) {
 			{
 				Config: testAccDNSRecordConfig(testDomain(), nameSuffix),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDNSRecordExists("vercel_dns_record.a_without_ttl", ""),
+					resource.TestCheckResourceAttr("vercel_dns_record.a", "domain", testDomain()),
+					resource.TestCheckResourceAttr("vercel_dns_record.a", "type", "A"),
+					resource.TestCheckResourceAttr("vercel_dns_record.a", "ttl", "60"),
+					resource.TestCheckResourceAttr("vercel_dns_record.a", "value", "127.0.0.1"),
 					testAccDNSRecordExists("vercel_dns_record.a", ""),
 					resource.TestCheckResourceAttr("vercel_dns_record.a", "domain", testDomain()),
 					resource.TestCheckResourceAttr("vercel_dns_record.a", "type", "A"),
@@ -137,6 +143,11 @@ func TestAcc_DNSRecord(t *testing.T) {
 			{
 				Config: testAccDNSRecordConfigUpdated(testDomain(), nameSuffix),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDNSRecordExists("vercel_dns_record.a_without_ttl", ""),
+					resource.TestCheckResourceAttr("vercel_dns_record.a", "domain", testDomain()),
+					resource.TestCheckResourceAttr("vercel_dns_record.a", "type", "A"),
+					resource.TestCheckResourceAttr("vercel_dns_record.a", "ttl", "120"),
+					resource.TestCheckResourceAttr("vercel_dns_record.a", "value", "127.0.0.1"),
 					testAccDNSRecordExists("vercel_dns_record.a", ""),
 					resource.TestCheckResourceAttr("vercel_dns_record.a", "domain", testDomain()),
 					resource.TestCheckResourceAttr("vercel_dns_record.a", "type", "A"),
@@ -234,6 +245,12 @@ func TestAcc_DNSRecord(t *testing.T) {
 
 func testAccDNSRecordConfig(testDomain, nameSuffix string) string {
 	return fmt.Sprintf(`
+resource "vercel_dns_record" "a_without_ttl" {
+  domain = "%[1]s"
+  name  = "test-acc-%[2]s-a-without-ttl-record"
+  type  = "A"
+  value = "127.0.0.1"
+}
 resource "vercel_dns_record" "a" {
   domain = "%[1]s"
   name  = "test-acc-%[2]s-a-record"
@@ -320,6 +337,13 @@ resource "vercel_dns_record" "ns" {
 
 func testAccDNSRecordConfigUpdated(testDomain, nameSuffix string) string {
 	return fmt.Sprintf(`
+resource "vercel_dns_record" "a_without_ttl" {
+  domain = "%[1]s"
+  name  = "test-acc-%[2]s-a-without-ttl-record"
+  type  = "A"
+  ttl   = 120
+  value = "127.0.0.1"
+}
 resource "vercel_dns_record" "a" {
   domain = "%[1]s"
   name  = "test-acc-%[2]s-a-record-updated"


### PR DESCRIPTION
This PR has the following changes:

- Fixes a bug where omitting `ttl` (defaults to 60) from the resource creates an inconsistent result.
- Adds tests for the above edge case.
- Adds additional validation for preventing to omit `value` for all DNS Record types except of type `SRV`

Closes #62 