### PR TITLE
Validate sensitive environment variable config when creating env vars

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -9,7 +10,7 @@ import (
 type Client struct {
 	token   string
 	client  *http.Client
-	_teamID string
+	team    Team
 	baseURL string
 }
 
@@ -33,9 +34,16 @@ func New(token string) *Client {
 	}
 }
 
-func (c *Client) WithTeamID(teamID string) *Client {
-	c._teamID = teamID
+func (c *Client) WithTeam(team Team) *Client {
+	c.team = team
 	return c
+}
+
+func (c *Client) Team(ctx context.Context, teamID string) (Team, error) {
+	if teamID != "" {
+		return c.GetTeam(ctx, teamID)
+	}
+	return c.team, nil
 }
 
 // teamID is a helper method to return one of two values based on specificity.
@@ -45,5 +53,5 @@ func (c *Client) teamID(teamID string) string {
 	if teamID != "" {
 		return teamID
 	}
-	return c._teamID
+	return c.team.ID
 }

--- a/client/team.go
+++ b/client/team.go
@@ -13,13 +13,14 @@ type TeamCreateRequest struct {
 	Name string `json:"name"`
 }
 
-// TeamResponse is the information returned by the vercel api when a team is created.
-type TeamResponse struct {
-	ID string `json:"id"`
+// Team is the information returned by the vercel api when a team is created.
+type Team struct {
+	ID                                 string  `json:"id"`
+	SensitiveEnvironmentVariablePolicy *string `json:"sensitiveEnvironmentVariablePolicy"`
 }
 
 // CreateTeam creates a team within vercel.
-func (c *Client) CreateTeam(ctx context.Context, request TeamCreateRequest) (r TeamResponse, err error) {
+func (c *Client) CreateTeam(ctx context.Context, request TeamCreateRequest) (r Team, err error) {
 	url := fmt.Sprintf("%s/v1/teams", c.baseURL)
 
 	payload := string(mustMarshal(request))
@@ -51,7 +52,7 @@ func (c *Client) DeleteTeam(ctx context.Context, teamID string) error {
 }
 
 // GetTeam returns information about an existing team within vercel.
-func (c *Client) GetTeam(ctx context.Context, idOrSlug string) (r TeamResponse, err error) {
+func (c *Client) GetTeam(ctx context.Context, idOrSlug string) (r Team, err error) {
 	url := fmt.Sprintf("%s/v2/teams/%s", c.baseURL, idOrSlug)
 	tflog.Info(ctx, "getting team", map[string]interface{}{
 		"url": url,

--- a/sweep/main.go
+++ b/sweep/main.go
@@ -26,6 +26,7 @@ func main() {
 		//lintignore:R009
 		panic("VERCEL_TERRAFORM_TESTING_DOMAIN environment variable not set")
 	}
+	clearDNS := os.Getenv("VERCEL_TERRAFORM_CLEAR_DNS") != ""
 	ctx := context.Background()
 
 	// delete both for the testing team, and for without a team
@@ -34,10 +35,12 @@ func main() {
 		//lintignore:R009
 		panic(err)
 	}
-	err = deleteAllDNSRecords(ctx, c, domain, teamID)
-	if err != nil {
-		//lintignore:R009
-		panic(err)
+	if clearDNS {
+		err = deleteAllDNSRecords(ctx, c, domain, teamID)
+		if err != nil {
+			//lintignore:R009
+			panic(err)
+		}
 	}
 	err = deleteAllSharedEnvironmentVariables(ctx, c, teamID)
 	if err != nil {

--- a/vercel/provider.go
+++ b/vercel/provider.go
@@ -154,7 +154,7 @@ func (p *vercelProvider) Configure(ctx context.Context, req provider.ConfigureRe
 			)
 			return
 		}
-		vercelClient = vercelClient.WithTeamID(res.ID)
+		vercelClient = vercelClient.WithTeam(res)
 	}
 
 	resp.DataSourceData = vercelClient

--- a/vercel/resource_project_environment_variable.go
+++ b/vercel/resource_project_environment_variable.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
@@ -17,8 +18,10 @@ import (
 )
 
 var (
-	_ resource.Resource              = &projectEnvironmentVariableResource{}
-	_ resource.ResourceWithConfigure = &projectEnvironmentVariableResource{}
+	_ resource.Resource                = &projectEnvironmentVariableResource{}
+	_ resource.ResourceWithConfigure   = &projectEnvironmentVariableResource{}
+	_ resource.ResourceWithImportState = &projectEnvironmentVariableResource{}
+	_ resource.ResourceWithModifyPlan  = &projectEnvironmentVariableResource{}
 )
 
 func newProjectEnvironmentVariableResource() resource.Resource {
@@ -108,6 +111,7 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				Description:   "Whether the Environment Variable is sensitive or not.",
 				Optional:      true,
 				Computed:      true,
+				Validators:    []validator.Bool{},
 				PlanModifiers: []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
 			},
 		},
@@ -124,6 +128,49 @@ type ProjectEnvironmentVariable struct {
 	ProjectID types.String   `tfsdk:"project_id"`
 	ID        types.String   `tfsdk:"id"`
 	Sensitive types.Bool     `tfsdk:"sensitive"`
+}
+
+func (r *projectEnvironmentVariableResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+	var config ProjectEnvironmentVariable
+	diags := req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.ID.ValueString() != "" {
+		// The resource already exists, so this is okay.
+		return
+	}
+	if config.Sensitive.IsUnknown() || config.Sensitive.IsNull() || config.Sensitive.ValueBool() {
+		// Sensitive is either true, or computed, which is fine.
+		return
+	}
+
+	// if sensitive is explicitly set to `false`, then validate that an env var can be created with the given
+	// team sensitive environment variable policy.
+	team, err := r.client.Team(ctx, config.TeamID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error validating project environment variable",
+			"Could not validate project environment variable, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	if team.SensitiveEnvironmentVariablePolicy == nil || *team.SensitiveEnvironmentVariablePolicy != "on" {
+		// the policy isn't enabled
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		path.Root("sensitive"),
+		"Project Environment Variable Invalid",
+		"This team has a policy that forces all environment variables to be sensitive. Please remove the `sensitive` field or set the `sensitive` field to `true` in your configuration.",
+	)
 }
 
 func (e *ProjectEnvironmentVariable) toCreateEnvironmentVariableRequest() client.CreateEnvironmentVariableRequest {

--- a/vercel/resource_project_environment_variable_test.go
+++ b/vercel/resource_project_environment_variable_test.go
@@ -78,6 +78,14 @@ func TestAcc_ProjectEnvironmentVariables(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_project_environment_variable.example_sensitive", "value", "bar-sensitive"),
 					resource.TestCheckTypeSetElemAttr("vercel_project_environment_variable.example_sensitive", "target.*", "production"),
 					resource.TestCheckResourceAttr("vercel_project_environment_variable.example_sensitive", "sensitive", "true"),
+
+					/*
+						testAccProjectEnvironmentVariableExists("vercel_project_environment_variable.example_not_sensitive", testTeam()),
+						resource.TestCheckResourceAttr("vercel_project_environment_variable.example_not_sensitive", "key", "foo_not_sensitive"),
+						resource.TestCheckResourceAttr("vercel_project_environment_variable.example_not_sensitive", "value", "bar-not-sensitive"),
+						resource.TestCheckTypeSetElemAttr("vercel_project_environment_variable.example_not_sensitive", "target.*", "production"),
+						resource.TestCheckResourceAttr("vercel_project_environment_variable.example_not_sensitive", "sensitive", "false"),
+					*/
 				),
 			},
 			{
@@ -179,6 +187,17 @@ resource "vercel_project_environment_variable" "example_sensitive" {
 	target     = ["production"]
 	sensitive  = true
 }
+
+/*
+resource "vercel_project_environment_variable" "example_not_sensitive" {
+	project_id = vercel_project.example.id
+	%[3]s
+	key        = "foo_not_sensitive"
+	value      = "bar-not-sensitive"
+	target     = ["production"]
+	sensitive  = false
+}
+*/
 `, projectName, testGithubRepo(), teamIDConfig())
 }
 

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -526,7 +526,7 @@ resource "vercel_project" "test_git" {
   git_repository = {
     type = "github"
     repo = "%s"
-    production_branch = "staging"
+    production_branch = "production"
     deploy_hooks = [
         {
             ref = "main"


### PR DESCRIPTION
Turns out the API elides non-sensitive values into being sensitive if
the team has a sensitiveEnvironmentVariablePolicy set on it.

To prevent this from causing provider issues when the `sensitive` field
is explicitly set to `false`, warn at plan time that the resource being
created does not match the team policy.

Closes #183
