### PR TITLE
Use default value for vercel authentication field on project

### DIFF
--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -6,9 +6,11 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -174,6 +176,15 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 			"vercel_authentication": schema.SingleNestedAttribute{
 				Description: "Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team.",
 				Optional:    true,
+				Computed:    true,
+				Default: objectdefault.StaticValue(types.ObjectValueMust(
+					map[string]attr.Type{
+						"protect_production": types.BoolType,
+					},
+					map[string]attr.Value{
+						"protect_production": types.BoolValue(false),
+					},
+				)),
 				Attributes: map[string]schema.Attribute{
 					"protect_production": schema.BoolAttribute{
 						Description: "If true, production deployments will also be protected",


### PR DESCRIPTION
Vercel Authentication defaults to enabled for Projects as of 2nd November.

See [Changelog](https://vercel.com/changelog/deployment-protection-is-now-enabled-by-default-for-new-projects).

This has the effect that the terraform provider previously did not treat the authentication field as computed, so expected it to not be set.

Closes #142