### PR TITLE
Add support for automatically exposing system env variables

### DIFF
--- a/client/project_get.go
+++ b/client/project_get.go
@@ -88,6 +88,7 @@ type ProjectResponse struct {
 	PasswordProtection       *PasswordProtection         `json:"passwordProtection"`
 	TrustedIps               *TrustedIps                 `json:"trustedIps"`
 	ProtectionBypass         map[string]ProtectionBypass `json:"protectionBypass"`
+	AutoExposeSystemEnvVars  *bool                       `json:"autoExposeSystemEnvs"`
 }
 
 // GetProject retrieves information about an existing project from Vercel.

--- a/client/project_update.go
+++ b/client/project_update.go
@@ -27,6 +27,7 @@ type UpdateProjectRequest struct {
 	VercelAuthentication        *VercelAuthentication           `json:"ssoProtection"`
 	PasswordProtection          *PasswordProtectionWithPassword `json:"passwordProtection"`
 	TrustedIps                  *TrustedIps                     `json:"trustedIps"`
+	AutoExposeSystemEnvVars     *bool                           `json:"autoExposeSystemEnvs,omitempty"`
 }
 
 // UpdateProject updates an existing projects configuration within Vercel.

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -42,6 +42,7 @@ output "project_id" {
 
 ### Read-Only
 
+- `automatically_expose_system_environment_variables` (Boolean) Vercel provides a set of Environment Variables that are automatically populated by the System, such as the URL of the Deployment or the name of the Git branch deployed. To expose them to your Deployments, enable this field
 - `build_command` (String) The build command for this project. If omitted, this value will be automatically detected.
 - `dev_command` (String) The dev command for this project. If omitted, this value will be automatically detected.
 - `environment` (Attributes Set) A list of environment variables that should be configured for the project. (see [below for nested schema](#nestedatt--environment))

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -55,6 +55,7 @@ resource "vercel_project" "example" {
 
 ### Optional
 
+- `automatically_expose_system_environment_variables` (Boolean) Vercel provides a set of Environment Variables that are automatically populated by the System, such as the URL of the Deployment or the name of the Git branch deployed. To expose them to your Deployments, enable this field
 - `build_command` (String) The build command for this project. If omitted, this value will be automatically detected.
 - `dev_command` (String) The dev command for this project. If omitted, this value will be automatically detected.
 - `environment` (Attributes Set) A set of Environment Variables that should be configured for the project. (see [below for nested schema](#nestedatt--environment))

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -213,6 +213,10 @@ For more detailed information, please see the [Vercel documentation](https://ver
 				Computed:    true,
 				Description: "The name of a directory or relative path to the source code of your project. When null is used it will default to the project root.",
 			},
+			"automatically_expose_system_environment_variables": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Vercel provides a set of Environment Variables that are automatically populated by the System, such as the URL of the Deployment or the name of the Git branch deployed. To expose them to your Deployments, enable this field",
+			},
 		},
 	}
 }

--- a/vercel/data_source_project_model.go
+++ b/vercel/data_source_project_model.go
@@ -26,6 +26,7 @@ type ProjectDataSource struct {
 	VercelAuthentication     *VercelAuthentication `tfsdk:"vercel_authentication"`
 	PasswordProtection       *PasswordProtection   `tfsdk:"password_protection"`
 	TrustedIps               *TrustedIps           `tfsdk:"trusted_ips"`
+	AutoExposeSystemEnvVars  types.Bool            `tfsdk:"automatically_expose_system_environment_variables"`
 }
 
 func convertResponseToProjectDataSource(ctx context.Context, response client.ProjectResponse, plan Project) (ProjectDataSource, error) {
@@ -58,5 +59,6 @@ func convertResponseToProjectDataSource(ctx context.Context, response client.Pro
 		VercelAuthentication:     project.VercelAuthentication,
 		PasswordProtection:       pp,
 		TrustedIps:               project.TrustedIps,
+		AutoExposeSystemEnvVars:  fromBoolPointer(response.AutoExposeSystemEnvVars),
 	}, nil
 }

--- a/vercel/data_source_project_test.go
+++ b/vercel/data_source_project_test.go
@@ -28,6 +28,7 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vercel_project.test", "vercel_authentication.deployment_type", "standard_protection"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "password_protection.deployment_type", "standard_protection"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "trusted_ips.addresses.#", "1"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "automatically_expose_system_environment_variables", "true"),
 					resource.TestCheckTypeSetElemNestedAttrs("data.vercel_project.test", "trusted_ips.addresses.*", map[string]string{
 						"value": "1.1.1.1",
 						"note":  "notey note",
@@ -82,6 +83,7 @@ resource "vercel_project" "test" {
       target = ["production"]
     }
   ]
+  automatically_expose_system_environment_variables = true
 }
 
 data "vercel_project" "test" {

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -298,6 +298,11 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				Computed:    true,
 				Description: "If `protection_bypass_for_automation` is enabled, use this value in the `x-vercel-protection-bypass` header to bypass Vercel Authentication and Password Protection for both Preview and Production Deployments.",
 			},
+			"automatically_expose_system_environment_variables": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Vercel provides a set of Environment Variables that are automatically populated by the System, such as the URL of the Deployment or the name of the Git branch deployed. To expose them to your Deployments, enable this field",
+			},
 		},
 	}
 }
@@ -348,7 +353,7 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	if plan.PasswordProtection != nil || plan.VercelAuthentication != nil || plan.TrustedIps != nil {
+	if plan.PasswordProtection != nil || plan.VercelAuthentication != nil || plan.TrustedIps != nil || !plan.AutoExposeSystemEnvVars.IsNull() {
 		out, err = r.client.UpdateProject(ctx, result.ID.ValueString(), plan.TeamID.ValueString(), plan.toUpdateProjectRequest(plan.Name.ValueString()), !plan.Environment.IsNull())
 		if err != nil {
 			resp.Diagnostics.AddError(

--- a/vercel/resource_project_model.go
+++ b/vercel/resource_project_model.go
@@ -30,6 +30,7 @@ type Project struct {
 	TrustedIps                          *TrustedIps                     `tfsdk:"trusted_ips"`
 	ProtectionBypassForAutomation       types.Bool                      `tfsdk:"protection_bypass_for_automation"`
 	ProtectionBypassForAutomationSecret types.String                    `tfsdk:"protection_bypass_for_automation_secret"`
+	AutoExposeSystemEnvVars             types.Bool                      `tfsdk:"automatically_expose_system_environment_variables"`
 }
 
 var nullProject = Project{
@@ -120,6 +121,7 @@ func (p *Project) toUpdateProjectRequest(oldName string) client.UpdateProjectReq
 		PasswordProtection:          p.PasswordProtection.toUpdateProjectRequest(),
 		VercelAuthentication:        p.VercelAuthentication.toUpdateProjectRequest(),
 		TrustedIps:                  p.TrustedIps.toUpdateProjectRequest(),
+		AutoExposeSystemEnvVars:     toBoolPointer(p.AutoExposeSystemEnvVars),
 	}
 }
 
@@ -471,5 +473,6 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 		TrustedIps:                          tip,
 		ProtectionBypassForAutomation:       protectionBypass,
 		ProtectionBypassForAutomationSecret: protectionBypassSecret,
+		AutoExposeSystemEnvVars:             fromBoolPointer(response.AutoExposeSystemEnvVars),
 	}, nil
 }

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -59,6 +59,7 @@ func TestAcc_Project(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_project.test", "root_directory", "ui/src"),
 					resource.TestCheckResourceAttr("vercel_project.test", "ignore_command", "echo 'wat'"),
 					resource.TestCheckResourceAttr("vercel_project.test", "serverless_function_region", "syd1"),
+					resource.TestCheckResourceAttr("vercel_project.test", "automatically_expose_system_environment_variables", "true"),
 					resource.TestCheckTypeSetElemNestedAttrs("vercel_project.test", "environment.*", map[string]string{
 						"key":   "foo",
 						"value": "bar",
@@ -570,6 +571,7 @@ resource "vercel_project" "test" {
   output_directory = ".output"
   public_source = true
   root_directory = "ui/src"
+  automatically_expose_system_environment_variables = true
   environment = [
     {
       key    = "foo"


### PR DESCRIPTION
This is a feature [in the Vercel UI](https://vercel.com/docs/projects/environment-variables/system-environment-variables)

Add support to the TF provider.

Closes #158
