### PR TITLE
Add support for Deploy Hooks

### DIFF
--- a/client/deploy_hooks.go
+++ b/client/deploy_hooks.go
@@ -1,0 +1,84 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+type DeployHook struct {
+	Name string `json:"name"`
+	Ref  string `json:"ref"`
+	URL  string `json:"url"`
+	ID   string `json:"id"`
+}
+
+type CreateDeployHookRequest struct {
+	ProjectID string `json:"-"`
+	TeamID    string `json:"-"`
+	Name      string `json:"name"`
+	Ref       string `json:"ref"`
+}
+
+func (c *Client) CreateDeployHook(ctx context.Context, request CreateDeployHookRequest) (h DeployHook, err error) {
+	url := fmt.Sprintf("%s/v2/projects/%s/deploy-hooks", c.baseURL, request.ProjectID)
+	if c.teamID(request.TeamID) != "" {
+		url = fmt.Sprintf("%s?teamId=%s", url, c.teamID(request.TeamID))
+	}
+	payload := string(mustMarshal(request))
+	tflog.Info(ctx, "creating deploy hook", map[string]interface{}{
+		"url":     url,
+		"payload": payload,
+	})
+
+	var r ProjectResponse
+	err = c.doRequest(clientRequest{
+		ctx:    ctx,
+		method: "POST",
+		url:    url,
+		body:   payload,
+	}, &r)
+	if err != nil {
+		return h, fmt.Errorf("error creating deploy hook: %w", err)
+	}
+
+	// Reverse the list as newest created are at the end
+	slices.Reverse(r.Link.DeployHooks)
+	for _, hook := range r.Link.DeployHooks {
+		if hook.Name == request.Name && hook.Ref == request.Ref {
+			return hook, nil
+		}
+	}
+
+	return h, fmt.Errorf("deploy hook was created successfully, but could not be found")
+}
+
+type DeleteDeployHookRequest struct {
+	ProjectID string
+	TeamID    string
+	ID        string
+}
+
+func (c *Client) DeleteDeployHook(ctx context.Context, request DeleteDeployHookRequest) error {
+	url := fmt.Sprintf("%s/v2/projects/%s/deploy-hooks/%s", c.baseURL, request.ProjectID, request.ID)
+	if c.teamID(request.TeamID) != "" {
+		url = fmt.Sprintf("%s?teamId=%s", url, c.teamID(request.TeamID))
+	}
+	payload := string(mustMarshal(request))
+	tflog.Info(ctx, "creating deploy hook", map[string]interface{}{
+		"url":     url,
+		"payload": payload,
+	})
+
+	err := c.doRequest(clientRequest{
+		ctx:    ctx,
+		method: "DELETE",
+		url:    url,
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("error deleting deploy hook: %w", err)
+	}
+	return nil
+}

--- a/client/deployment.go
+++ b/client/deployment.go
@@ -150,7 +150,7 @@ func (e MissingFilesError) Error() string {
 }
 
 func (c *Client) getGitSource(ctx context.Context, projectID, ref, teamID string) (gs gitSource, err error) {
-	project, err := c.GetProject(ctx, projectID, teamID, false)
+	project, err := c.GetProject(ctx, projectID, teamID)
 	if err != nil {
 		return gs, fmt.Errorf("error getting project: %w", err)
 	}

--- a/client/environment_variable.go
+++ b/client/environment_variable.go
@@ -123,7 +123,7 @@ func (c *Client) DeleteEnvironmentVariable(ctx context.Context, projectID, teamI
 	}, nil)
 }
 
-func (c *Client) getEnvironmentVariables(ctx context.Context, projectID, teamID string) ([]EnvironmentVariable, error) {
+func (c *Client) GetEnvironmentVariables(ctx context.Context, projectID, teamID string) ([]EnvironmentVariable, error) {
 	url := fmt.Sprintf("%s/v8/projects/%s/env?decrypt=true", c.baseURL, projectID)
 	if c.teamID(teamID) != "" {
 		url = fmt.Sprintf("%s&teamId=%s", url, c.teamID(teamID))

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -107,7 +107,22 @@ Required:
 
 Optional:
 
+- `deploy_hooks` (Attributes Set) Deploy hooks are unique URLs that allow you to trigger a deployment of a given branch. See https://vercel.com/docs/deployments/deploy-hooks for full information. (see [below for nested schema](#nestedatt--git_repository--deploy_hooks))
 - `production_branch` (String) By default, every commit pushed to the main branch will trigger a Production Deployment instead of the usual Preview Deployment. You can switch to a different branch here.
+
+<a id="nestedatt--git_repository--deploy_hooks"></a>
+### Nested Schema for `git_repository.deploy_hooks`
+
+Required:
+
+- `name` (String) The name of the deploy hook.
+- `ref` (String) The branch or commit hash that should be deployed.
+
+Read-Only:
+
+- `id` (String) The ID of the deploy hook.
+- `url` (String, Sensitive) A URL that, when a POST request is made to, will trigger a new deployment.
+
 
 
 <a id="nestedatt--password_protection"></a>

--- a/vercel/resource_deployment.go
+++ b/vercel/resource_deployment.go
@@ -524,7 +524,7 @@ func (r *deploymentResource) Create(ctx context.Context, req resource.CreateRequ
 		Ref:             plan.Ref.ValueString(),
 	}
 
-	_, err = r.client.GetProject(ctx, plan.ProjectID.ValueString(), plan.TeamID.ValueString(), false)
+	_, err = r.client.GetProject(ctx, plan.ProjectID.ValueString(), plan.TeamID.ValueString())
 	if client.NotFound(err) {
 		resp.Diagnostics.AddError(
 			"Error creating deployment",

--- a/vercel/resource_project_domain.go
+++ b/vercel/resource_project_domain.go
@@ -148,7 +148,7 @@ func (r *projectDomainResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	_, err := r.client.GetProject(ctx, plan.ProjectID.ValueString(), plan.TeamID.ValueString(), false)
+	_, err := r.client.GetProject(ctx, plan.ProjectID.ValueString(), plan.TeamID.ValueString())
 	if client.NotFound(err) {
 		resp.Diagnostics.AddError(
 			"Error creating project domain",

--- a/vercel/resource_project_environment_variable.go
+++ b/vercel/resource_project_environment_variable.go
@@ -213,7 +213,7 @@ func (r *projectEnvironmentVariableResource) Create(ctx context.Context, req res
 		return
 	}
 
-	_, err := r.client.GetProject(ctx, plan.ProjectID.ValueString(), plan.TeamID.ValueString(), false)
+	_, err := r.client.GetProject(ctx, plan.ProjectID.ValueString(), plan.TeamID.ValueString())
 	if client.NotFound(err) {
 		resp.Diagnostics.AddError(
 			"Error creating project environment variable",

--- a/vercel/resource_project_environment_variable_test.go
+++ b/vercel/resource_project_environment_variable_test.go
@@ -37,12 +37,12 @@ func testAccProjectEnvironmentVariablesDoNotExist(n, teamID string) resource.Tes
 			return fmt.Errorf("no ID is set")
 		}
 
-		project, err := testClient().GetProject(context.TODO(), rs.Primary.ID, teamID, true)
+		envs, err := testClient().GetEnvironmentVariables(context.TODO(), rs.Primary.ID, teamID)
 		if err != nil {
 			return fmt.Errorf("could not fetch the project: %w", err)
 		}
 
-		if len(project.EnvironmentVariables) != 0 {
+		if len(envs) != 0 {
 			return fmt.Errorf("project environment variables not deleted, they still exist")
 		}
 

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -283,7 +283,7 @@ func testAccProjectExists(n, teamID string) resource.TestCheckFunc {
 			return fmt.Errorf("no projectID is set")
 		}
 
-		_, err := testClient().GetProject(context.TODO(), rs.Primary.ID, teamID, false)
+		_, err := testClient().GetProject(context.TODO(), rs.Primary.ID, teamID)
 		return err
 	}
 }
@@ -299,7 +299,7 @@ func testAccProjectDestroy(n, teamID string) resource.TestCheckFunc {
 			return fmt.Errorf("no projectID is set")
 		}
 
-		_, err := testClient().GetProject(context.TODO(), rs.Primary.ID, teamID, false)
+		_, err := testClient().GetProject(context.TODO(), rs.Primary.ID, teamID)
 		if err == nil {
 			return fmt.Errorf("expected not_found error, but got no error")
 		}
@@ -487,6 +487,12 @@ resource "vercel_project" "test_git" {
   git_repository = {
     type = "github"
     repo = "%s"
+    deploy_hooks = [
+        {
+            ref = "main"
+            name = "some deploy hook"
+        }
+    ]
   }
   environment = [
     {
@@ -510,6 +516,16 @@ resource "vercel_project" "test_git" {
     type = "github"
     repo = "%s"
     production_branch = "staging"
+    deploy_hooks = [
+        {
+            ref = "main"
+            name = "some deploy hook"
+        },
+        {
+            ref = "main"
+            name = "some other hook"
+        }
+    ]
   }
   environment = [
     {


### PR DESCRIPTION
Deploy Hooks are available underneath the `git_repostiory` section of a
`vercel_project`.

These generate a URL that can be used to trigger new deployment of a
specific `ref`.

Existing on the `vercel_project` resource under `git_repository` is
the only place that seems to make sense, as linking/unlinking a
git repository causes all deploy hooks to require recreation, so
they cannot exist as a separate resource.

Closes #104
