### PR TITLE
Parse teams with saml configs containing access group objects as role values

### DIFF
--- a/client/team.go
+++ b/client/team.go
@@ -24,16 +24,6 @@ type SamlRole struct {
 	AccessGroupID *SamlRoleAccessGroupID
 }
 
-func (f SamlRole) MarshalJSON() ([]byte, error) {
-	if f.Role != nil {
-		return json.Marshal(f.Role)
-	}
-	if f.AccessGroupID != nil {
-		return json.Marshal(f.AccessGroupID)
-	}
-	return nil, fmt.Errorf("config value is neither Role string nor AccessGroupID map")
-}
-
 func (f *SamlRole) UnmarshalJSON(data []byte) error {
 	var role string
 	if err := json.Unmarshal(data, &role); err == nil {

--- a/client/team_test.go
+++ b/client/team_test.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetTeam(t *testing.T) {
+	type TestCase struct {
+		Name         string
+		ResponseJSON string
+	}
+
+	for _, tc := range []TestCase{
+		{
+			Name:         "SAML",
+			ResponseJSON: `{ "saml": { "roles": { "A": "OWNER", "B": { "accessGroupId": "foo" } } } }`},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			h := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				fmt.Fprintln(w, tc.ResponseJSON)
+			}))
+			cl := New("INVALID")
+			cl.baseURL = fmt.Sprintf("http://%s", h.Listener.Addr().String())
+			_, err := cl.GetTeam(context.Background(), "INVALID")
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/client/team_test.go
+++ b/client/team_test.go
@@ -17,7 +17,8 @@ func TestGetTeam(t *testing.T) {
 	for _, tc := range []TestCase{
 		{
 			Name:         "SAML",
-			ResponseJSON: `{ "saml": { "roles": { "A": "OWNER", "B": { "accessGroupId": "foo" } } } }`},
+			ResponseJSON: `{ "saml": { "roles": { "A": "OWNER", "B": { "accessGroupId": "foo" } } } }`,
+		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			h := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
With certain permissions on the Vercel token, a get team request can return JSON that looks like:
```
{
  ...
  "saml": {
    ...
    "roles": {
      "a": { "accessGroupId": "b" }
    }
  },
  ...
```

This fails to parse because we are expecting only JSON of the form:

```
{
  ...
  "saml": {
    ...
    "roles": {
      "a": "ROLE"
    }
  },
  ...
```

This PR parses both forms and only exposes the role based form. Since we use PATCH for updating these states, it should be non-destructive when omitting this information coming from the API.