### PR TITLE
Omit `null` environment variables in vercel_deployment

### DIFF
--- a/vercel/resource_deployment_test.go
+++ b/vercel/resource_deployment_test.go
@@ -109,7 +109,8 @@ func TestAcc_DeploymentWithEnvironment(t *testing.T) {
 			{
 				Config: testAccDeploymentConfig(projectSuffix, teamIDConfig(), `environment = {
                     FOO = "baz",
-                    BAR = "qux"
+                    BAR = "qux",
+                    BAZ = null
                 }`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccDeploymentExists("vercel_deployment.test", ""),
@@ -286,7 +287,7 @@ resource "vercel_deployment" "test" {
   project_id = vercel_project.test.id
   %[2]s
 
-  files       = data.vercel_prebuilt_project.test.output 
+  files       = data.vercel_prebuilt_project.test.output
   path_prefix = data.vercel_prebuilt_project.test.path
 }
 `, projectSuffix, teamID)


### PR DESCRIPTION
Creating a vercel_deployment and passing a `null` environment variable results in a conversion error.
```
An unexpected error was encountered trying to build a value. This is always
an error in the provider. Please report the following to the provider
developer:

Received null value, however the target type cannot handle null values. Use
the corresponding `types` package type, a pointer type or a custom type that
handles null values.

Path: ["BAZ"]
Target Type: string
Suggested `types` Type: basetypes.StringValue
Suggested Pointer Type: *string
```

We need to handle the case where the field value is `null`, which is currently omitted.

Since the API only accepts string values for enviroment variables, the best solution is to simply omit sending `null` to the API altogether.

Closes #95