### PR TITLE
Mark project_environment_variable value as sensitive

### DIFF
--- a/vercel/resource_project_environment_variable.go
+++ b/vercel/resource_project_environment_variable.go
@@ -48,6 +48,7 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				Required:    true,
 				Description: "The value of the Environment Variable.",
 				Type:        types.StringType,
+				Sensitive:   true,
 			},
 			"git_branch": {
 				Optional:    true,


### PR DESCRIPTION
This prevents it being displayed in plan/apply output. 

Ref #71 