### PR TITLE
[firewall-config] fix typo in docs

### DIFF
--- a/docs/resources/firewall_config.md
+++ b/docs/resources/firewall_config.md
@@ -105,7 +105,7 @@ resource "vercel_firewall_config" "example" {
           algo = "fixed_window"
           action = "deny"
         }
-        actionDuration = "5m"
+        action_duration = "5m"
       }
     }
   }

--- a/examples/resources/vercel_firewall_config/resource.tf
+++ b/examples/resources/vercel_firewall_config/resource.tf
@@ -90,7 +90,7 @@ resource "vercel_firewall_config" "example" {
           algo = "fixed_window"
           action = "deny"
         }
-        actionDuration = "5m"
+        action_duration = "5m"
       }
     }
   }

--- a/vercel/resource_firewall_config.go
+++ b/vercel/resource_firewall_config.go
@@ -511,8 +511,8 @@ func (r *FirewallRule) Mitigate() (client.Mitigate, error) {
 	if !r.Action.Redirect.IsNull() {
 		rd := &client.Redirect{}
 		diags := r.Action.Redirect.As(context.Background(), rd, basetypes.ObjectAsOptions{
-			UnhandledNullAsEmpty:    true,
-			UnhandledUnknownAsEmpty: true,
+			UnhandledNullAsEmpty:    false,
+			UnhandledUnknownAsEmpty: false,
 		})
 		if diags.HasError() {
 			return mit, fmt.Errorf("error converting rate limit: %s - %s", diags[0].Summary(), diags[0].Detail())


### PR DESCRIPTION
typo in docs uses camelcase instead of snakecase for `action_duration`
