### PR TITLE
Fix team id differently

### DIFF
--- a/vercel/data_source_alias.go
+++ b/vercel/data_source_alias.go
@@ -55,6 +55,7 @@ An Alias allows a ` + "`vercel_deployment` to be accessed through a different UR
 		Attributes: map[string]schema.Attribute{
 			"team_id": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "The ID of the team the Alias and Deployment exist under. Required when configuring a team resource if a default team has not been set in the provider.",
 			},
 			"alias": schema.StringAttribute{

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -61,6 +61,7 @@ For more detailed information, please see the [Vercel documentation](https://ver
 		Attributes: map[string]schema.Attribute{
 			"team_id": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "The team ID the project exists beneath. Required when configuring a team resource if a default team has not been set in the provider.",
 			},
 			"name": schema.StringAttribute{

--- a/vercel/resource_alias.go
+++ b/vercel/resource_alias.go
@@ -68,6 +68,7 @@ An Alias allows a ` + "`vercel_deployment` to be accessed through a different UR
 			},
 			"team_id": schema.StringAttribute{
 				Optional:      true,
+				Computed:      true,
 				Description:   "The ID of the team the Alias and Deployment exist under. Required when configuring a team resource if a default team has not been set in the provider.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},

--- a/vercel/resource_alias.go
+++ b/vercel/resource_alias.go
@@ -70,7 +70,7 @@ An Alias allows a ` + "`vercel_deployment` to be accessed through a different UR
 				Optional:      true,
 				Computed:      true,
 				Description:   "The ID of the team the Alias and Deployment exist under. Required when configuring a team resource if a default team has not been set in the provider.",
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplaceIfConfigured()},
 			},
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/vercel/resource_deployment.go
+++ b/vercel/resource_deployment.go
@@ -93,7 +93,7 @@ terraform to your Deployment.
 				Description:   "The team ID to add the deployment to. Required when configuring a team resource if a default team has not been set in the provider.",
 				Optional:      true,
 				Computed:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplaceIfConfigured(), stringplanmodifier.UseStateForUnknown()},
 			},
 			"project_id": schema.StringAttribute{
 				Description:   "The project ID to add the deployment to.",

--- a/vercel/resource_deployment.go
+++ b/vercel/resource_deployment.go
@@ -92,6 +92,7 @@ terraform to your Deployment.
 			"team_id": schema.StringAttribute{
 				Description:   "The team ID to add the deployment to. Required when configuring a team resource if a default team has not been set in the provider.",
 				Optional:      true,
+				Computed:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
 			},
 			"project_id": schema.StringAttribute{

--- a/vercel/resource_dns_record.go
+++ b/vercel/resource_dns_record.go
@@ -66,6 +66,7 @@ For more detailed information, please see the [Vercel documentation](https://ver
 			},
 			"team_id": schema.StringAttribute{
 				Optional:      true,
+				Computed:      true,
 				Description:   "The team ID that the domain and DNS records belong to. Required when configuring a team resource if a default team has not been set in the provider.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
 			},

--- a/vercel/resource_dns_record.go
+++ b/vercel/resource_dns_record.go
@@ -68,7 +68,7 @@ For more detailed information, please see the [Vercel documentation](https://ver
 				Optional:      true,
 				Computed:      true,
 				Description:   "The team ID that the domain and DNS records belong to. Required when configuring a team resource if a default team has not been set in the provider.",
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplaceIfConfigured(), stringplanmodifier.UseStateForUnknown()},
 			},
 			"domain": schema.StringAttribute{
 				Description:   "The domain name, or zone, that the DNS record should be created beneath.",

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -70,7 +70,7 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 			"team_id": schema.StringAttribute{
 				Optional:      true,
 				Computed:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplaceIfConfigured(), stringplanmodifier.UseStateForUnknown()},
 				Description:   "The team ID to add the project to. Required when configuring a team resource if a default team has not been set in the provider.",
 			},
 			"name": schema.StringAttribute{

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -69,6 +69,7 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 		Attributes: map[string]schema.Attribute{
 			"team_id": schema.StringAttribute{
 				Optional:      true,
+				Computed:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
 				Description:   "The team ID to add the project to. Required when configuring a team resource if a default team has not been set in the provider.",
 			},

--- a/vercel/resource_project_domain.go
+++ b/vercel/resource_project_domain.go
@@ -67,7 +67,7 @@ By default, Project Domains will be automatically applied to any ` + "`productio
 			"team_id": schema.StringAttribute{
 				Optional:      true,
 				Computed:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplaceIfConfigured(), stringplanmodifier.UseStateForUnknown()},
 				Description:   "The ID of the team the project exists under. Required when configuring a team resource if a default team has not been set in the provider.",
 			},
 			"id": schema.StringAttribute{

--- a/vercel/resource_project_domain.go
+++ b/vercel/resource_project_domain.go
@@ -66,6 +66,7 @@ By default, Project Domains will be automatically applied to any ` + "`productio
 			},
 			"team_id": schema.StringAttribute{
 				Optional:      true,
+				Computed:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
 				Description:   "The ID of the team the project exists under. Required when configuring a team resource if a default team has not been set in the provider.",
 			},

--- a/vercel/resource_project_environment_variable.go
+++ b/vercel/resource_project_environment_variable.go
@@ -94,6 +94,7 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 			},
 			"team_id": schema.StringAttribute{
 				Optional:      true,
+				Computed:      true,
 				Description:   "The ID of the Vercel team.Required when configuring a team resource if a default team has not been set in the provider.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
 			},

--- a/vercel/resource_project_environment_variable.go
+++ b/vercel/resource_project_environment_variable.go
@@ -96,7 +96,7 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				Optional:      true,
 				Computed:      true,
 				Description:   "The ID of the Vercel team.Required when configuring a team resource if a default team has not been set in the provider.",
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplaceIfConfigured(), stringplanmodifier.UseStateForUnknown()},
 			},
 			"id": schema.StringAttribute{
 				Description:   "The ID of the Environment Variable.",

--- a/vercel/resource_shared_environment_variable.go
+++ b/vercel/resource_shared_environment_variable.go
@@ -87,6 +87,7 @@ For more detailed information, please see the [Vercel documentation](https://ver
 			},
 			"team_id": schema.StringAttribute{
 				Optional:      true,
+				Computed:      true,
 				Description:   "The ID of the Vercel team. Shared environment variables require a team.",
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
 			},

--- a/vercel/resource_shared_environment_variable.go
+++ b/vercel/resource_shared_environment_variable.go
@@ -89,7 +89,7 @@ For more detailed information, please see the [Vercel documentation](https://ver
 				Optional:      true,
 				Computed:      true,
 				Description:   "The ID of the Vercel team. Shared environment variables require a team.",
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace(), stringplanmodifier.UseStateForUnknown()},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplaceIfConfigured(), stringplanmodifier.UseStateForUnknown()},
 			},
 			"id": schema.StringAttribute{
 				Description:   "The ID of the Environment Variable.",


### PR DESCRIPTION
Turns out it's computed for a good reason. If configuring team via the provider, then it should be a computed field (as the resource does not know the value until it is created). 

Avoid this by using `RequiresReplaceIfConfigured` instead. 

Closes #138. 
Closes #139. 