### PR TITLE
Add `oidc_token_config.issuer_mode` property to projects

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -16,7 +16,8 @@ type GitRepository struct {
 }
 
 type OIDCTokenConfig struct {
-	Enabled bool `json:"enabled"`
+	Enabled    bool   `json:"enabled"`
+	IssuerMode string `json:"issuerMode,omitempty"`
 }
 
 // EnvironmentVariable defines the information Vercel requires and surfaces about an environment variable

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -123,7 +123,7 @@ Read-Only:
 
 Optional:
 
-- `issuer_mode` (String) Configures the URL of the `iss` claim. `team` = `https://oidc.vercel.com/[team_slug]` `owner` = `https://oidc.vercel.com`
+- `issuer_mode` (String) Configures the URL of the `iss` claim. `team` = `https://oidc.vercel.com/[team_slug]` `global` = `https://oidc.vercel.com`
 
 Read-Only:
 

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -120,6 +120,10 @@ Read-Only:
 <a id="nestedatt--oidc_token_config"></a>
 ### Nested Schema for `oidc_token_config`
 
+Optional:
+
+- `issuer_mode` (String) Configures the URL of the `iss` claim. `team` = `https://oidc.vercel.com/[team_slug]` `owner` = `https://oidc.vercel.com`
+
 Read-Only:
 
 - `enabled` (Boolean) When true, Vercel issued OpenID Connect (OIDC) tokens will be available on the compute environments. See https://vercel.com/docs/security/secure-backend-access/oidc for more information.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -154,6 +154,10 @@ Required:
 
 - `enabled` (Boolean) When true, Vercel issued OpenID Connect (OIDC) tokens will be available on the compute environments. See https://vercel.com/docs/security/secure-backend-access/oidc for more information.
 
+Optional:
+
+- `issuer_mode` (String) Configures the URL of the `iss` claim. `team` = `https://oidc.vercel.com/[team_slug]` `owner` = `https://oidc.vercel.com`
+
 
 <a id="nestedatt--options_allowlist"></a>
 ### Nested Schema for `options_allowlist`

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -157,7 +157,7 @@ Required:
 
 Optional:
 
-- `issuer_mode` (String) Configures the URL of the `iss` claim. `team` = `https://oidc.vercel.com/[team_slug]` `owner` = `https://oidc.vercel.com`
+- `issuer_mode` (String) Configures the URL of the `iss` claim. `team` = `https://oidc.vercel.com/[team_slug]` `global` = `https://oidc.vercel.com`
 
 
 <a id="nestedatt--options_allowlist"></a>

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -233,7 +233,7 @@ For more detailed information, please see the [Vercel documentation](https://ver
 						Computed:    true,
 					},
 					"issuer_mode": schema.StringAttribute{
-						Description: "Configures the URL of the `iss` claim. `team` = `https://oidc.vercel.com/[team_slug]` `owner` = `https://oidc.vercel.com`",
+						Description: "Configures the URL of the `iss` claim. `team` = `https://oidc.vercel.com/[team_slug]` `global` = `https://oidc.vercel.com`",
 						Computed:    true,
 						Optional:    true,
 						Validators: []validator.String{

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -228,6 +228,14 @@ For more detailed information, please see the [Vercel documentation](https://ver
 						Description: "When true, Vercel issued OpenID Connect (OIDC) tokens will be available on the compute environments. See https://vercel.com/docs/security/secure-backend-access/oidc for more information.",
 						Computed:    true,
 					},
+					"issuer_mode": schema.StringAttribute{
+						Description: "Configures the URL of the `iss` claim. `team` = `https://oidc.vercel.com/[team_slug]` `owner` = `https://oidc.vercel.com`",
+						Computed:    true,
+						Optional:    true,
+						Validators: []validator.String{
+							stringOneOf("team", "global"),
+						},
+					},
 				},
 			},
 			"options_allowlist": schema.SingleNestedAttribute{

--- a/vercel/data_source_project_test.go
+++ b/vercel/data_source_project_test.go
@@ -55,6 +55,8 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vercel_project.test", "skew_protection", "7 days"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "resource_config.function_default_cpu_type", "standard_legacy"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "resource_config.function_default_timeout", "30"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "oidc_token_config.enabled", "true"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "oidc_token_config.issuer_mode", "team"),
 				),
 			},
 		},
@@ -129,7 +131,11 @@ resource "vercel_project" "test" {
   }
   resource_config = {
     function_default_cpu_type = "standard_legacy"
-	function_default_timeout = 30
+    function_default_timeout = 30
+  }
+  oidc_token_config = {
+    enabled = true
+    issuer_mode = "team"
   }
 }
 

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -322,7 +322,7 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 						Optional:      true,
 						Computed:      true,
 						Default:       stringdefault.StaticString("team"),
-						Description:   "Configures the URL of the `iss` claim. `team` = `https://oidc.vercel.com/[team_slug]` `owner` = `https://oidc.vercel.com`",
+						Description:   "Configures the URL of the `iss` claim. `team` = `https://oidc.vercel.com/[team_slug]` `global` = `https://oidc.vercel.com`",
 						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 						Validators: []validator.String{
 							stringOneOf("team", "global"),
@@ -336,7 +336,7 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 					},
 					map[string]attr.Value{
 						"enabled":     types.BoolValue(false),
-						"issuer_mode": types.StringValue("team"),
+						"issuer_mode": types.StringValue("global"),
 					},
 				)),
 			},
@@ -920,7 +920,7 @@ func (o *OIDCTokenConfig) toUpdateProjectRequest() *client.OIDCTokenConfig {
 	if o == nil {
 		return &client.OIDCTokenConfig{
 			Enabled:    types.BoolValue(false).ValueBool(),
-			IssuerMode: types.StringValue("team").ValueString(),
+			IssuerMode: types.StringValue("global").ValueString(),
 		}
 	}
 
@@ -1153,7 +1153,7 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 
 	var oidcTokenConfig = &OIDCTokenConfig{
 		Enabled:    types.BoolValue(false),
-		IssuerMode: types.StringValue("team"),
+		IssuerMode: types.StringValue("global"),
 	}
 	if response.OIDCTokenConfig != nil {
 		oidcTokenConfig.Enabled = types.BoolValue(response.OIDCTokenConfig.Enabled)

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -310,13 +310,25 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 						Description: "When true, Vercel issued OpenID Connect (OIDC) tokens will be available on the compute environments. See https://vercel.com/docs/security/secure-backend-access/oidc for more information.",
 						Required:    true,
 					},
+					"issuer_mode": schema.StringAttribute{
+						Optional:      true,
+						Computed:      true,
+						Default:       stringdefault.StaticString("team"),
+						Description:   "Configures the URL of the `iss` claim. `team` = `https://oidc.vercel.com/[team_slug]` `owner` = `https://oidc.vercel.com`",
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+						Validators: []validator.String{
+							stringOneOf("team", "global"),
+						},
+					},
 				},
 				Default: objectdefault.StaticValue(types.ObjectValueMust(
 					map[string]attr.Type{
-						"enabled": types.BoolType,
+						"enabled":     types.BoolType,
+						"issuer_mode": types.StringType,
 					},
 					map[string]attr.Value{
-						"enabled": types.BoolValue(false),
+						"enabled":     types.BoolValue(false),
+						"issuer_mode": types.StringValue("team"),
 					},
 				)),
 			},
@@ -878,7 +890,8 @@ func (t *TrustedIps) toUpdateProjectRequest() *client.TrustedIps {
 }
 
 type OIDCTokenConfig struct {
-	Enabled types.Bool `tfsdk:"enabled"`
+	Enabled    types.Bool   `tfsdk:"enabled"`
+	IssuerMode types.String `tfsdk:"issuer_mode"`
 }
 
 func (o *OIDCTokenConfig) toCreateProjectRequest() *client.OIDCTokenConfig {
@@ -887,19 +900,22 @@ func (o *OIDCTokenConfig) toCreateProjectRequest() *client.OIDCTokenConfig {
 	}
 
 	return &client.OIDCTokenConfig{
-		Enabled: o.Enabled.ValueBool(),
+		Enabled:    o.Enabled.ValueBool(),
+		IssuerMode: o.IssuerMode.ValueString(),
 	}
 }
 
 func (o *OIDCTokenConfig) toUpdateProjectRequest() *client.OIDCTokenConfig {
 	if o == nil {
 		return &client.OIDCTokenConfig{
-			Enabled: types.BoolValue(false).ValueBool(),
+			Enabled:    types.BoolValue(false).ValueBool(),
+			IssuerMode: types.StringValue("team").ValueString(),
 		}
 	}
 
 	return &client.OIDCTokenConfig{
-		Enabled: o.Enabled.ValueBool(),
+		Enabled:    o.Enabled.ValueBool(),
+		IssuerMode: o.IssuerMode.ValueString(),
 	}
 }
 
@@ -1124,10 +1140,12 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 	}
 
 	var oidcTokenConfig = &OIDCTokenConfig{
-		Enabled: types.BoolValue(false),
+		Enabled:    types.BoolValue(false),
+		IssuerMode: types.StringValue("team"),
 	}
 	if response.OIDCTokenConfig != nil {
 		oidcTokenConfig.Enabled = types.BoolValue(response.OIDCTokenConfig.Enabled)
+		oidcTokenConfig.IssuerMode = types.StringValue(response.OIDCTokenConfig.IssuerMode)
 	}
 
 	resourceConfig := &ResourceConfig{}

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -81,6 +81,7 @@ func TestAcc_Project(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_project.test", "directory_listing", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "skew_protection", "7 days"),
 					resource.TestCheckResourceAttr("vercel_project.test", "oidc_token_config.enabled", "true"),
+					resource.TestCheckResourceAttr("vercel_project.test", "oidc_token_config.issuer_mode", "team"),
 				),
 			},
 			// Update testing
@@ -747,6 +748,7 @@ resource "vercel_project" "test" {
   skew_protection = "7 days"
   oidc_token_config = {
     enabled = true
+    issuer_mode = "team"
   }
   environment = [
     {


### PR DESCRIPTION
Project's `oidcTokenConfig` now supports `issuerMode`. See https://vercel.com/docs/security/secure-backend-access/oidc#issuer-mode for more information on the property.