### PR TITLE
Allow computed/null values for `target`

### DIFF
--- a/vercel/validator_string_set_items_in.go
+++ b/vercel/validator_string_set_items_in.go
@@ -45,6 +45,9 @@ func (v validatorStringSetItemsIn) ValidateSet(ctx context.Context, req validato
 
 	for _, i := range req.ConfigValue.Elements() {
 		var item types.String
+		if item.IsUnknown() || item.IsNull() {
+			continue
+		}
 		diags := tfsdk.ValueAs(ctx, i, &item)
 		resp.Diagnostics.Append(diags...)
 		if diags.HasError() {


### PR DESCRIPTION
Validation occurs at plan time, this was breaking the ability to use a variable to determine the `target` field, as variables are computed (or null) at plan time.

Fixes #114