### PR TITLE
Don't fetch env variables on project import

### DIFF
--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -478,7 +478,7 @@ func (r resourceProject) ImportState(ctx context.Context, req resource.ImportSta
 		)
 	}
 
-	out, err := r.p.client.GetProject(ctx, projectID, teamID, true)
+	out, err := r.p.client.GetProject(ctx, projectID, teamID, false)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading project",


### PR DESCRIPTION
If importing a project that explicitly has environment variables, reading them as part of the import can be painful.

See #71 for details.