### PR TITLE
Expose elastic_concurrent_builds on resource config

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -217,6 +217,7 @@ type Security struct {
 type ResourceConfig struct {
 	FunctionDefaultMemoryType string `json:"functionDefaultMemoryType,omitempty"`
 	FunctionDefaultTimeout    int64  `json:"functionDefaultTimeout,omitempty"`
+	ElasticConcurrencyEnabled bool   `json:"elasticConcurrencyEnabled,omitempty"`
 }
 
 // GetProject retrieves information about an existing project from Vercel.

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -365,6 +365,10 @@ For more detailed information, please see the [Vercel documentation](https://ver
 						Description: "The default timeout for Serverless Functions.",
 						Computed:    true,
 					},
+					"elastic_concurrency_enabled": schema.BoolAttribute{
+						Description: "Whether to enable elastic builds on the project.",
+						Computed:    true,
+					},
 				},
 			},
 		},

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -525,6 +525,12 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 						},
 						PlanModifiers: []planmodifier.Int64{SuppressDiffIfNotConfigured(), int64planmodifier.UseStateForUnknown()},
 					},
+					"elastic_concurrency_enabled": schema.BoolAttribute{
+						Description:   "Whether to enable elastic builds on the project.",
+						Optional:      true,
+						Computed:      true,
+						PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+					},
 				},
 				Default: objectdefault.StaticValue(types.ObjectValueMust(
 					map[string]attr.Type{
@@ -605,6 +611,7 @@ type Project struct {
 	PrioritiseProductionBuilds          types.Bool                      `tfsdk:"prioritise_production_builds"`
 	DirectoryListing                    types.Bool                      `tfsdk:"directory_listing"`
 	SkewProtection                      types.String                    `tfsdk:"skew_protection"`
+	ElasticConcurrency                  types.Bool                      `tfsdk:"elastic_concurrency"`
 	ResourceConfig                      *ResourceConfig                 `tfsdk:"resource_config"`
 }
 
@@ -992,6 +999,7 @@ func (o *OIDCTokenConfig) toUpdateProjectRequest() *client.OIDCTokenConfig {
 type ResourceConfig struct {
 	FunctionDefaultMemoryType types.String `tfsdk:"function_default_cpu_type"`
 	FunctionDefaultTimeout    types.Int64  `tfsdk:"function_default_timeout"`
+	ElasticConcurrencyEnabled types.Bool   `tfsdk:"elastic_concurrency_enabled"`
 }
 
 func (r *ResourceConfig) toUpdateProjectRequest() *client.ResourceConfig {
@@ -1005,6 +1013,9 @@ func (r *ResourceConfig) toUpdateProjectRequest() *client.ResourceConfig {
 	}
 	if !r.FunctionDefaultTimeout.IsNull() {
 		resourceConfig.FunctionDefaultTimeout = r.FunctionDefaultTimeout.ValueInt64()
+	}
+	if !r.ElasticConcurrencyEnabled.IsNull() {
+		resourceConfig.ElasticConcurrencyEnabled = r.ElasticConcurrencyEnabled.ValueBool()
 	}
 	return resourceConfig
 }


### PR DESCRIPTION
Enable the new elastic concurrency property on project settings through the terraform provider.