### PR TITLE
Update Deployment Protection support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,23 @@ jobs:
         run: task build
       - name: Format
         run: task lint
+
+  docs:
+    name: Docs Test
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.20"
+        id: go
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          version: "3.x"
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
       - name: Check if docs are up-to-date
         run: |
           task docs
@@ -48,7 +65,7 @@ jobs:
 
   test:
     name: Matrix Test
-    needs: [ build ]
+    needs: [build]
     timeout-minutes: 15
     strategy:
       max-parallel: 1
@@ -80,7 +97,7 @@ jobs:
         env:
           TF_ACC: "true"
           VERCEL_API_TOKEN: ${{ secrets.VERCEL_API_TOKEN }}
-          VERCEL_TERRAFORM_TESTING_TEAM: "team_Q8MH2GVRnqKLtxicP2HWPgLi"
+          VERCEL_TERRAFORM_TESTING_TEAM: "team_RvxIb1z0pi9RSsQ13p3ES4cK"
           VERCEL_TERRAFORM_TESTING_GITHUB_REPO: "dglsparsons/test"
           VERCEL_TERRAFORM_TESTING_GITLAB_REPO: "dglsparsons/test"
           VERCEL_TERRAFORM_TESTING_BITBUCKET_REPO: "dglsparsons-test/test"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The acceptance tests require a few environment variables to be set:
 * `VERCEL_TERRAFORM_TESTING_TEAM` - a Vercel team_id where resources can be created and destroyed
 * `VERCEL_TERRAFORM_TESTING_GITHUB_REPO` - a GitHub repository in the form 'org/repo' that can be used to trigger deployments
 * `VERCEL_TERRAFORM_TESTING_BITBUCKET_REPO` - a Bitbucket repository in the form 'project/repo' that can be used to trigger deployments
+* `VERCEL_TERRAFORM_TESTING_GITLAB_REPO` - a GitLab repository in the form 'project/repo' that can be used to trigger deployments
+* `VERCEL_TERRAFORM_TESTING_DOMAIN` - a Vercel testing domain that can be used for testing
 
 ```sh
 $ task test
@@ -58,6 +60,22 @@ To run a specific set of tests, use the `-run` flag and specify a regex pattern 
 ```sh
 $ task test -- -run 'TestAcc_Project*'
 ```
+
+## Running the provider locally
+
+Set up a local override on your machine
+
+```sh
+$ task install
+```
+
+Build the provider
+
+```sh
+$ task build
+```
+
+Create a `main.tf` file on your machine and use the [terraform cli](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli#install-terraform) to test
 
 ## Building The Documentation
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,29 @@ If you wish to work on the provider, you'll first need [Go](http://www.golang.or
 
 To compile the provider, run `task build`. This will build the provider and put the provider binary in the repository root.
 
-In addition, you can run `task install` to set up a developer overrides in your ~/.terraformrc. This will then allow you
-to use your locally built provider binary.
+```sh
+$ task build
+```
+
+In addition, you can run `task install` to set up a developer overrides in your ~/.terraformrc. This will then allow you to use your locally built provider binary.
+
+```sh
+$ task install
+```
+
+Create a `main.tf` file on your machine and use the [terraform cli](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli#install-terraform) to test
+
+```sh
+$ terraform plan
+$ terraform apply
+```
 
 When you are finished using a local version of the provider, running `task uninstall` will remove _all_ developer
 overrides.
+
+```sh
+$ task uninstall
+```
 
 - HashiCorp - [Development Overrides for Provider developers](https://www.terraform.io/docs/cli/config/config-file.html#development-overrides-for-provider-developers).
 
@@ -61,21 +79,6 @@ To run a specific set of tests, use the `-run` flag and specify a regex pattern 
 $ task test -- -run 'TestAcc_Project*'
 ```
 
-## Running the provider locally
-
-Set up a local override on your machine
-
-```sh
-$ task install
-```
-
-Build the provider
-
-```sh
-$ task build
-```
-
-Create a `main.tf` file on your machine and use the [terraform cli](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli#install-terraform) to test
 
 ## Building The Documentation
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,7 +23,7 @@ tasks:
   install-tfplugindocs:
     desc: "Install the tfplugindocs tool"
     cmds:
-      - go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.7.0
+      - go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.16.0
     status:
       - which tfplugindocs
 

--- a/client/deployment_protection.go
+++ b/client/deployment_protection.go
@@ -1,0 +1,28 @@
+package client
+
+type VercelAuthentication struct {
+	DeploymentType string `json:"deploymentType"`
+}
+
+type PasswordProtection struct {
+	DeploymentType string `json:"deploymentType"`
+}
+type PasswordProtectionWithPassword struct {
+	DeploymentType string `json:"deploymentType"`
+	Password       string `json:"password"`
+}
+
+type TrustedIpAddress struct {
+	Value string `json:"value"`
+	Note  string `json:"note"`
+}
+
+type TrustedIps struct {
+	DeploymentType string             `json:"deploymentType"`
+	Addresses      []TrustedIpAddress `json:"addresses"`
+	ProtectionMode string             `json:"protectionMode"`
+}
+
+type ProtectionBypass struct {
+	Scope string `json:"scope"`
+}

--- a/client/must_marshal.go
+++ b/client/must_marshal.go
@@ -1,6 +1,20 @@
 package client
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
+
+func (v *VercelAuthentication) MarshalJSON() ([]byte, error) {
+	if v.DeploymentType == "none" {
+		return []byte(`null`), nil
+	}
+
+	return json.Marshal(&struct {
+		DeploymentType string `json:"deploymentType"`
+	}{
+		DeploymentType: v.DeploymentType,
+	})
+}
 
 // mustMarshal is a helper to remove unnecessary error checking when marshaling a Go
 // struct to json. There are only a few instances where marshaling can fail, and they

--- a/client/project_get.go
+++ b/client/project_get.go
@@ -54,20 +54,6 @@ func (r *ProjectResponse) Repository() *Repository {
 	return nil
 }
 
-type Protection struct {
-	DeploymentType string `json:"deploymentType"`
-}
-
-type TrustedIps struct {
-	DeploymentType string             `json:"deploymentType"`
-	Addresses      []TrustedIpAddress `json:"addresses"`
-	ProtectionMode string             `json:"protectionMode"`
-}
-
-type ProtectionBypass struct {
-	Scope string `json:"scope"`
-}
-
 // ProjectResponse defines the information Vercel returns about a project.
 type ProjectResponse struct {
 	BuildCommand                *string               `json:"buildCommand"`
@@ -98,8 +84,8 @@ type ProjectResponse struct {
 	PublicSource             *bool                       `json:"publicSource"`
 	RootDirectory            *string                     `json:"rootDirectory"`
 	ServerlessFunctionRegion *string                     `json:"serverlessFunctionRegion"`
-	VercelAuthentication     *Protection                 `json:"ssoProtection"`
-	PasswordProtection       *Protection                 `json:"passwordProtection"`
+	VercelAuthentication     *VercelAuthentication       `json:"ssoProtection"`
+	PasswordProtection       *PasswordProtection         `json:"passwordProtection"`
 	TrustedIps               *TrustedIps                 `json:"trustedIps"`
 	ProtectionBypass         map[string]ProtectionBypass `json:"protectionBypass"`
 }

--- a/client/project_get.go
+++ b/client/project_get.go
@@ -58,6 +58,12 @@ type Protection struct {
 	DeploymentType string `json:"deploymentType"`
 }
 
+type TrustedIps struct {
+	DeploymentType string             `json:"deploymentType"`
+	Addresses      []TrustedIpAddress `json:"addresses"`
+	ProtectionMode string             `json:"protectionMode"`
+}
+
 type ProtectionBypass struct {
 	Scope string `json:"scope"`
 }
@@ -92,8 +98,9 @@ type ProjectResponse struct {
 	PublicSource             *bool                       `json:"publicSource"`
 	RootDirectory            *string                     `json:"rootDirectory"`
 	ServerlessFunctionRegion *string                     `json:"serverlessFunctionRegion"`
-	SSOProtection            *Protection                 `json:"ssoProtection"`
+	VercelAuthentication     *Protection                 `json:"ssoProtection"`
 	PasswordProtection       *Protection                 `json:"passwordProtection"`
+	TrustedIps               *TrustedIps                 `json:"trustedIps"`
 	ProtectionBypass         map[string]ProtectionBypass `json:"protectionBypass"`
 }
 

--- a/client/project_update.go
+++ b/client/project_update.go
@@ -7,25 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-type PasswordProtectionRequest struct {
-	DeploymentType string `json:"deploymentType"`
-	Password       string `json:"password"`
-}
-
-type VercelAuthenticationRequest struct {
-	DeploymentType string `json:"deploymentType"`
-}
-
-type TrustedIpAddress struct {
-	Value string `json:"value"`
-	Note  string `json:"note"`
-}
-type TrustedIpsRequest struct {
-	DeploymentType string             `json:"deploymentType"`
-	Addresses      []TrustedIpAddress `json:"addresses"`
-	ProtectionMode string             `json:"protectionMode"`
-}
-
 // UpdateProjectRequest defines the possible fields that can be updated within a vercel project.
 // note that the values are all pointers, with many containing `omitempty` for serialisation.
 // This is because the Vercel API behaves in the following manner:
@@ -33,19 +14,19 @@ type TrustedIpsRequest struct {
 // - setting the field to an empty value (e.g. "") will remove the setting for that field.
 // - omitting the value entirely from the request will _not_ update the field.
 type UpdateProjectRequest struct {
-	BuildCommand                *string                      `json:"buildCommand"`
-	CommandForIgnoringBuildStep *string                      `json:"commandForIgnoringBuildStep"`
-	DevCommand                  *string                      `json:"devCommand"`
-	Framework                   *string                      `json:"framework"`
-	InstallCommand              *string                      `json:"installCommand"`
-	Name                        *string                      `json:"name,omitempty"`
-	OutputDirectory             *string                      `json:"outputDirectory"`
-	PublicSource                *bool                        `json:"publicSource"`
-	RootDirectory               *string                      `json:"rootDirectory"`
-	ServerlessFunctionRegion    *string                      `json:"serverlessFunctionRegion"`
-	VercelAuthentication        *VercelAuthenticationRequest `json:"ssoProtection"`
-	PasswordProtection          *PasswordProtectionRequest   `json:"passwordProtection"`
-	TrustedIps                  *TrustedIpsRequest           `json:"trustedIps"`
+	BuildCommand                *string                         `json:"buildCommand"`
+	CommandForIgnoringBuildStep *string                         `json:"commandForIgnoringBuildStep"`
+	DevCommand                  *string                         `json:"devCommand"`
+	Framework                   *string                         `json:"framework"`
+	InstallCommand              *string                         `json:"installCommand"`
+	Name                        *string                         `json:"name,omitempty"`
+	OutputDirectory             *string                         `json:"outputDirectory"`
+	PublicSource                *bool                           `json:"publicSource"`
+	RootDirectory               *string                         `json:"rootDirectory"`
+	ServerlessFunctionRegion    *string                         `json:"serverlessFunctionRegion"`
+	VercelAuthentication        *VercelAuthentication           `json:"ssoProtection"`
+	PasswordProtection          *PasswordProtectionWithPassword `json:"passwordProtection"`
+	TrustedIps                  *TrustedIps                     `json:"trustedIps"`
 }
 
 // UpdateProject updates an existing projects configuration within Vercel.

--- a/client/project_update.go
+++ b/client/project_update.go
@@ -12,6 +12,20 @@ type PasswordProtectionRequest struct {
 	Password       string `json:"password"`
 }
 
+type VercelAuthenticationRequest struct {
+	DeploymentType string `json:"deploymentType"`
+}
+
+type TrustedIpAddress struct {
+	Value string `json:"value"`
+	Note  string `json:"note"`
+}
+type TrustedIpsRequest struct {
+	DeploymentType string             `json:"deploymentType"`
+	Addresses      []TrustedIpAddress `json:"addresses"`
+	ProtectionMode string             `json:"protectionMode"`
+}
+
 // UpdateProjectRequest defines the possible fields that can be updated within a vercel project.
 // note that the values are all pointers, with many containing `omitempty` for serialisation.
 // This is because the Vercel API behaves in the following manner:
@@ -19,18 +33,19 @@ type PasswordProtectionRequest struct {
 // - setting the field to an empty value (e.g. "") will remove the setting for that field.
 // - omitting the value entirely from the request will _not_ update the field.
 type UpdateProjectRequest struct {
-	BuildCommand                *string                    `json:"buildCommand"`
-	CommandForIgnoringBuildStep *string                    `json:"commandForIgnoringBuildStep"`
-	DevCommand                  *string                    `json:"devCommand"`
-	Framework                   *string                    `json:"framework"`
-	InstallCommand              *string                    `json:"installCommand"`
-	Name                        *string                    `json:"name,omitempty"`
-	OutputDirectory             *string                    `json:"outputDirectory"`
-	PublicSource                *bool                      `json:"publicSource"`
-	RootDirectory               *string                    `json:"rootDirectory"`
-	ServerlessFunctionRegion    *string                    `json:"serverlessFunctionRegion"`
-	SSOProtection               *Protection                `json:"ssoProtection"`
-	PasswordProtection          *PasswordProtectionRequest `json:"passwordProtection"`
+	BuildCommand                *string                      `json:"buildCommand"`
+	CommandForIgnoringBuildStep *string                      `json:"commandForIgnoringBuildStep"`
+	DevCommand                  *string                      `json:"devCommand"`
+	Framework                   *string                      `json:"framework"`
+	InstallCommand              *string                      `json:"installCommand"`
+	Name                        *string                      `json:"name,omitempty"`
+	OutputDirectory             *string                      `json:"outputDirectory"`
+	PublicSource                *bool                        `json:"publicSource"`
+	RootDirectory               *string                      `json:"rootDirectory"`
+	ServerlessFunctionRegion    *string                      `json:"serverlessFunctionRegion"`
+	VercelAuthentication        *VercelAuthenticationRequest `json:"ssoProtection"`
+	PasswordProtection          *PasswordProtectionRequest   `json:"passwordProtection"`
+	TrustedIps                  *TrustedIpsRequest           `json:"trustedIps"`
 }
 
 // UpdateProject updates an existing projects configuration within Vercel.

--- a/docs/data-sources/alias.md
+++ b/docs/data-sources/alias.md
@@ -30,5 +30,3 @@ An Alias allows a `vercel_deployment` to be accessed through a different URL.
 
 - `deployment_id` (String) The ID of the Deployment the Alias is associated with.
 - `id` (String) The ID of this resource.
-
-

--- a/docs/data-sources/file.md
+++ b/docs/data-sources/file.md
@@ -44,5 +44,3 @@ resource "vercel_deployment" "example" {
 
 - `file` (Map of String) A map of filename to metadata about the file. The metadata contains the file size and hash, and allows a deployment to be created if the file changes.
 - `id` (String) The ID of this resource.
-
-

--- a/docs/data-sources/prebuilt_project.md
+++ b/docs/data-sources/prebuilt_project.md
@@ -65,5 +65,3 @@ resource "vercel_deployment" "example" {
 
 - `id` (String) The ID of this resource.
 - `output` (Map of String) A map of output file to metadata about the file. The metadata contains the file size and hash, and allows a deployment to be created if the file changes.
-
-

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -38,7 +38,6 @@ output "project_id" {
 
 ### Optional
 
-- `password_protection` (Attributes) Ensures visitors of your Preview Deployments must enter a password in order to gain access. (see [below for nested schema](#nestedatt--password_protection))
 - `team_id` (String) The team ID the project exists beneath. Required when configuring a team resource if a default team has not been set in the provider.
 
 ### Read-Only
@@ -55,14 +54,9 @@ output "project_id" {
 - `public_source` (Boolean) Specifies whether the source code and logs of the deployments for this project should be public or not.
 - `root_directory` (String) The name of a directory or relative path to the source code of your project. When null is used it will default to the project root.
 - `serverless_function_region` (String) The region on Vercel's network to which your Serverless Functions are deployed. It should be close to any data source your Serverless Function might depend on. A new Deployment is required for your changes to take effect. Please see [Vercel's documentation](https://vercel.com/docs/concepts/edge-network/regions) for a full list of regions.
-- `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team. (see [below for nested schema](#nestedatt--vercel_authentication))
-
-<a id="nestedatt--password_protection"></a>
-### Nested Schema for `password_protection`
-
-Optional:
-
-- `protect_production` (Boolean) If true, production deployments will also be protected
+- `password_protection` (Attributes) Ensures visitors of your Preview Deployments must enter a password in order to gain access. (see [below for nested schema](#nestedatt--password_protection))
+- `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have access to the deployment. (see [below for nested schema](#nestedatt--vercel_authentication))
+- `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
 
 
 <a id="nestedatt--environment"></a>
@@ -86,12 +80,5 @@ Read-Only:
 - `repo` (String) The name of the git repository. For example: `vercel/next.js`.
 - `type` (String) The git provider of the repository. Must be either `github`, `gitlab`, or `bitbucket`.
 
-
-<a id="nestedatt--vercel_authentication"></a>
-### Nested Schema for `vercel_authentication`
-
-Read-Only:
-
-- `protect_production` (Boolean) If true, production deployments will also be protected
 
 

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -38,7 +38,9 @@ output "project_id" {
 
 ### Optional
 
+- `password_protection` (Attributes) Ensures visitors of your Preview Deployments must enter a password in order to gain access. (see [below for nested schema](#nestedatt--password_protection))
 - `team_id` (String) The team ID the project exists beneath. Required when configuring a team resource if a default team has not been set in the provider.
+- `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
 
 ### Read-Only
 
@@ -54,9 +56,33 @@ output "project_id" {
 - `public_source` (Boolean) Specifies whether the source code and logs of the deployments for this project should be public or not.
 - `root_directory` (String) The name of a directory or relative path to the source code of your project. When null is used it will default to the project root.
 - `serverless_function_region` (String) The region on Vercel's network to which your Serverless Functions are deployed. It should be close to any data source your Serverless Function might depend on. A new Deployment is required for your changes to take effect. Please see [Vercel's documentation](https://vercel.com/docs/concepts/edge-network/regions) for a full list of regions.
-- `password_protection` (Attributes) Ensures visitors of your Preview Deployments must enter a password in order to gain access. (see [below for nested schema](#nestedatt--password_protection))
-- `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have access to the deployment. (see [below for nested schema](#nestedatt--vercel_authentication))
-- `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
+- `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team. (see [below for nested schema](#nestedatt--vercel_authentication))
+
+<a id="nestedatt--password_protection"></a>
+### Nested Schema for `password_protection`
+
+Read-Only:
+
+- `deployment_type` (String) The deployment environment that will be protected.
+
+
+<a id="nestedatt--trusted_ips"></a>
+### Nested Schema for `trusted_ips`
+
+Read-Only:
+
+- `addresses` (List of Object) The allowed IP addressses and CIDR ranges with optional descriptions. (see [below for nested schema](#nestedatt--trusted_ips--addresses))
+- `deployment_type` (String) The deployment environment that will be protected.
+- `protection_mode` (String) Whether or not Trusted IPs is optional to access a deployment.
+
+<a id="nestedatt--trusted_ips--addresses"></a>
+### Nested Schema for `trusted_ips.addresses`
+
+Optional:
+
+- `note` (String)
+- `value` (String)
+
 
 
 <a id="nestedatt--environment"></a>
@@ -81,4 +107,9 @@ Read-Only:
 - `type` (String) The git provider of the repository. Must be either `github`, `gitlab`, or `bitbucket`.
 
 
+<a id="nestedatt--vercel_authentication"></a>
+### Nested Schema for `vercel_authentication`
 
+Read-Only:
+
+- `deployment_type` (String) The deployment environment that will be protected.

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -95,7 +95,7 @@ Read-Only:
 
 - `addresses` (List of Object) The allowed IP addressses and CIDR ranges with optional descriptions. (see [below for nested schema](#nestedatt--trusted_ips--addresses))
 - `deployment_type` (String) The deployment environment that will be protected.
-- `protection_mode` (String) Whether or not Trusted IPs is optional to access a deployment.
+- `protection_mode` (String) Whether or not Trusted IPs is required or optional to access a deployment.
 
 <a id="nestedatt--trusted_ips--addresses"></a>
 ### Nested Schema for `trusted_ips.addresses`

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -38,9 +38,7 @@ output "project_id" {
 
 ### Optional
 
-- `password_protection` (Attributes) Ensures visitors of your Preview Deployments must enter a password in order to gain access. (see [below for nested schema](#nestedatt--password_protection))
 - `team_id` (String) The team ID the project exists beneath. Required when configuring a team resource if a default team has not been set in the provider.
-- `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
 
 ### Read-Only
 
@@ -53,37 +51,12 @@ output "project_id" {
 - `ignore_command` (String) When a commit is pushed to the Git repository that is connected with your Project, its SHA will determine if a new Build has to be issued. If the SHA was deployed before, no new Build will be issued. You can customize this behavior with a command that exits with code 1 (new Build needed) or code 0.
 - `install_command` (String) The install command for this project. If omitted, this value will be automatically detected.
 - `output_directory` (String) The output directory of the project. When null is used this value will be automatically detected.
+- `password_protection` (Attributes) Ensures visitors of your Preview Deployments must enter a password in order to gain access. (see [below for nested schema](#nestedatt--password_protection))
 - `public_source` (Boolean) Specifies whether the source code and logs of the deployments for this project should be public or not.
 - `root_directory` (String) The name of a directory or relative path to the source code of your project. When null is used it will default to the project root.
 - `serverless_function_region` (String) The region on Vercel's network to which your Serverless Functions are deployed. It should be close to any data source your Serverless Function might depend on. A new Deployment is required for your changes to take effect. Please see [Vercel's documentation](https://vercel.com/docs/concepts/edge-network/regions) for a full list of regions.
+- `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
 - `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team. (see [below for nested schema](#nestedatt--vercel_authentication))
-
-<a id="nestedatt--password_protection"></a>
-### Nested Schema for `password_protection`
-
-Read-Only:
-
-- `deployment_type` (String) The deployment environment that will be protected.
-
-
-<a id="nestedatt--trusted_ips"></a>
-### Nested Schema for `trusted_ips`
-
-Read-Only:
-
-- `addresses` (List of Object) The allowed IP addressses and CIDR ranges with optional descriptions. (see [below for nested schema](#nestedatt--trusted_ips--addresses))
-- `deployment_type` (String) The deployment environment that will be protected.
-- `protection_mode` (String) Whether or not Trusted IPs is optional to access a deployment.
-
-<a id="nestedatt--trusted_ips--addresses"></a>
-### Nested Schema for `trusted_ips.addresses`
-
-Optional:
-
-- `note` (String)
-- `value` (String)
-
-
 
 <a id="nestedatt--environment"></a>
 ### Nested Schema for `environment`
@@ -105,6 +78,33 @@ Read-Only:
 - `production_branch` (String) By default, every commit pushed to the main branch will trigger a Production Deployment instead of the usual Preview Deployment. You can switch to a different branch here.
 - `repo` (String) The name of the git repository. For example: `vercel/next.js`.
 - `type` (String) The git provider of the repository. Must be either `github`, `gitlab`, or `bitbucket`.
+
+
+<a id="nestedatt--password_protection"></a>
+### Nested Schema for `password_protection`
+
+Read-Only:
+
+- `deployment_type` (String) The deployment environment that will be protected.
+
+
+<a id="nestedatt--trusted_ips"></a>
+### Nested Schema for `trusted_ips`
+
+Read-Only:
+
+- `addresses` (List of Object) The allowed IP addressses and CIDR ranges with optional descriptions. (see [below for nested schema](#nestedatt--trusted_ips--addresses))
+- `deployment_type` (String) The deployment environment that will be protected.
+- `protection_mode` (String) Whether or not Trusted IPs is optional to access a deployment.
+
+<a id="nestedatt--trusted_ips--addresses"></a>
+### Nested Schema for `trusted_ips.addresses`
+
+Read-Only:
+
+- `note` (String)
+- `value` (String)
+
 
 
 <a id="nestedatt--vercel_authentication"></a>

--- a/docs/data-sources/project_directory.md
+++ b/docs/data-sources/project_directory.md
@@ -58,5 +58,3 @@ resource "vercel_deployment" "example" {
 
 - `files` (Map of String) A map of filename to metadata about the file. The metadata contains the file size and hash, and allows a deployment to be created if the file changes.
 - `id` (String) The ID of this resource.
-
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     vercel = {
       source  = "vercel/vercel"
-      version = "~> 0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/docs/resources/alias.md
+++ b/docs/resources/alias.md
@@ -30,5 +30,3 @@ An Alias allows a `vercel_deployment` to be accessed through a different URL.
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-
-

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -129,5 +129,3 @@ Optional:
 - `install_command` (String) The install command for this deployment. If omitted, this value will be taken from the project or automatically detected.
 - `output_directory` (String) The output directory of the deployment. If omitted, this value will be taken from the project or automatically detected.
 - `root_directory` (String) The name of a directory or relative path to the source code of your project. When null is used it will default to the project root.
-
-

--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -124,7 +124,7 @@ For 'TXT' records, this can contain arbitrary text.
 <a id="nestedatt--srv"></a>
 ### Nested Schema for `srv`
 
-Optional:
+Required:
 
 - `port` (Number) The TCP or UDP port on which the service is to be found.
 - `priority` (Number) The priority of the target host, lower value means more preferred.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -113,7 +113,7 @@ Optional:
 
 Required:
 
-- `deployment_type` (String) The deployment environment to protect. Must be one one `standard_protection`, `all_deployments`, or `only_preview_deployments`.
+- `deployment_type` (String) The deployment environment to protect. Must be one of `standard_protection`, `all_deployments`, or `only_preview_deployments`.
 - `password` (String, Sensitive) The password that visitors must enter to gain access to your Preview Deployments. Drift detection is not possible for this field.
 
 
@@ -122,20 +122,23 @@ Required:
 
 Required:
 
-- `addresses` (Set of Object) The allowed IP addressses and CIDR ranges with optional descriptions. (see [below for nested schema](#nestedatt--trusted_ips--addresses))
-- `deployment_type` (String) The deployment environment to protect. Must be one one `standard_protection`, `all_deployments`, `only_production_deployments`, or `only_preview_deployments`.
+- `addresses` (Attributes Set) The allowed IP addressses and CIDR ranges with optional descriptions. (see [below for nested schema](#nestedatt--trusted_ips--addresses))
+- `deployment_type` (String) The deployment environment to protect. Must be one of `standard_protection`, `all_deployments`, `only_production_deployments`, or `only_preview_deployments`.
 
 Optional:
 
-- `protection_mode` (String) Whether or not Trusted IPs is optional to access a deployment. Must be either `additional` or `exclusive`. `exclusive` is only availible with Standalone Trusted IPs.
+- `protection_mode` (String) Whether or not Trusted IPs is optional to access a deployment. Must be either `trusted_ip_required` or `trusted_ip_optional`. `trusted_ip_optional` is only available with Standalone Trusted IPs.
 
 <a id="nestedatt--trusted_ips--addresses"></a>
 ### Nested Schema for `trusted_ips.addresses`
 
+Required:
+
+- `value` (String, Sensitive) The address or CIDR range that can access deployments.
+
 Optional:
 
-- `note` (String)
-- `value` (String)
+- `note` (String) A description for the value
 
 
 
@@ -144,7 +147,7 @@ Optional:
 
 Required:
 
-- `deployment_type` (String) The deployment environment to protect. Must be one one `standard_protection`, `all_deployments`, or `only_preview_deployments`.
+- `deployment_type` (String) The deployment environment to protect. Must be one of `standard_protection`, `all_deployments`, `only_preview_deployments`, or `none`.
 
 ## Import
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -64,12 +64,13 @@ resource "vercel_project" "example" {
 - `install_command` (String) The install command for this project. If omitted, this value will be automatically detected.
 - `output_directory` (String) The output directory of the project. If omitted, this value will be automatically detected.
 - `password_protection` (Attributes) Ensures visitors of your Preview Deployments must enter a password in order to gain access. (see [below for nested schema](#nestedatt--password_protection))
+- `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team. (see [below for nested schema](#nestedatt--vercel_authentication))
+- `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
 - `protection_bypass_for_automation` (Boolean) Allow automation services to bypass Vercel Authentication and Password Protection for both Preview and Production Deployments on this project when using an HTTP header named `x-vercel-protection-bypass` with a value of the `password_protection_for_automation_secret` field.
 - `public_source` (Boolean) By default, visitors to the `/_logs` and `/_src` paths of your Production and Preview Deployments must log in with Vercel (requires being a member of your team) to see the Source, Logs and Deployment Status of your project. Setting `public_source` to `true` disables this behaviour, meaning the Source, Logs and Deployment Status can be publicly viewed.
 - `root_directory` (String) The name of a directory or relative path to the source code of your project. If omitted, it will default to the project root.
 - `serverless_function_region` (String) The region on Vercel's network to which your Serverless Functions are deployed. It should be close to any data source your Serverless Function might depend on. A new Deployment is required for your changes to take effect. Please see [Vercel's documentation](https://vercel.com/docs/concepts/edge-network/regions) for a full list of regions.
 - `team_id` (String) The team ID to add the project to. Required when configuring a team resource if a default team has not been set in the provider.
-- `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team. (see [below for nested schema](#nestedatt--vercel_authentication))
 
 ### Read-Only
 
@@ -97,22 +98,32 @@ Optional:
 - `repo` (String) The name of the git repository. For example: `vercel/next.js`.
 - `type` (String) The git provider of the repository. Must be either `github`, `gitlab`, or `bitbucket`.
 
-
 <a id="nestedatt--password_protection"></a>
 ### Nested Schema for `password_protection`
 
-Optional:
+Required:
 
 - `password` (String, Sensitive) The password that visitors must enter to gain access to your Preview Deployments. Drift detection is not possible for this field.
-- `protect_production` (Boolean) If true, production deployments will also be protected
-
+- `deployment_type` (String) Must be one one `standard_protection`, `all_deployments`, or `only_preview_deployments`. See [Understanding Deployment Protection by environment](https://vercel.com/docs/security/deployment-protection#understanding-deployment-protection-by-environment).
 
 <a id="nestedatt--vercel_authentication"></a>
 ### Nested Schema for `vercel_authentication`
 
+Required:
+
+- `deployment_type` (String) Must be one one `standard_protection`, `all_deployments`, or `only_preview_deployments`. See [Understanding Deployment Protection by environment](https://vercel.com/docs/security/deployment-protection#understanding-deployment-protection-by-environment).
+
+<a id="nestedatt--trusted_ips"></a>
+### Nested Schema for `trusted_ips`
+
+Required:
+
+- `addresses` (List) The allowed IP addressses and CIDR ranges with optional descriptions.
+- `deployment_type` (String) Must be one one `standard_protection`, `all_deployments`, `only_production_deployments` or `only_preview_deployments`. See [Understanding Deployment Protection by environment](https://vercel.com/docs/security/deployment-protection#understanding-deployment-protection-by-environment).
+
 Optional:
 
-- `protect_production` (Boolean) If true, production deployments will also be protected
+- `protection_mode` (String) Whether or not Trusted IPs is optional to access a deployment. Must be either `additional` or `exclusive`. `exclusive` is only availible with Standalone Trusted IPs.
 
 ## Import
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -64,13 +64,13 @@ resource "vercel_project" "example" {
 - `install_command` (String) The install command for this project. If omitted, this value will be automatically detected.
 - `output_directory` (String) The output directory of the project. If omitted, this value will be automatically detected.
 - `password_protection` (Attributes) Ensures visitors of your Preview Deployments must enter a password in order to gain access. (see [below for nested schema](#nestedatt--password_protection))
-- `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team. (see [below for nested schema](#nestedatt--vercel_authentication))
-- `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
 - `protection_bypass_for_automation` (Boolean) Allow automation services to bypass Vercel Authentication and Password Protection for both Preview and Production Deployments on this project when using an HTTP header named `x-vercel-protection-bypass` with a value of the `password_protection_for_automation_secret` field.
 - `public_source` (Boolean) By default, visitors to the `/_logs` and `/_src` paths of your Production and Preview Deployments must log in with Vercel (requires being a member of your team) to see the Source, Logs and Deployment Status of your project. Setting `public_source` to `true` disables this behaviour, meaning the Source, Logs and Deployment Status can be publicly viewed.
 - `root_directory` (String) The name of a directory or relative path to the source code of your project. If omitted, it will default to the project root.
 - `serverless_function_region` (String) The region on Vercel's network to which your Serverless Functions are deployed. It should be close to any data source your Serverless Function might depend on. A new Deployment is required for your changes to take effect. Please see [Vercel's documentation](https://vercel.com/docs/concepts/edge-network/regions) for a full list of regions.
 - `team_id` (String) The team ID to add the project to. Required when configuring a team resource if a default team has not been set in the provider.
+- `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
+- `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team. (see [below for nested schema](#nestedatt--vercel_authentication))
 
 ### Read-Only
 
@@ -80,50 +80,71 @@ resource "vercel_project" "example" {
 <a id="nestedatt--environment"></a>
 ### Nested Schema for `environment`
 
-Optional:
+Required:
 
-- `git_branch` (String) The git branch of the Environment Variable.
-- `id` (String) The ID of the Environment Variable.
 - `key` (String) The name of the Environment Variable.
 - `target` (Set of String) The environments that the Environment Variable should be present on. Valid targets are either `production`, `preview`, or `development`.
 - `value` (String, Sensitive) The value of the Environment Variable.
+
+Optional:
+
+- `git_branch` (String) The git branch of the Environment Variable.
+
+Read-Only:
+
+- `id` (String) The ID of the Environment Variable.
 
 
 <a id="nestedatt--git_repository"></a>
 ### Nested Schema for `git_repository`
 
+Required:
+
+- `repo` (String) The name of the git repository. For example: `vercel/next.js`.
+- `type` (String) The git provider of the repository. Must be either `github`, `gitlab`, or `bitbucket`.
+
 Optional:
 
 - `production_branch` (String) By default, every commit pushed to the main branch will trigger a Production Deployment instead of the usual Preview Deployment. You can switch to a different branch here.
-- `repo` (String) The name of the git repository. For example: `vercel/next.js`.
-- `type` (String) The git provider of the repository. Must be either `github`, `gitlab`, or `bitbucket`.
+
 
 <a id="nestedatt--password_protection"></a>
 ### Nested Schema for `password_protection`
 
 Required:
 
+- `deployment_type` (String) The deployment environment to protect. Must be one one `standard_protection`, `all_deployments`, or `only_preview_deployments`.
 - `password` (String, Sensitive) The password that visitors must enter to gain access to your Preview Deployments. Drift detection is not possible for this field.
-- `deployment_type` (String) Must be one one `standard_protection`, `all_deployments`, or `only_preview_deployments`. See [Understanding Deployment Protection by environment](https://vercel.com/docs/security/deployment-protection#understanding-deployment-protection-by-environment).
 
-<a id="nestedatt--vercel_authentication"></a>
-### Nested Schema for `vercel_authentication`
-
-Required:
-
-- `deployment_type` (String) Must be one one `standard_protection`, `all_deployments`, or `only_preview_deployments`. See [Understanding Deployment Protection by environment](https://vercel.com/docs/security/deployment-protection#understanding-deployment-protection-by-environment).
 
 <a id="nestedatt--trusted_ips"></a>
 ### Nested Schema for `trusted_ips`
 
 Required:
 
-- `addresses` (List) The allowed IP addressses and CIDR ranges with optional descriptions.
-- `deployment_type` (String) Must be one one `standard_protection`, `all_deployments`, `only_production_deployments` or `only_preview_deployments`. See [Understanding Deployment Protection by environment](https://vercel.com/docs/security/deployment-protection#understanding-deployment-protection-by-environment).
+- `addresses` (Set of Object) The allowed IP addressses and CIDR ranges with optional descriptions. (see [below for nested schema](#nestedatt--trusted_ips--addresses))
+- `deployment_type` (String) The deployment environment to protect. Must be one one `standard_protection`, `all_deployments`, `only_production_deployments`, or `only_preview_deployments`.
 
 Optional:
 
 - `protection_mode` (String) Whether or not Trusted IPs is optional to access a deployment. Must be either `additional` or `exclusive`. `exclusive` is only availible with Standalone Trusted IPs.
+
+<a id="nestedatt--trusted_ips--addresses"></a>
+### Nested Schema for `trusted_ips.addresses`
+
+Optional:
+
+- `note` (String)
+- `value` (String)
+
+
+
+<a id="nestedatt--vercel_authentication"></a>
+### Nested Schema for `vercel_authentication`
+
+Required:
+
+- `deployment_type` (String) The deployment environment to protect. Must be one one `standard_protection`, `all_deployments`, or `only_preview_deployments`.
 
 ## Import
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     vercel = {
       source  = "vercel/vercel"
-      version = "~> 0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -149,8 +150,8 @@ For more detailed information, please see the [Vercel documentation](https://ver
 				Description: "Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team.",
 				Computed:    true,
 				Attributes: map[string]schema.Attribute{
-					"protect_production": schema.BoolAttribute{
-						Description: "If true, production deployments will also be protected",
+					"deployment_type": schema.StringAttribute{
+						Description: "The deployment environment that will be protected.",
 						Computed:    true,
 					},
 				},
@@ -159,8 +160,32 @@ For more detailed information, please see the [Vercel documentation](https://ver
 				Description: "Ensures visitors of your Preview Deployments must enter a password in order to gain access.",
 				Optional:    true,
 				Attributes: map[string]schema.Attribute{
-					"protect_production": schema.BoolAttribute{
-						Description: "If true, production deployments will also be protected",
+					"deployment_type": schema.StringAttribute{
+						Description: "The deployment environment that will be protected.",
+						Computed:    true,
+					},
+				},
+			},
+			"trusted_ips": schema.SingleNestedAttribute{
+				Description: "Ensures only visitors from an allowed IP address can access your deployment.",
+				Optional:    true,
+				Attributes: map[string]schema.Attribute{
+					"deployment_type": schema.StringAttribute{
+						Description: "The deployment environment that will be protected.",
+						Computed:    true,
+					},
+					"addresses": schema.ListAttribute{
+						Description: "The allowed IP addressses and CIDR ranges with optional descriptions.",
+						Computed:    true,
+						ElementType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"value": types.StringType,
+								"note":  types.StringType,
+							},
+						},
+					},
+					"protection_mode": schema.StringAttribute{
+						Description: "Whether or not Trusted IPs is optional to access a deployment.",
 						Computed:    true,
 					},
 				},

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -158,7 +158,7 @@ For more detailed information, please see the [Vercel documentation](https://ver
 			},
 			"password_protection": schema.SingleNestedAttribute{
 				Description: "Ensures visitors of your Preview Deployments must enter a password in order to gain access.",
-				Optional:    true,
+				Computed:    true,
 				Attributes: map[string]schema.Attribute{
 					"deployment_type": schema.StringAttribute{
 						Description: "The deployment environment that will be protected.",
@@ -168,7 +168,7 @@ For more detailed information, please see the [Vercel documentation](https://ver
 			},
 			"trusted_ips": schema.SingleNestedAttribute{
 				Description: "Ensures only visitors from an allowed IP address can access your deployment.",
-				Optional:    true,
+				Computed:    true,
 				Attributes: map[string]schema.Attribute{
 					"deployment_type": schema.StringAttribute{
 						Description: "The deployment environment that will be protected.",

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -185,7 +185,7 @@ For more detailed information, please see the [Vercel documentation](https://ver
 						},
 					},
 					"protection_mode": schema.StringAttribute{
-						Description: "Whether or not Trusted IPs is optional to access a deployment.",
+						Description: "Whether or not Trusted IPs is required or optional to access a deployment.",
 						Computed:    true,
 					},
 				},

--- a/vercel/data_source_project_model.go
+++ b/vercel/data_source_project_model.go
@@ -7,37 +7,28 @@ import (
 
 // Project reflects the state terraform stores internally for a project.
 type ProjectDataSource struct {
-	BuildCommand             types.String                  `tfsdk:"build_command"`
-	DevCommand               types.String                  `tfsdk:"dev_command"`
-	Environment              types.Set                     `tfsdk:"environment"`
-	Framework                types.String                  `tfsdk:"framework"`
-	GitRepository            *GitRepository                `tfsdk:"git_repository"`
-	ID                       types.String                  `tfsdk:"id"`
-	IgnoreCommand            types.String                  `tfsdk:"ignore_command"`
-	InstallCommand           types.String                  `tfsdk:"install_command"`
-	Name                     types.String                  `tfsdk:"name"`
-	OutputDirectory          types.String                  `tfsdk:"output_directory"`
-	PublicSource             types.Bool                    `tfsdk:"public_source"`
-	RootDirectory            types.String                  `tfsdk:"root_directory"`
-	ServerlessFunctionRegion types.String                  `tfsdk:"serverless_function_region"`
-	TeamID                   types.String                  `tfsdk:"team_id"`
-	VercelAuthentication     *VercelAuthentication         `tfsdk:"vercel_authentication"`
-	PasswordProtection       *PasswordProtectionDataSource `tfsdk:"password_protection"`
-}
-
-type PasswordProtectionDataSource struct {
-	ProtectProduction types.Bool `tfsdk:"protect_production"`
+	BuildCommand             types.String          `tfsdk:"build_command"`
+	DevCommand               types.String          `tfsdk:"dev_command"`
+	Environment              types.Set             `tfsdk:"environment"`
+	Framework                types.String          `tfsdk:"framework"`
+	GitRepository            *GitRepository        `tfsdk:"git_repository"`
+	ID                       types.String          `tfsdk:"id"`
+	IgnoreCommand            types.String          `tfsdk:"ignore_command"`
+	InstallCommand           types.String          `tfsdk:"install_command"`
+	Name                     types.String          `tfsdk:"name"`
+	OutputDirectory          types.String          `tfsdk:"output_directory"`
+	PublicSource             types.Bool            `tfsdk:"public_source"`
+	RootDirectory            types.String          `tfsdk:"root_directory"`
+	ServerlessFunctionRegion types.String          `tfsdk:"serverless_function_region"`
+	TeamID                   types.String          `tfsdk:"team_id"`
+	VercelAuthentication     *VercelAuthentication `tfsdk:"vercel_authentication"`
+	PasswordProtection       *PasswordProtection   `tfsdk:"password_protection"`
+	TrustedIps               *TrustedIps           `tfsdk:"trusted_ips"`
 }
 
 func convertResponseToProjectDataSource(response client.ProjectResponse, plan Project) ProjectDataSource {
 	project := convertResponseToProject(response, plan)
 
-	var pp *PasswordProtectionDataSource
-	if project.PasswordProtection != nil {
-		pp = &PasswordProtectionDataSource{
-			ProtectProduction: project.PasswordProtection.ProtectProduction,
-		}
-	}
 	return ProjectDataSource{
 		BuildCommand:             project.BuildCommand,
 		DevCommand:               project.DevCommand,
@@ -54,6 +45,7 @@ func convertResponseToProjectDataSource(response client.ProjectResponse, plan Pr
 		ServerlessFunctionRegion: project.ServerlessFunctionRegion,
 		TeamID:                   project.TeamID,
 		VercelAuthentication:     project.VercelAuthentication,
-		PasswordProtection:       pp,
+		PasswordProtection:       project.PasswordProtection,
+		TrustedIps:               project.TrustedIps,
 	}
 }

--- a/vercel/data_source_project_model.go
+++ b/vercel/data_source_project_model.go
@@ -29,6 +29,12 @@ type ProjectDataSource struct {
 func convertResponseToProjectDataSource(response client.ProjectResponse, plan Project) ProjectDataSource {
 	project := convertResponseToProject(response, plan)
 
+	var pp *PasswordProtection
+	if project.PasswordProtection != nil {
+		pp = &PasswordProtection{
+			DeploymentType: project.PasswordProtection.DeploymentType,
+		}
+	}
 	return ProjectDataSource{
 		BuildCommand:             project.BuildCommand,
 		DevCommand:               project.DevCommand,
@@ -45,7 +51,7 @@ func convertResponseToProjectDataSource(response client.ProjectResponse, plan Pr
 		ServerlessFunctionRegion: project.ServerlessFunctionRegion,
 		TeamID:                   project.TeamID,
 		VercelAuthentication:     project.VercelAuthentication,
-		PasswordProtection:       project.PasswordProtection,
+		PasswordProtection:       pp,
 		TrustedIps:               project.TrustedIps,
 	}
 }

--- a/vercel/data_source_project_test.go
+++ b/vercel/data_source_project_test.go
@@ -33,7 +33,7 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 						"note":  "notey note",
 					}),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "trusted_ips.deployment_type", "only_production_deployments"),
-					resource.TestCheckResourceAttr("data.vercel_project.test", "trusted_ips.protection_mode", "additional"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "trusted_ips.protection_mode", "trusted_ip_required"),
 
 					resource.TestCheckTypeSetElemNestedAttrs("data.vercel_project.test", "environment.*", map[string]string{
 						"key":   "foo",
@@ -72,7 +72,7 @@ resource "vercel_project" "test" {
 		}
 	]
 	deployment_type = "only_production_deployments"
-	protection_mode = "additional"
+	protection_mode = "trusted_ip_required"
   }
   %s
   environment = [

--- a/vercel/data_source_project_test.go
+++ b/vercel/data_source_project_test.go
@@ -25,8 +25,16 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vercel_project.test", "output_directory", ".output"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "public_source", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "root_directory", "ui/src"),
-					resource.TestCheckResourceAttr("data.vercel_project.test", "vercel_authentication.protect_production", "true"),
-					resource.TestCheckResourceAttr("data.vercel_project.test", "password_protection.protect_production", "true"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "vercel_authentication.deployment_type", "standard_protection"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "password_protection.deployment_type", "standard_protection"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "trusted_ips.addresses.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("data.vercel_project.test", "trusted_ips.addresses.*", map[string]string{
+						"value": "1.1.1.1",
+						"note":  "notey note",
+					}),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "trusted_ips.deployment_type", "only_production_deployments"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "trusted_ips.protection_mode", "additional"),
+
 					resource.TestCheckTypeSetElemNestedAttrs("data.vercel_project.test", "environment.*", map[string]string{
 						"key":   "foo",
 						"value": "bar",
@@ -50,11 +58,21 @@ resource "vercel_project" "test" {
   public_source = true
   root_directory = "ui/src"
   vercel_authentication = {
-    protect_production = true
+    deployment_type = "standard_protection"
   }
   password_protection = {
     password = "foo"
-    protect_production = true
+    deployment_type = "standard_protection"
+  }
+  trusted_ips = {
+	addresses = [
+		{
+			value = "1.1.1.1"
+			note = "notey note"
+		}
+	]
+	deployment_type = "only_production_deployments"
+	protection_mode = "additional"
   }
   %s
   environment = [

--- a/vercel/deployment_protection.go
+++ b/vercel/deployment_protection.go
@@ -1,0 +1,30 @@
+package vercel
+
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
+type VercelAuthentication struct {
+	DeploymentType types.String `tfsdk:"deployment_type"`
+}
+
+type PasswordProtection struct {
+	DeploymentType types.String `tfsdk:"deployment_type"`
+}
+type PasswordProtectionWithPassword struct {
+	DeploymentType types.String `tfsdk:"deployment_type"`
+	Password       types.String `tfsdk:"password"`
+}
+
+type TrustedIpAddress struct {
+	Value types.String `tfsdk:"value"`
+	Note  types.String `tfsdk:"note"`
+}
+
+type TrustedIps struct {
+	DeploymentType types.String       `tfsdk:"deployment_type"`
+	Addresses      []TrustedIpAddress `tfsdk:"addresses"`
+	ProtectionMode types.String       `tfsdk:"protection_mode"`
+}
+
+type ProtectionBypass struct {
+	Scope types.String `tfsdk:"scope"`
+}

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -237,7 +236,6 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 						Validators: []validator.String{
 							stringOneOf("additional", "exclusive"),
 						},
-						Default: stringdefault.StaticString("additional"),
 					},
 				},
 			},

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -212,8 +213,9 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				Optional:    true,
 				Attributes: map[string]schema.Attribute{
 					"addresses": schema.SetAttribute{
-						Description: "The allowed IP addressses and CIDR ranges with optional descriptions.",
-						Required:    true,
+						Description:   "The allowed IP addressses and CIDR ranges with optional descriptions.",
+						Required:      true,
+						PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
 						ElementType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{
 								"value": types.StringType,

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -241,6 +241,9 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 								},
 							},
 						},
+						Validators: []validator.Set{
+							stringSetMinCount(1),
+						},
 					},
 					"deployment_type": schema.StringAttribute{
 						Required:      true,

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -9,9 +9,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -173,15 +175,25 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				},
 			},
 			"vercel_authentication": schema.SingleNestedAttribute{
-				Description: "Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team.",
-				Optional:    true,
+				Description:   "Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+				Default: objectdefault.StaticValue(types.ObjectValueMust(
+					map[string]attr.Type{
+						"deployment_type": types.StringType,
+					},
+					map[string]attr.Value{
+						"deployment_type": types.StringValue("standard_protection"),
+					},
+				)),
 				Attributes: map[string]schema.Attribute{
 					"deployment_type": schema.StringAttribute{
 						Required:      true,
-						Description:   "The deployment environment to protect. Must be one one `standard_protection`, `all_deployments`, or `only_preview_deployments`.",
+						Description:   "The deployment environment to protect. Must be one of `standard_protection`, `all_deployments`, `only_preview_deployments`, or `none`.",
 						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 						Validators: []validator.String{
-							stringOneOf("standard_protection", "all_deployments", "only_preview_deployments"),
+							stringOneOf("standard_protection", "all_deployments", "only_preview_deployments", "none"),
 						},
 					},
 				},
@@ -200,7 +212,7 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 					},
 					"deployment_type": schema.StringAttribute{
 						Required:      true,
-						Description:   "The deployment environment to protect. Must be one one `standard_protection`, `all_deployments`, or `only_preview_deployments`.",
+						Description:   "The deployment environment to protect. Must be one of `standard_protection`, `all_deployments`, or `only_preview_deployments`.",
 						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 						Validators: []validator.String{
 							stringOneOf("standard_protection", "all_deployments", "only_preview_deployments"),
@@ -212,20 +224,27 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				Description: "Ensures only visitors from an allowed IP address can access your deployment.",
 				Optional:    true,
 				Attributes: map[string]schema.Attribute{
-					"addresses": schema.SetAttribute{
+					"addresses": schema.SetNestedAttribute{
 						Description:   "The allowed IP addressses and CIDR ranges with optional descriptions.",
 						Required:      true,
 						PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
-						ElementType: types.ObjectType{
-							AttrTypes: map[string]attr.Type{
-								"value": types.StringType,
-								"note":  types.StringType,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"value": schema.StringAttribute{
+									Description: "The address or CIDR range that can access deployments.",
+									Required:    true,
+									Sensitive:   true,
+								},
+								"note": schema.StringAttribute{
+									Description: "A description for the value",
+									Optional:    true,
+								},
 							},
 						},
 					},
 					"deployment_type": schema.StringAttribute{
 						Required:      true,
-						Description:   "The deployment environment to protect. Must be one one `standard_protection`, `all_deployments`, `only_production_deployments`, or `only_preview_deployments`.",
+						Description:   "The deployment environment to protect. Must be one of `standard_protection`, `all_deployments`, `only_production_deployments`, or `only_preview_deployments`.",
 						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 						Validators: []validator.String{
 							stringOneOf("standard_protection", "all_deployments", "only_production_deployments", "only_preview_deployments"),
@@ -233,10 +252,12 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 					},
 					"protection_mode": schema.StringAttribute{
 						Optional:      true,
-						Description:   "Whether or not Trusted IPs is optional to access a deployment. Must be either `additional` or `exclusive`. `exclusive` is only availible with Standalone Trusted IPs.",
+						Computed:      true,
+						Default:       stringdefault.StaticString("trusted_ip_required"),
+						Description:   "Whether or not Trusted IPs is optional to access a deployment. Must be either `trusted_ip_required` or `trusted_ip_optional`. `trusted_ip_optional` is only available with Standalone Trusted IPs.",
 						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 						Validators: []validator.String{
-							stringOneOf("additional", "exclusive"),
+							stringOneOf("trusted_ip_required", "trusted_ip_optional"),
 						},
 					},
 				},

--- a/vercel/resource_project_model.go
+++ b/vercel/resource_project_model.go
@@ -274,15 +274,6 @@ var envVariableElemType = types.ObjectType{
 	},
 }
 
-var trustedIpsAddressesVariableElemType = types.SetType{
-	ElemType: types.ObjectType{
-		AttrTypes: map[string]attr.Type{
-			"value": types.StringType,
-			"note":  types.StringType,
-		},
-	},
-}
-
 func convertResponseToProject(response client.ProjectResponse, plan Project) Project {
 	fields := plan.coercedFields()
 

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -166,7 +166,7 @@ func TestAcc_ProjectWithVercelAuthAndPasswordProtectionAndTrustedIps(t *testing.
 						"note":  "notey note",
 					}),
 					resource.TestCheckResourceAttr("vercel_project.enabled_to_start", "trusted_ips.deployment_type", "all_deployments"),
-					resource.TestCheckResourceAttr("vercel_project.enabled_to_start", "trusted_ips.protection_mode", "exclusive"),
+					resource.TestCheckResourceAttr("vercel_project.enabled_to_start", "trusted_ips.protection_mode", "trusted_ip_optional"),
 					resource.TestCheckResourceAttr("vercel_project.enabled_to_start", "protection_bypass_for_automation", "true"),
 					resource.TestCheckResourceAttrSet("vercel_project.enabled_to_start", "protection_bypass_for_automation_secret"),
 					testAccProjectExists("vercel_project.disabled_to_start", testTeam()),
@@ -185,7 +185,7 @@ func TestAcc_ProjectWithVercelAuthAndPasswordProtectionAndTrustedIps(t *testing.
 						"note":  "notey notey note",
 					}),
 					resource.TestCheckResourceAttr("vercel_project.enabled_to_update", "trusted_ips.deployment_type", "only_production_deployments"),
-					resource.TestCheckResourceAttr("vercel_project.enabled_to_update", "trusted_ips.protection_mode", "additional"),
+					resource.TestCheckResourceAttr("vercel_project.enabled_to_update", "trusted_ips.protection_mode", "trusted_ip_required"),
 					resource.TestCheckResourceAttr("vercel_project.enabled_to_update", "protection_bypass_for_automation", "true"),
 					resource.TestCheckResourceAttrSet("vercel_project.enabled_to_update", "protection_bypass_for_automation_secret"),
 				),
@@ -208,7 +208,7 @@ func TestAcc_ProjectWithVercelAuthAndPasswordProtectionAndTrustedIps(t *testing.
 						"note":  "notey note",
 					}),
 					resource.TestCheckResourceAttr("vercel_project.disabled_to_start", "trusted_ips.deployment_type", "standard_protection"),
-					resource.TestCheckResourceAttr("vercel_project.disabled_to_start", "trusted_ips.protection_mode", "additional"),
+					resource.TestCheckResourceAttr("vercel_project.disabled_to_start", "trusted_ips.protection_mode", "trusted_ip_required"),
 					resource.TestCheckResourceAttr("vercel_project.disabled_to_start", "protection_bypass_for_automation", "true"),
 					resource.TestCheckResourceAttrSet("vercel_project.disabled_to_start", "protection_bypass_for_automation_secret"),
 
@@ -221,7 +221,7 @@ func TestAcc_ProjectWithVercelAuthAndPasswordProtectionAndTrustedIps(t *testing.
 						"note":  "notey notey",
 					}),
 					resource.TestCheckResourceAttr("vercel_project.enabled_to_update", "trusted_ips.deployment_type", "all_deployments"),
-					resource.TestCheckResourceAttr("vercel_project.enabled_to_update", "trusted_ips.protection_mode", "exclusive"),
+					resource.TestCheckResourceAttr("vercel_project.enabled_to_update", "trusted_ips.protection_mode", "trusted_ip_optional"),
 					resource.TestCheckResourceAttr("vercel_project.enabled_to_update", "protection_bypass_for_automation", "false"),
 					resource.TestCheckNoResourceAttr("vercel_project.enabled_to_update", "protection_bypass_for_automation_secret"),
 				),
@@ -380,7 +380,7 @@ resource "vercel_project" "enabled_to_start" {
 		}
 	]
 	deployment_type = "all_deployments"
-	protection_mode = "exclusive"
+	protection_mode = "trusted_ip_optional"
   }
   protection_bypass_for_automation = true
 }
@@ -465,7 +465,7 @@ resource "vercel_project" "enabled_to_update" {
 		}
 	]
 	deployment_type = "all_deployments"
-	protection_mode = "exclusive"
+	protection_mode = "trusted_ip_optional"
   }
   protection_bypass_for_automation = false
 }


### PR DESCRIPTION
- Add support for [Trusted IPs](https://vercel.com/docs/security/deployment-protection/methods-to-protect-deployments/trusted-ips)
- **[Breaking change]** Replace `protect_production` (boolean) with `deployment_type` (string) for [Password Protection](https://vercel.com/docs/security/deployment-protection/methods-to-protect-deployments/password-protection), [Vercel Authentication](https://vercel.com/docs/security/deployment-protection/methods-to-protect-deployments/vercel-authentication), and [Trusted IPs](https://vercel.com/docs/security/deployment-protection/methods-to-protect-deployments/trusted-ips)
- Make Vercel Authentication disable-able
- Update related tests & docs

Closes #144 