### PR TITLE
fix the link to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Vercel Terraform Provider
 
 - Website: https://www.terraform.io
-- Documentation: https://registry.terraform.io/providers/vercel/vercel/latest
+- Documentation: https://registry.terraform.io/providers/vercel/vercel/latest/docs
 
 ## Requirements
 


### PR DESCRIPTION
I don't know much about terraform and I got confused when I clicked the link, took me a while to see the "documentation" tab on the right. Maybe this link should point directly to the docs ?