### PR TITLE
Add OPTIONS Allowlist support to vercel terraform provider

### DIFF
--- a/client/deployment_protection.go
+++ b/client/deployment_protection.go
@@ -26,3 +26,11 @@ type TrustedIps struct {
 type ProtectionBypass struct {
 	Scope string `json:"scope"`
 }
+
+type OptionsAllowlist struct {
+	Paths []OptionsAllowlistPath `json:"paths"`
+}
+
+type OptionsAllowlistPath struct {
+	Value string `json:"value"`
+}

--- a/client/project.go
+++ b/client/project.go
@@ -169,6 +169,7 @@ type ProjectResponse struct {
 	VercelAuthentication                 *VercelAuthentication       `json:"ssoProtection"`
 	PasswordProtection                   *PasswordProtection         `json:"passwordProtection"`
 	TrustedIps                           *TrustedIps                 `json:"trustedIps"`
+	OptionsAllowlist                     *OptionsAllowlist           `json:"optionsAllowlist"`
 	ProtectionBypass                     map[string]ProtectionBypass `json:"protectionBypass"`
 	AutoExposeSystemEnvVars              *bool                       `json:"autoExposeSystemEnvs"`
 	EnablePreviewFeedback                *bool                       `json:"enablePreviewFeedback"`
@@ -261,6 +262,7 @@ type UpdateProjectRequest struct {
 	VercelAuthentication                 *VercelAuthentication           `json:"ssoProtection"`
 	PasswordProtection                   *PasswordProtectionWithPassword `json:"passwordProtection"`
 	TrustedIps                           *TrustedIps                     `json:"trustedIps"`
+	OptionsAllowlist                     *OptionsAllowlist               `json:"optionsAllowlist"`
 	AutoExposeSystemEnvVars              bool                            `json:"autoExposeSystemEnvs"`
 	EnablePreviewFeedback                *bool                           `json:"enablePreviewFeedback"`
 	AutoAssignCustomDomains              bool                            `json:"autoAssignCustomDomains"`

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -69,6 +69,7 @@ output "project_id" {
 - `skew_protection` (String) Ensures that outdated clients always fetch the correct version for a given deployment. This value defines how long Vercel keeps Skew Protection active.
 - `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
 - `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team. (see [below for nested schema](#nestedatt--vercel_authentication))
+- `options_allowlist` (Attributes) Configuration for the OPTIONS Allowlist. (see [below for nested schema](#nestedatt--options_allowlist))
 
 <a id="nestedatt--environment"></a>
 ### Nested Schema for `environment`
@@ -139,6 +140,19 @@ Read-Only:
 - `note` (String)
 - `value` (String)
 
+<a id="#nestedatt--options_allowlist"></a>
+### Nested Schema for `options_allowlist`
+
+Read-Only:
+
+- `paths` (List of Object) The allowed paths for the OPTIONS Allowlist. (see [below for nested schema](#nestedatt--options_allowlist--paths))
+
+<a id="nestedatt--options_allowlist--paths"></a>
+### Nested Schema for `options_allowlist.paths`
+
+Read-Only:
+
+- `value` (String)
 
 
 <a id="nestedatt--vercel_authentication"></a>

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -69,7 +69,7 @@ output "project_id" {
 - `skew_protection` (String) Ensures that outdated clients always fetch the correct version for a given deployment. This value defines how long Vercel keeps Skew Protection active.
 - `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
 - `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team. (see [below for nested schema](#nestedatt--vercel_authentication))
-- `options_allowlist` (Attributes) Configuration for the OPTIONS Allowlist. (see [below for nested schema](#nestedatt--options_allowlist))
+- `options_allowlist` (Attributes) Disable Deployment Protection for CORS preflight `OPTIONS` requests for a list of paths. (see [below for nested schema](#nestedatt--options_allowlist))
 
 <a id="nestedatt--environment"></a>
 ### Nested Schema for `environment`
@@ -145,14 +145,14 @@ Read-Only:
 
 Read-Only:
 
-- `paths` (List of Object) The allowed paths for the OPTIONS Allowlist. (see [below for nested schema](#nestedatt--options_allowlist--paths))
+- `paths` (List of Object) The allowed paths for the OPTIONS Allowlist. Incoming requests will bypass Deployment Protection if they have the method `OPTIONS` and **start with** one of the path values. (see [below for nested schema](#nestedatt--options_allowlist--paths))
 
 <a id="nestedatt--options_allowlist--paths"></a>
 ### Nested Schema for `options_allowlist.paths`
 
 Read-Only:
 
-- `value` (String)
+- `value` (String) The prefix for allowed paths
 
 
 <a id="nestedatt--vercel_authentication"></a>

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -58,6 +58,7 @@ output "project_id" {
 - `id` (String) The ID of this resource.
 - `ignore_command` (String) When a commit is pushed to the Git repository that is connected with your Project, its SHA will determine if a new Build has to be issued. If the SHA was deployed before, no new Build will be issued. You can customize this behavior with a command that exits with code 1 (new Build needed) or code 0.
 - `install_command` (String) The install command for this project. If omitted, this value will be automatically detected.
+- `options_allowlist` (Attributes) Disable Deployment Protection for CORS preflight `OPTIONS` requests for a list of paths. (see [below for nested schema](#nestedatt--options_allowlist))
 - `output_directory` (String) The output directory of the project. When null is used this value will be automatically detected.
 - `password_protection` (Attributes) Ensures visitors of your Preview Deployments must enter a password in order to gain access. (see [below for nested schema](#nestedatt--password_protection))
 - `preview_comments` (Boolean) Whether comments are enabled on your Preview Deployments.
@@ -69,7 +70,6 @@ output "project_id" {
 - `skew_protection` (String) Ensures that outdated clients always fetch the correct version for a given deployment. This value defines how long Vercel keeps Skew Protection active.
 - `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
 - `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team. (see [below for nested schema](#nestedatt--vercel_authentication))
-- `options_allowlist` (Attributes) Disable Deployment Protection for CORS preflight `OPTIONS` requests for a list of paths. (see [below for nested schema](#nestedatt--options_allowlist))
 
 <a id="nestedatt--environment"></a>
 ### Nested Schema for `environment`
@@ -115,6 +115,22 @@ Read-Only:
 
 
 
+<a id="nestedatt--options_allowlist"></a>
+### Nested Schema for `options_allowlist`
+
+Read-Only:
+
+- `paths` (List of Object) The allowed paths for the OPTIONS Allowlist. Incoming requests will bypass Deployment Protection if they have the method `OPTIONS` and **start with** one of the path values. (see [below for nested schema](#nestedatt--options_allowlist--paths))
+
+<a id="nestedatt--options_allowlist--paths"></a>
+### Nested Schema for `options_allowlist.paths`
+
+Read-Only:
+
+- `value` (String)
+
+
+
 <a id="nestedatt--password_protection"></a>
 ### Nested Schema for `password_protection`
 
@@ -140,19 +156,6 @@ Read-Only:
 - `note` (String)
 - `value` (String)
 
-<a id="#nestedatt--options_allowlist"></a>
-### Nested Schema for `options_allowlist`
-
-Read-Only:
-
-- `paths` (List of Object) The allowed paths for the OPTIONS Allowlist. Incoming requests will bypass Deployment Protection if they have the method `OPTIONS` and **start with** one of the path values. (see [below for nested schema](#nestedatt--options_allowlist--paths))
-
-<a id="nestedatt--options_allowlist--paths"></a>
-### Nested Schema for `options_allowlist.paths`
-
-Read-Only:
-
-- `value` (String) The prefix for allowed paths
 
 
 <a id="nestedatt--vercel_authentication"></a>

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -82,7 +82,7 @@ resource "vercel_project" "example" {
 - `team_id` (String) The team ID to add the project to. Required when configuring a team resource if a default team has not been set in the provider.
 - `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
 - `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team. (see [below for nested schema](#nestedatt--vercel_authentication))
-- `options_allowlist` (Attributes) Configuration for the OPTIONS Allowlist. (see [below for nested schema](#nestedatt--options_allowlist))
+- `options_allowlist` (Attributes) Disable Deployment Protection for CORS preflight `OPTIONS` requests for a list of paths. (see [below for nested schema](#nestedatt--options_allowlist))
 
 ### Read-Only
 
@@ -182,14 +182,14 @@ Optional:
 
 Required:
 
-- `paths` (Attributes Set) The allowed paths for the OPTIONS Allowlist. (see [below for nested schema](#nestedatt--options_allowlist--paths))
+- `paths` (Attributes Set) The allowed paths for the OPTIONS Allowlist. Incoming requests will bypass Deployment Protection if they have the method `OPTIONS` and **start with** one of the path values. (see [below for nested schema](#nestedatt--options_allowlist--paths))
 
 <a id="nestedatt--options_allowlist--paths"></a>
 ### Nested Schema for `options_allowlist.paths`
 
 Required:
 
-- `value` (String) The path that can be accessed.
+- `value` (String) The prefix for allowed paths
 
 <a id="nestedatt--vercel_authentication"></a>
 ### Nested Schema for `vercel_authentication`

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -82,6 +82,7 @@ resource "vercel_project" "example" {
 - `team_id` (String) The team ID to add the project to. Required when configuring a team resource if a default team has not been set in the provider.
 - `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
 - `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team. (see [below for nested schema](#nestedatt--vercel_authentication))
+- `options_allowlist` (Attributes) Configuration for the OPTIONS Allowlist. (see [below for nested schema](#nestedatt--options_allowlist))
 
 ### Read-Only
 
@@ -176,7 +177,19 @@ Optional:
 
 - `note` (String) A description for the value
 
+<a id="nestedatt--options_allowlist"></a>
+### Nested Schema for `options_allowlist`
 
+Required:
+
+- `paths` (Attributes Set) The allowed paths for the OPTIONS Allowlist. (see [below for nested schema](#nestedatt--options_allowlist--paths))
+
+<a id="nestedatt--options_allowlist--paths"></a>
+### Nested Schema for `options_allowlist.paths`
+
+Required:
+
+- `value` (String) The path that can be accessed.
 
 <a id="nestedatt--vercel_authentication"></a>
 ### Nested Schema for `vercel_authentication`

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -70,6 +70,7 @@ resource "vercel_project" "example" {
 - `git_repository` (Attributes) The Git Repository that will be connected to the project. When this is defined, any pushes to the specified connected Git Repository will be automatically deployed. This requires the corresponding Vercel for [Github](https://vercel.com/docs/concepts/git/vercel-for-github), [Gitlab](https://vercel.com/docs/concepts/git/vercel-for-gitlab) or [Bitbucket](https://vercel.com/docs/concepts/git/vercel-for-bitbucket) plugins to be installed. (see [below for nested schema](#nestedatt--git_repository))
 - `ignore_command` (String) When a commit is pushed to the Git repository that is connected with your Project, its SHA will determine if a new Build has to be issued. If the SHA was deployed before, no new Build will be issued. You can customize this behavior with a command that exits with code 1 (new Build needed) or code 0.
 - `install_command` (String) The install command for this project. If omitted, this value will be automatically detected.
+- `options_allowlist` (Attributes) Disable Deployment Protection for CORS preflight `OPTIONS` requests for a list of paths. (see [below for nested schema](#nestedatt--options_allowlist))
 - `output_directory` (String) The output directory of the project. If omitted, this value will be automatically detected.
 - `password_protection` (Attributes) Ensures visitors of your Preview Deployments must enter a password in order to gain access. (see [below for nested schema](#nestedatt--password_protection))
 - `preview_comments` (Boolean) Whether to enable comments on your Preview Deployments. If omitted, comments are controlled at the team level (default behaviour).
@@ -82,7 +83,6 @@ resource "vercel_project" "example" {
 - `team_id` (String) The team ID to add the project to. Required when configuring a team resource if a default team has not been set in the provider.
 - `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
 - `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team. (see [below for nested schema](#nestedatt--vercel_authentication))
-- `options_allowlist` (Attributes) Disable Deployment Protection for CORS preflight `OPTIONS` requests for a list of paths. (see [below for nested schema](#nestedatt--options_allowlist))
 
 ### Read-Only
 
@@ -145,6 +145,22 @@ Read-Only:
 
 
 
+<a id="nestedatt--options_allowlist"></a>
+### Nested Schema for `options_allowlist`
+
+Required:
+
+- `paths` (Attributes Set) The allowed paths for the OPTIONS Allowlist. Incoming requests will bypass Deployment Protection if they have the method `OPTIONS` and **start with** one of the path values. (see [below for nested schema](#nestedatt--options_allowlist--paths))
+
+<a id="nestedatt--options_allowlist--paths"></a>
+### Nested Schema for `options_allowlist.paths`
+
+Required:
+
+- `value` (String) The path prefix to compare with the incoming request path.
+
+
+
 <a id="nestedatt--password_protection"></a>
 ### Nested Schema for `password_protection`
 
@@ -177,19 +193,7 @@ Optional:
 
 - `note` (String) A description for the value
 
-<a id="nestedatt--options_allowlist"></a>
-### Nested Schema for `options_allowlist`
 
-Required:
-
-- `paths` (Attributes Set) The allowed paths for the OPTIONS Allowlist. Incoming requests will bypass Deployment Protection if they have the method `OPTIONS` and **start with** one of the path values. (see [below for nested schema](#nestedatt--options_allowlist--paths))
-
-<a id="nestedatt--options_allowlist--paths"></a>
-### Nested Schema for `options_allowlist.paths`
-
-Required:
-
-- `value` (String) The prefix for allowed paths
 
 <a id="nestedatt--vercel_authentication"></a>
 ### Nested Schema for `vercel_authentication`

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -220,6 +220,21 @@ For more detailed information, please see the [Vercel documentation](https://ver
 					},
 				},
 			},
+			"options_allowlist": schema.SingleNestedAttribute{
+				Description: "Ensures only requests starting with specified paths can bypass Deployment Protection for OPTIONS requests.",
+				Computed:    true,
+				Attributes: map[string]schema.Attribute{
+					"paths": schema.ListAttribute{
+						Description: "The path to compare the request path against.",
+						Computed:    true,
+						ElementType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"value": types.StringType,
+							},
+						},
+					},
+				},
+			},
 			"id": schema.StringAttribute{
 				Computed: true,
 			},
@@ -320,6 +335,7 @@ type ProjectDataSource struct {
 	VercelAuthentication          *VercelAuthentication `tfsdk:"vercel_authentication"`
 	PasswordProtection            *PasswordProtection   `tfsdk:"password_protection"`
 	TrustedIps                    *TrustedIps           `tfsdk:"trusted_ips"`
+	OptionsAllowlist              *OptionsAllowlist     `tfsdk:"options_allowlist"`
 	ProtectionBypassForAutomation types.Bool            `tfsdk:"protection_bypass_for_automation"`
 	AutoExposeSystemEnvVars       types.Bool            `tfsdk:"automatically_expose_system_environment_variables"`
 	GitComments                   types.Object          `tfsdk:"git_comments"`
@@ -375,6 +391,7 @@ func convertResponseToProjectDataSource(ctx context.Context, response client.Pro
 		VercelAuthentication:          project.VercelAuthentication,
 		PasswordProtection:            pp,
 		TrustedIps:                    project.TrustedIps,
+		OptionsAllowlist:              project.OptionsAllowlist,
 		AutoExposeSystemEnvVars:       types.BoolPointerValue(response.AutoExposeSystemEnvVars),
 		ProtectionBypassForAutomation: project.ProtectionBypassForAutomation,
 		GitComments:                   project.GitComments,

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -221,11 +221,11 @@ For more detailed information, please see the [Vercel documentation](https://ver
 				},
 			},
 			"options_allowlist": schema.SingleNestedAttribute{
-				Description: "Ensures only requests starting with specified paths can bypass Deployment Protection for OPTIONS requests.",
+				Description: "Disable Deployment Protection for CORS preflight `OPTIONS` requests for a list of paths.",
 				Computed:    true,
 				Attributes: map[string]schema.Attribute{
 					"paths": schema.ListAttribute{
-						Description: "The path to compare the request path against.",
+						Description: "The allowed paths for the OPTIONS Allowlist. Incoming requests will bypass Deployment Protection if they have the method `OPTIONS` and **start with** one of the path values.",
 						Computed:    true,
 						ElementType: types.ObjectType{
 							AttrTypes: map[string]attr.Type{

--- a/vercel/data_source_project_test.go
+++ b/vercel/data_source_project_test.go
@@ -35,6 +35,8 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 					}),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "trusted_ips.deployment_type", "only_production_deployments"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "trusted_ips.protection_mode", "trusted_ip_required"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "options_allowlist.paths.#", "1"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "options_allowlist.paths.0.value", "/api"),
 
 					resource.TestCheckTypeSetElemNestedAttrs("data.vercel_project.test", "environment.*", map[string]string{
 						"key":   "foo",
@@ -85,6 +87,13 @@ resource "vercel_project" "test" {
 	]
 	deployment_type = "only_production_deployments"
 	protection_mode = "trusted_ip_required"
+  }
+  options_allowlist = {
+    paths = [
+      {
+        value = "/api"
+      }
+    ]
   }
   %s
   environment = [

--- a/vercel/deployment_protection.go
+++ b/vercel/deployment_protection.go
@@ -28,3 +28,11 @@ type TrustedIps struct {
 type ProtectionBypass struct {
 	Scope types.String `tfsdk:"scope"`
 }
+
+type OptionsAllowlist struct {
+	Paths []OptionsAllowlistPath `tfsdk:"paths"`
+}
+
+type OptionsAllowlistPath struct {
+	Value types.String `tfsdk:"value"`
+}

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -301,17 +301,17 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				},
 			},
 			"options_allowlist": schema.SingleNestedAttribute{
-				Description: "Ensures only requests starting with specified paths can bypass Deployment Protection for OPTIONS requests.",
+				Description: "Disable Deployment Protection for CORS preflight `OPTIONS` requests for a list of paths.",
 				Optional:    true,
 				Attributes: map[string]schema.Attribute{
 					"paths": schema.SetNestedAttribute{
-						Description:   "The paths that can be accessed bypassing Deployment Protection for OPTIONS requests.",
+						Description:   "The allowed paths for the OPTIONS Allowlist. Incoming requests will bypass Deployment Protection if they have the method `OPTIONS` and **start with** one of the path values.",
 						Required:      true,
 						PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"value": schema.StringAttribute{
-									Description: "The path to compare the request path against.",
+									Description: "The path prefix to compare with the incoming request path.",
 									Required:    true,
 								},
 							},

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -300,6 +300,28 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 					},
 				},
 			},
+			"options_allowlist": schema.SingleNestedAttribute{
+				Description: "Ensures only requests starting with specified paths can bypass Deployment Protection for OPTIONS requests.",
+				Optional:    true,
+				Attributes: map[string]schema.Attribute{
+					"paths": schema.SetNestedAttribute{
+						Description:   "The paths that can be accessed bypassing Deployment Protection for OPTIONS requests.",
+						Required:      true,
+						PlanModifiers: []planmodifier.Set{setplanmodifier.UseStateForUnknown()},
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"value": schema.StringAttribute{
+									Description: "The path to compare the request path against.",
+									Required:    true,
+								},
+							},
+						},
+						Validators: []validator.Set{
+							stringSetMinCount(1),
+						},
+					},
+				},
+			},
 			"id": schema.StringAttribute{
 				Computed:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
@@ -425,6 +447,7 @@ type Project struct {
 	VercelAuthentication                *VercelAuthentication           `tfsdk:"vercel_authentication"`
 	PasswordProtection                  *PasswordProtectionWithPassword `tfsdk:"password_protection"`
 	TrustedIps                          *TrustedIps                     `tfsdk:"trusted_ips"`
+	OptionsAllowlist                    *OptionsAllowlist               `tfsdk:"options_allowlist"`
 	ProtectionBypassForAutomation       types.Bool                      `tfsdk:"protection_bypass_for_automation"`
 	ProtectionBypassForAutomationSecret types.String                    `tfsdk:"protection_bypass_for_automation_secret"`
 	AutoExposeSystemEnvVars             types.Bool                      `tfsdk:"automatically_expose_system_environment_variables"`
@@ -459,6 +482,7 @@ func (p Project) RequiresUpdateAfterCreation() bool {
 	return p.PasswordProtection != nil ||
 		p.VercelAuthentication != nil ||
 		p.TrustedIps != nil ||
+		p.OptionsAllowlist != nil ||
 		!p.AutoExposeSystemEnvVars.IsNull() ||
 		p.GitComments.IsNull() ||
 		!p.PreviewComments.IsNull() ||
@@ -581,6 +605,7 @@ func (p *Project) toUpdateProjectRequest(ctx context.Context, oldName string) (r
 		PasswordProtection:                   p.PasswordProtection.toUpdateProjectRequest(),
 		VercelAuthentication:                 p.VercelAuthentication.toUpdateProjectRequest(),
 		TrustedIps:                           p.TrustedIps.toUpdateProjectRequest(),
+		OptionsAllowlist:                     p.OptionsAllowlist.toUpdateProjectRequest(),
 		AutoExposeSystemEnvVars:              p.AutoExposeSystemEnvVars.ValueBool(),
 		EnablePreviewFeedback:                p.PreviewComments.ValueBoolPointer(),
 		AutoAssignCustomDomains:              p.AutoAssignCustomDomains.ValueBool(),
@@ -755,6 +780,23 @@ func (t *TrustedIps) toUpdateProjectRequest() *client.TrustedIps {
 		Addresses:      addresses,
 		DeploymentType: toApiDeploymentProtectionType(t.DeploymentType),
 		ProtectionMode: toApiTrustedIpProtectionMode(t.ProtectionMode),
+	}
+}
+
+func (t *OptionsAllowlist) toUpdateProjectRequest() *client.OptionsAllowlist {
+	if t == nil {
+		return nil
+	}
+
+	var paths = []client.OptionsAllowlistPath{}
+	for _, path := range t.Paths {
+		paths = append(paths, client.OptionsAllowlistPath{
+			Value: path.Value.ValueString(),
+		})
+	}
+
+	return &client.OptionsAllowlist{
+		Paths: paths,
 	}
 }
 
@@ -937,6 +979,19 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 		}
 	}
 
+	var oal *OptionsAllowlist
+	if response.OptionsAllowlist != nil {
+		var paths []OptionsAllowlistPath
+		for _, path := range response.OptionsAllowlist.Paths {
+			paths = append(paths, OptionsAllowlistPath{
+				Value: types.StringValue(path.Value),
+			})
+		}
+		oal = &OptionsAllowlist{
+			Paths: paths,
+		}
+	}
+
 	var env []attr.Value
 	for _, e := range environmentVariables {
 		target := []attr.Value{}
@@ -1029,6 +1084,7 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 		PasswordProtection:                  pp,
 		VercelAuthentication:                va,
 		TrustedIps:                          tip,
+		OptionsAllowlist:                    oal,
 		ProtectionBypassForAutomation:       protectionBypass,
 		ProtectionBypassForAutomationSecret: protectionBypassSecret,
 		AutoExposeSystemEnvVars:             types.BoolPointerValue(response.AutoExposeSystemEnvVars),


### PR DESCRIPTION
Add Terraform support for the new **OPTIONS Allowlist** feature

👉 [docs](https://vercel.com/docs/security/deployment-protection/methods-to-bypass-deployment-protection/options-allowlist)
👉 [changelog](https://vercel.com/changelog/options-allowlist)

