### PR TITLE
Fix issues with removing git_repository from a project

### DIFF
--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -96,9 +97,10 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				Description: "When a commit is pushed to the Git repository that is connected with your Project, its SHA will determine if a new Build has to be issued. If the SHA was deployed before, no new Build will be issued. You can customize this behavior with a command that exits with code 1 (new Build needed) or code 0.",
 			},
 			"serverless_function_region": schema.StringAttribute{
-				Optional:    true,
-				Computed:    true,
-				Description: "The region on Vercel's network to which your Serverless Functions are deployed. It should be close to any data source your Serverless Function might depend on. A new Deployment is required for your changes to take effect. Please see [Vercel's documentation](https://vercel.com/docs/concepts/edge-network/regions) for a full list of regions.",
+				Optional:      true,
+				Computed:      true,
+				Description:   "The region on Vercel's network to which your Serverless Functions are deployed. It should be close to any data source your Serverless Function might depend on. A new Deployment is required for your changes to take effect. Please see [Vercel's documentation](https://vercel.com/docs/concepts/edge-network/regions) for a full list of regions.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 				Validators: []validator.String{
 					validateServerlessFunctionRegion(),
 				},
@@ -145,8 +147,9 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				},
 			},
 			"git_repository": schema.SingleNestedAttribute{
-				Description: "The Git Repository that will be connected to the project. When this is defined, any pushes to the specified connected Git Repository will be automatically deployed. This requires the corresponding Vercel for [Github](https://vercel.com/docs/concepts/git/vercel-for-github), [Gitlab](https://vercel.com/docs/concepts/git/vercel-for-gitlab) or [Bitbucket](https://vercel.com/docs/concepts/git/vercel-for-bitbucket) plugins to be installed.",
-				Optional:    true,
+				Description:   "The Git Repository that will be connected to the project. When this is defined, any pushes to the specified connected Git Repository will be automatically deployed. This requires the corresponding Vercel for [Github](https://vercel.com/docs/concepts/git/vercel-for-github), [Gitlab](https://vercel.com/docs/concepts/git/vercel-for-gitlab) or [Bitbucket](https://vercel.com/docs/concepts/git/vercel-for-bitbucket) plugins to be installed.",
+				Optional:      true,
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.RequiresReplace(), objectplanmodifier.UseStateForUnknown()},
 				Attributes: map[string]schema.Attribute{
 					"type": schema.StringAttribute{
 						Description: "The git provider of the repository. Must be either `github`, `gitlab`, or `bitbucket`.",

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -135,6 +135,13 @@ func TestAcc_ProjectWithGitRepository(t *testing.T) {
 					}),
 				),
 			},
+			{
+				Config: testAccProjectConfigWithGitRepoRemoved(projectSuffix, teamIDConfig()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectExists("vercel_project.test_git", testTeam()),
+					resource.TestCheckNoResourceAttr("vercel_project.test_git", "git_repository"),
+				),
+			},
 		},
 	})
 }
@@ -434,6 +441,23 @@ resource "vercel_project" "test_git" {
   ]
 }
     `, projectSuffix, teamID, testGithubRepo())
+}
+
+func testAccProjectConfigWithGitRepoRemoved(projectSuffix, teamID string) string {
+	return fmt.Sprintf(`
+resource "vercel_project" "test_git" {
+  name = "test-acc-two-%s"
+  %s
+  public_source = false
+  environment = [
+    {
+      key        = "foo"
+      value      = "bar2"
+      target     = ["preview"]
+    }
+  ]
+}
+    `, projectSuffix, teamID)
 }
 
 func projectConfigWithoutEnv(projectSuffix, teamID string) string {


### PR DESCRIPTION
At the moment, this should force recreation of the project, as we don't support updating or removing the linked repository.

See issue #105 for info on this.

However, there is a bug insofar as we don't explicitly flag this as requiring the project to be replaced. This creates an inconsistent plan.

Closes #133 