### PR TITLE
Fix usage of resource config on vercel_project resource.

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -218,8 +218,8 @@ type Security struct {
 }
 
 type ResourceConfig struct {
-	FunctionDefaultMemoryType string `json:"functionDefaultMemoryType,omitempty"`
-	FunctionDefaultTimeout    int64  `json:"functionDefaultTimeout,omitempty"`
+	FunctionDefaultMemoryType *string `json:"functionDefaultMemoryType,omitempty"`
+	FunctionDefaultTimeout    *int64  `json:"functionDefaultTimeout,omitempty"`
 }
 
 // GetProject retrieves information about an existing project from Vercel.

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -414,7 +414,7 @@ type ProjectDataSource struct {
 	DirectoryListing                    types.Bool            `tfsdk:"directory_listing"`
 	EnableAffectedProjectsDeployments   types.Bool            `tfsdk:"enable_affected_projects_deployments"`
 	SkewProtection                      types.String          `tfsdk:"skew_protection"`
-	ResourceConfig                      *ResourceConfig       `tfsdk:"resource_config"`
+	ResourceConfig                      types.Object          `tfsdk:"resource_config"`
 	NodeVersion                         types.String          `tfsdk:"node_version"`
 }
 
@@ -429,13 +429,6 @@ func convertResponseToProjectDataSource(ctx context.Context, response client.Pro
 			"on_pull_request": types.BoolValue(response.GitComments.OnPullRequest),
 			"on_commit":       types.BoolValue(response.GitComments.OnCommit),
 		})
-	}
-
-	if response.ResourceConfig != nil {
-		plan.ResourceConfig = &ResourceConfig{
-			FunctionDefaultMemoryType: types.StringValue(response.ResourceConfig.FunctionDefaultMemoryType),
-			FunctionDefaultTimeout:    types.Int64Value(response.ResourceConfig.FunctionDefaultTimeout),
-		}
 	}
 
 	project, err := convertResponseToProject(ctx, response, plan, environmentVariables)

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -82,6 +82,8 @@ func TestAcc_Project(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_project.test", "skew_protection", "7 days"),
 					resource.TestCheckResourceAttr("vercel_project.test", "oidc_token_config.enabled", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "oidc_token_config.issuer_mode", "team"),
+					resource.TestCheckResourceAttr("vercel_project.test", "resource_config.function_default_cpu_type", "standard"),
+					resource.TestCheckResourceAttr("vercel_project.test", "resource_config.function_default_timeout", "60"),
 				),
 			},
 			// Update testing
@@ -922,6 +924,10 @@ resource "vercel_project" "test" {
   oidc_token_config = {
     enabled = true
     issuer_mode = "team"
+  }
+  resource_config = {
+      function_default_cpu_type = "standard"
+      function_default_timeout = 60
   }
   environment = [
     {


### PR DESCRIPTION
- properly support null or unknown values for this field.
- remove false defaults of `null` for the fields.
- Fix validation allowing `0` or `901` as timeout values.
- Remove a lot of unnecessary code to suppress diffs.
- Allow setting resourceConfig on project creation.
