### PR TITLE
[firewall config resource] off by one error

### DIFF
--- a/vercel/resource_firewall_config.go
+++ b/vercel/resource_firewall_config.go
@@ -808,7 +808,7 @@ func fromClient(conf client.FirewallConfig, state FirewallConfig) (FirewallConfi
 			var stateRule = FirewallRule{
 				Active: types.BoolNull(),
 			}
-			if state.Rules != nil && len(state.Rules.Rules)-1 > i {
+			if state.Rules != nil && len(state.Rules.Rules) > i {
 				stateRule = state.Rules.Rules[i]
 			}
 			rules[i], err = fromFirewallRule(rule, stateRule)

--- a/vercel/resource_firewall_config_test.go
+++ b/vercel/resource_firewall_config_test.go
@@ -242,10 +242,6 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 						"path"),
 					resource.TestCheckResourceAttr(
 						"vercel_firewall_config.custom",
-						"rules.rule.0.condition_group.0.conditions.0.neg",
-						""),
-					resource.TestCheckResourceAttr(
-						"vercel_firewall_config.custom",
 						"rules.rule.0.condition_group.0.conditions.1.value",
 						"POST"),
 					resource.TestCheckResourceAttrWith(

--- a/vercel/resource_firewall_config_test.go
+++ b/vercel/resource_firewall_config_test.go
@@ -242,6 +242,10 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 						"path"),
 					resource.TestCheckResourceAttr(
 						"vercel_firewall_config.custom",
+						"rules.rule.0.condition_group.0.conditions.0.neg",
+						""),
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.custom",
 						"rules.rule.0.condition_group.0.conditions.1.value",
 						"POST"),
 					resource.TestCheckResourceAttrWith(
@@ -294,6 +298,14 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 						"vercel_firewall_config.custom",
 						"rules.rule.2.action.redirect.permanent",
 						"false"),
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.custom_neg",
+						"rules.rule.0.condition_group.0.conditions.0.neg",
+						"true"),
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.custom_neg",
+						"rules.rule.0.condition_group.0.conditions.0.values",
+						"true"),
 					resource.TestCheckResourceAttr(
 						"vercel_firewall_config.ips",
 						"ip_rules.rule.0.action",
@@ -612,5 +624,37 @@ resource "vercel_firewall_config" "ips" {
             hostname = "*"
         }
     }
-}`, name, teamID)
+}
+
+resource "vercel_project" "custom_neg" {
+    name = "test-acc-%[1]s-custom_neg"
+    %[2]s
+}
+
+resource "vercel_firewall_config" "custom_neg" {
+    project_id = vercel_project.custom_neg.id
+    %[2]s
+
+    rules {
+        rule {
+          name =  "test"
+          action = {
+            action = "deny"
+          }
+          condition_group = [{
+            conditions = [{
+                type = "ip_address"
+                op = "inc"
+                neg = true
+                values = [
+                    "1.2.3.4",
+                    "3.4.5.6",
+                    "5.6.7.7",
+                ]
+            }
+          }]
+        }
+    }
+}
+`, name, teamID)
 }

--- a/vercel/resource_firewall_config_test.go
+++ b/vercel/resource_firewall_config_test.go
@@ -651,7 +651,7 @@ resource "vercel_firewall_config" "custom_neg" {
                     "3.4.5.6",
                     "5.6.7.7",
                 ]
-            }
+            }]
           }]
         }
     }

--- a/vercel/resource_firewall_config_test.go
+++ b/vercel/resource_firewall_config_test.go
@@ -299,13 +299,17 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 						"rules.rule.2.action.redirect.permanent",
 						"false"),
 					resource.TestCheckResourceAttr(
-						"vercel_firewall_config.custom_neg",
+						"vercel_firewall_config.neg",
 						"rules.rule.0.condition_group.0.conditions.0.neg",
 						"true"),
 					resource.TestCheckResourceAttr(
-						"vercel_firewall_config.custom_neg",
-						"rules.rule.0.condition_group.0.conditions.0.values",
-						"true"),
+						"vercel_firewall_config.neg",
+						"rules.rule.0.condition_group.0.conditions.0.values.0",
+						"1.2.3.4"),
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.neg",
+						"rules.rule.0.condition_group.0.conditions.0.values.1",
+						"3.4.5.6"),
 					resource.TestCheckResourceAttr(
 						"vercel_firewall_config.ips",
 						"ip_rules.rule.0.action",
@@ -626,13 +630,13 @@ resource "vercel_firewall_config" "ips" {
     }
 }
 
-resource "vercel_project" "custom_neg" {
-    name = "test-acc-%[1]s-custom_neg"
+resource "vercel_project" "neg" {
+    name = "test-acc-%[1]s-neg"
     %[2]s
 }
 
-resource "vercel_firewall_config" "custom_neg" {
-    project_id = vercel_project.custom_neg.id
+resource "vercel_firewall_config" "neg" {
+    project_id = vercel_project.neg.id
     %[2]s
 
     rules {


### PR DESCRIPTION
there is a check against the current tf state to convert go default values into terraform nil values
the check that passes the existing state is incorrect and will never pass the last condition in a condition group to the check, which casts the values to nil
