### PR TITLE
add missing_files test when creating deployments

### DIFF
--- a/vercel/resource_deployment_test.go
+++ b/vercel/resource_deployment_test.go
@@ -286,7 +286,7 @@ func TestAcc_DeploymentWithLargeFile(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() { createRandomFilePreConfig(t) },
-				Config: testAccWithLargeFile(projectSuffix, teamIDConfig()),
+				Config: testAccWithDirectoryUpload(projectSuffix, teamIDConfig()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccDeploymentExists("vercel_deployment.test", ""),
 				),
@@ -448,7 +448,7 @@ resource "vercel_deployment" "bitbucket" {
 `, projectSuffix, testGithubRepo(), testBitbucketRepo(), teamID)
 }
 
-func testAccWithLargeFile(projectSuffix, teamID string) string {
+func testAccWithDirectoryUpload(projectSuffix, teamID string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "test-acc-deployment-%[1]s"

--- a/vercel/resource_deployment_test.go
+++ b/vercel/resource_deployment_test.go
@@ -261,7 +261,7 @@ func TestAcc_DeploymentWithMissingFilesPath(t *testing.T) {
 	createRandomFilePreConfig := func(t *testing.T) {
 		min := 1
 		max := 1_000_000
-		randomInt := rand.Intn(max - min) + min
+		randomInt := rand.Intn(max-min) + min
 
 		fileBody := []byte(fmt.Sprintf("<html>\n<body>\nRandom integer: %d\n</body>\n</html>\n", randomInt))
 		err := os.WriteFile(tmpFilePath, fileBody, 0644)
@@ -285,7 +285,7 @@ func TestAcc_DeploymentWithMissingFilesPath(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() { createRandomFilePreConfig(t) },
-				Config: testAccWithDirectoryUpload(projectSuffix, teamIDConfig()),
+				Config:    testAccWithDirectoryUpload(projectSuffix, teamIDConfig()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccDeploymentExists("vercel_deployment.test", ""),
 				),

--- a/vercel/resource_deployment_test.go
+++ b/vercel/resource_deployment_test.go
@@ -264,7 +264,6 @@ func TestAcc_DeploymentWithMissingFilesPath(t *testing.T) {
 		randomInt := rand.Intn(max - min) + min
 
 		fileBody := []byte(fmt.Sprintf("<html>\n<body>\nRandom integer: %d\n</body>\n</html>\n", randomInt))
-
 		err := os.WriteFile(tmpFilePath, fileBody, 0644)
 		if err != nil {
 			t.Fatalf("Could not create the temporal file path %s. Error: %s", tmpFilePath, err)

--- a/vercel/resource_deployment_test.go
+++ b/vercel/resource_deployment_test.go
@@ -255,7 +255,7 @@ func TestAcc_DeploymentWithGitSource(t *testing.T) {
 // To do that, we need to create a new file with random contents to trigger the
 // `missing_files` error. Otherwise, if the contents do not change, we will use
 // the cached deployments files
-func TestAcc_DeploymentWithLargeFile(t *testing.T) {
+func TestAcc_DeploymentWithMissingFilesPath(t *testing.T) {
 	tmpFilePath := "../vercel/examples/one/random-file.html"
 
 	createRandomFilePreConfig := func(t *testing.T) {


### PR DESCRIPTION
Add a new test to the `create-deployment` so that we test when the `missing_files` error triggers and we have to process it.

It was a bit tricky as we need to avoid the cache: we need to create a random file with random contents.