### PR TITLE
Remove Fluid + standard_legacy CPU validator for vercel_project

### DIFF
--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -30,11 +30,11 @@ import (
 )
 
 var (
-	_ resource.Resource                     = &projectResource{}
-	_ resource.ResourceWithConfigure        = &projectResource{}
-	_ resource.ResourceWithImportState      = &projectResource{}
-	_ resource.ResourceWithModifyPlan       = &projectResource{}
-	_ resource.ResourceWithConfigValidators = &projectResource{}
+	_ resource.Resource                = &projectResource{}
+	_ resource.ResourceWithConfigure   = &projectResource{}
+	_ resource.ResourceWithImportState = &projectResource{}
+	_ resource.ResourceWithModifyPlan  = &projectResource{}
+	// _ resource.ResourceWithConfigValidators = &projectResource{}
 )
 
 func newProjectResource() resource.Resource {
@@ -556,11 +556,13 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 	}
 }
 
+/*
 func (r *projectResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
 		&fluidComputeBasicCPUValidator{},
 	}
 }
+*/
 
 // Project reflects the state terraform stores internally for a project.
 type Project struct {

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -114,16 +114,17 @@ func TestAcc_ProjectFluidCompute(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// check we get a sensible error if fluid + invalid CPU combination.
-				Config: `
+				Config: fmt.Sprintf(`
                 resource "vercel_project" "test" {
-                    name = "foo"
+                    name = "test-acc-fluid-%[1]s"
+                    %[2]s
                     resource_config = {
                         fluid = true
                         function_default_cpu_type = "standard_legacy"
                     }
                 }
-                `,
-				ExpectError: regexp.MustCompile(strings.ReplaceAll("Fluid compute is only supported with the standard or performance CPU types.", " ", `\s*`)),
+                `, projectSuffix, teamIDConfig()),
+				ExpectError: regexp.MustCompile(strings.ReplaceAll("\"standard_legacy\" is not a valid memory type for Fluid compute", " ", `\s*`)),
 			},
 			{
 				// check creating a project with Fluid


### PR DESCRIPTION
This causes issues with unsupported Unknown fields for the project resource.

Disable for now until we can rework the types to properly support this.

Closes #290
