### PR TITLE
docs: update `ref` description in `resource_deployment` to fix reference to `files`

### DIFF
--- a/vercel/resource_deployment.go
+++ b/vercel/resource_deployment.go
@@ -132,7 +132,7 @@ terraform to your Deployment.
 				},
 			},
 			"ref": schema.StringAttribute{
-				Description:   "The branch or commit hash that should be deployed. Note this will only work if the project is configured to use a Git repository. Required if `ref` is not set.",
+				Description:   "The branch or commit hash that should be deployed. Note this will only work if the project is configured to use a Git repository. Required if `files` is not set.",
 				Optional:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},


### PR DESCRIPTION
the `ref` description incorrectly says that `ref` is required if `ref` is not specified, when really I believe it means `files`.