### PR TITLE
team_id should not be computed

### DIFF
--- a/vercel/data_source_alias.go
+++ b/vercel/data_source_alias.go
@@ -55,7 +55,6 @@ An Alias allows a ` + "`vercel_deployment` to be accessed through a different UR
 		Attributes: map[string]schema.Attribute{
 			"team_id": schema.StringAttribute{
 				Optional:    true,
-				Computed:    true,
 				Description: "The ID of the team the Alias and Deployment exist under. Required when configuring a team resource if a default team has not been set in the provider.",
 			},
 			"alias": schema.StringAttribute{

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -61,7 +61,6 @@ For more detailed information, please see the [Vercel documentation](https://ver
 		Attributes: map[string]schema.Attribute{
 			"team_id": schema.StringAttribute{
 				Optional:    true,
-				Computed:    true,
 				Description: "The team ID the project exists beneath. Required when configuring a team resource if a default team has not been set in the provider.",
 			},
 			"name": schema.StringAttribute{

--- a/vercel/resource_alias.go
+++ b/vercel/resource_alias.go
@@ -68,7 +68,6 @@ An Alias allows a ` + "`vercel_deployment` to be accessed through a different UR
 			},
 			"team_id": schema.StringAttribute{
 				Optional:      true,
-				Computed:      true,
 				Description:   "The ID of the team the Alias and Deployment exist under. Required when configuring a team resource if a default team has not been set in the provider.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},

--- a/vercel/resource_deployment.go
+++ b/vercel/resource_deployment.go
@@ -92,7 +92,6 @@ terraform to your Deployment.
 			"team_id": schema.StringAttribute{
 				Description:   "The team ID to add the deployment to. Required when configuring a team resource if a default team has not been set in the provider.",
 				Optional:      true,
-				Computed:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
 			},
 			"project_id": schema.StringAttribute{

--- a/vercel/resource_dns_record.go
+++ b/vercel/resource_dns_record.go
@@ -66,7 +66,6 @@ For more detailed information, please see the [Vercel documentation](https://ver
 			},
 			"team_id": schema.StringAttribute{
 				Optional:      true,
-				Computed:      true,
 				Description:   "The team ID that the domain and DNS records belong to. Required when configuring a team resource if a default team has not been set in the provider.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
 			},

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -69,7 +69,6 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 		Attributes: map[string]schema.Attribute{
 			"team_id": schema.StringAttribute{
 				Optional:      true,
-				Computed:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
 				Description:   "The team ID to add the project to. Required when configuring a team resource if a default team has not been set in the provider.",
 			},

--- a/vercel/resource_project_domain.go
+++ b/vercel/resource_project_domain.go
@@ -66,7 +66,6 @@ By default, Project Domains will be automatically applied to any ` + "`productio
 			},
 			"team_id": schema.StringAttribute{
 				Optional:      true,
-				Computed:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
 				Description:   "The ID of the team the project exists under. Required when configuring a team resource if a default team has not been set in the provider.",
 			},

--- a/vercel/resource_project_environment_variable.go
+++ b/vercel/resource_project_environment_variable.go
@@ -94,7 +94,6 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 			},
 			"team_id": schema.StringAttribute{
 				Optional:      true,
-				Computed:      true,
 				Description:   "The ID of the Vercel team.Required when configuring a team resource if a default team has not been set in the provider.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
 			},

--- a/vercel/resource_shared_environment_variable.go
+++ b/vercel/resource_shared_environment_variable.go
@@ -87,7 +87,6 @@ For more detailed information, please see the [Vercel documentation](https://ver
 			},
 			"team_id": schema.StringAttribute{
 				Optional:      true,
-				Computed:      true,
 				Description:   "The ID of the Vercel team. Shared environment variables require a team.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
 			},


### PR DESCRIPTION
Team IDs are optionally set on a per-resource basis. However, when omitted, they should not be set as 'computed', because they can never be anything other than Null/Unknown. Computed makes them show as unknown, expecting the value to later be set.

This causes a weird churn when creating resources under a personal Vercel account.

Closes #136