### PR TITLE
feat: upgrade api versions to v10

### DIFF
--- a/client/environment_variable.go
+++ b/client/environment_variable.go
@@ -62,6 +62,8 @@ func (c *Client) CreateEnvironmentVariable(ctx context.Context, request CreateEn
 	if err != nil {
 		return e, fmt.Errorf("%w - %s", err, payload)
 	}
+	response.Created.Value = request.EnvironmentVariable.Value
+	response.Created.TeamID = c.teamID(request.TeamID)
 	return response.Created, err
 }
 

--- a/client/error.go
+++ b/client/error.go
@@ -25,13 +25,14 @@ type EnvConflictError struct {
 	Code      string   `json:"code"`
 	Message   string   `json:"message"`
 	Key       string   `json:"key"`
+	EnvVarKey string   `json:"envVarKey"`
 	Target    []string `json:"target"`
 	GitBranch *string  `json:"gitBranch"`
 }
 
 func conflictingEnvVar(e error) (envConflictError EnvConflictError, ok bool, err error) {
 	var apiErr APIError
-	conflict := e != nil && errors.As(e, &apiErr) && apiErr.StatusCode == 403 && apiErr.Code == "ENV_ALREADY_EXISTS"
+	conflict := e != nil && errors.As(e, &apiErr) && apiErr.StatusCode == 400 && apiErr.Code == "ENV_CONFLICT"
 	if !conflict {
 		return envConflictError, false, err
 	}

--- a/vercel/resource_project_environment_variable.go
+++ b/vercel/resource_project_environment_variable.go
@@ -82,7 +82,6 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				ElementType: types.StringType,
 				Validators: []validator.Set{
 					setvalidator.ValueStringsAre(stringvalidator.OneOf("production", "preview", "development")),
-					setvalidator.SizeAtLeast(1),
 					setvalidator.AtLeastOneOf(
 						path.MatchRoot("custom_environment_ids"),
 						path.MatchRoot("target"),


### PR DESCRIPTION
This PR fixes https://github.com/vercel/terraform-provider-vercel/issues/255

### What was done:

1. Upgraded API versions used by Provider to v10 (which is latest [according to Vercel API Documentation](https://vercel.com/docs/rest-api/endpoints/projects#create-one-or-more-environment-variables))
2. Added `CreateEnvironmentVariableResponse`, since new format of response is returned in v10
3. Removed validation of `target` parameter to be empty. in `project_environment_variable` resource
The requests from **Vercel Web UI** (_Network_ tab) and **Terraform Provider** were different and API reacted differently.
The examples of the requests body

**Vercel Web UI**
```
{
  "key": "NEXT_PUBLIC_MY_KEY",
  "value": "",
  "target": [],
  "customEnvironmentIds": [
    "env_********************"
  ],
  "type": "sensitive",
  "comment": "Sensitive test environment variable"
}
```

**Terraform Provider**
```
{
  "key": "NEXT_PUBLIC_MY_KEY",
  "value": "**********",
  "customEnvironmentIds": [
    "env_********************"
  ],
  "type": "sensitive",
  "comment": "Sensitive test environment variable"
}
```

It means now **you have to add `target = []`** if you want to add environment variable only to `custom_environment_ids`


Unfortunately, I wasn't able to perform the full test on my own.
My changes might not be perfect, so I welcome your comments and contributions
