### PR TITLE
[vercel_team_config] Fix saml dsync for access groups

### DIFF
--- a/client/team.go
+++ b/client/team.go
@@ -19,12 +19,21 @@ type SamlRoleAccessGroupID struct {
 	AccessGroupID string `json:"accessGroupId"`
 }
 
-type SamlRole struct {
+type SamlRoleAPI struct {
 	Role          *string
 	AccessGroupID *SamlRoleAccessGroupID
 }
 
-func (f *SamlRole) UnmarshalJSON(data []byte) error {
+type SamlRolesAPI map[string]SamlRoleAPI
+
+type SamlRole struct {
+	Role          *string `json:"role"`
+	AccessGroupID *string `json:"access_group_id"`
+}
+
+type SamlRoles map[string]SamlRole
+
+func (f *SamlRoleAPI) UnmarshalJSON(data []byte) error {
 	var role string
 	if err := json.Unmarshal(data, &role); err == nil {
 		f.Role = &role
@@ -38,10 +47,8 @@ func (f *SamlRole) UnmarshalJSON(data []byte) error {
 	return fmt.Errorf("received json is neither Role string nor AccessGroupID map")
 }
 
-type SamlRoles map[string]string
-
 func (f *SamlRoles) UnmarshalJSON(data []byte) error {
-	var result map[string]SamlRole
+	var result SamlRolesAPI
 	if err := json.Unmarshal(data, &result); err != nil {
 		return err
 	}
@@ -50,7 +57,14 @@ func (f *SamlRoles) UnmarshalJSON(data []byte) error {
 		k := k
 		v := v
 		if v.Role != nil {
-			tmp[k] = *(v.Role)
+			tmp[k] = SamlRole{
+				Role: v.Role,
+			}
+		}
+		if v.AccessGroupID != nil {
+			tmp[k] = SamlRole{
+				AccessGroupID: &v.AccessGroupID.AccessGroupID,
+			}
 		}
 	}
 	*f = tmp
@@ -120,8 +134,8 @@ func (c *Client) GetTeam(ctx context.Context, idOrSlug string) (t Team, err erro
 }
 
 type UpdateSamlConfig struct {
-	Enforced bool              `json:"enforced"`
-	Roles    map[string]string `json:"roles"`
+	Enforced bool           `json:"enforced"`
+	Roles    map[string]any `json:"roles"`
 }
 
 type UpdateTeamRequest struct {

--- a/client/team.go
+++ b/client/team.go
@@ -28,7 +28,7 @@ type SamlRolesAPI map[string]SamlRoleAPI
 
 type SamlRole struct {
 	Role          *string `json:"role"`
-	AccessGroupID *string `json:"access_group_id"`
+	AccessGroupID *string `json:"accessGroupId"`
 }
 
 type SamlRoles map[string]SamlRole

--- a/docs/data-sources/team_config.md
+++ b/docs/data-sources/team_config.md
@@ -54,6 +54,13 @@ Read-Only:
 
 Read-Only:
 
-- `access_group_id` (String) The ID of the access group to use for the team.
 - `enforced` (Boolean) Indicates if SAML is enforced for the team.
-- `roles` (Map of String) Directory groups to role or access group mappings.
+- `roles` (Map of Object) Directory groups to role or access group mappings. For each directory key, either a role or access group id is specified. The role is one of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'. The access group id is the id of an access group. (see [below for nested schema](#nestedatt--saml--roles))
+
+<a id="nestedatt--saml--roles"></a>
+### Nested Schema for `saml.roles`
+
+Read-Only:
+
+- `access_group_id` (String)
+- `role` (String)

--- a/docs/data-sources/team_config.md
+++ b/docs/data-sources/team_config.md
@@ -55,12 +55,12 @@ Read-Only:
 Read-Only:
 
 - `enforced` (Boolean) Indicates if SAML is enforced for the team.
-- `roles` (Map of Object) Directory groups to role or access group mappings. For each directory key, either a role or access group id is specified. The role is one of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'. The access group id is the id of an access group. (see [below for nested schema](#nestedatt--saml--roles))
+- `roles` (Attributes Map) Directory groups to role or access group mappings. For each directory key, specify either a role or access group id. (see [below for nested schema](#nestedatt--saml--roles))
 
 <a id="nestedatt--saml--roles"></a>
 ### Nested Schema for `saml.roles`
 
 Read-Only:
 
-- `access_group_id` (String)
-- `role` (String)
+- `access_group_id` (String) The access group id to assign to the user.
+- `role` (String) The role to assign to the user. One of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'.

--- a/docs/data-sources/team_config.md
+++ b/docs/data-sources/team_config.md
@@ -55,12 +55,12 @@ Read-Only:
 Read-Only:
 
 - `enforced` (Boolean) Indicates if SAML is enforced for the team.
-- `roles` (Attributes Map) Directory groups to role or access group mappings. For each directory key, specify either a role or access group id. (see [below for nested schema](#nestedatt--saml--roles))
+- `roles` (Attributes Map) Directory groups to role or access group mappings. For each directory group, either a role or access group id is specified. (see [below for nested schema](#nestedatt--saml--roles))
 
 <a id="nestedatt--saml--roles"></a>
 ### Nested Schema for `saml.roles`
 
 Read-Only:
 
-- `access_group_id` (String) The access group id to assign to the user.
-- `role` (String) The role to assign to the user. One of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'.
+- `access_group_id` (String) The access group the assign is assigned to.
+- `role` (String) The team level role the user is assigned. One of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'.

--- a/docs/resources/team_config.md
+++ b/docs/resources/team_config.md
@@ -78,12 +78,12 @@ Required:
 
 Optional:
 
-- `roles` (Map of Object) Directory groups to role or access group mappings. For each directory key, specify either a role or access group id. The role should be one of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'. The access group id should be the id of an access group. (see [below for nested schema](#nestedatt--saml--roles))
+- `roles` (Attributes Map) Directory groups to role or access group mappings. For each directory key, specify either a role or access group id. The role should be one of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'. The access group id should be the id of an access group. (see [below for nested schema](#nestedatt--saml--roles))
 
 <a id="nestedatt--saml--roles"></a>
 ### Nested Schema for `saml.roles`
 
 Optional:
 
-- `access_group_id` (String)
-- `role` (String)
+- `access_group_id` (String) The access group id to assign to the user.
+- `role` (String) The role to assign to the user. One of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'.

--- a/docs/resources/team_config.md
+++ b/docs/resources/team_config.md
@@ -78,7 +78,7 @@ Required:
 
 Optional:
 
-- `roles` (Attributes Map) Directory groups to role or access group mappings. For each directory key, specify either a role or access group id. The role should be one of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'. The access group id should be the id of an access group. (see [below for nested schema](#nestedatt--saml--roles))
+- `roles` (Attributes Map) Directory groups to role or access group mappings. For each directory key, specify either a role or access group id. (see [below for nested schema](#nestedatt--saml--roles))
 
 <a id="nestedatt--saml--roles"></a>
 ### Nested Schema for `saml.roles`

--- a/docs/resources/team_config.md
+++ b/docs/resources/team_config.md
@@ -78,7 +78,7 @@ Required:
 
 Optional:
 
-- `roles` (Attributes Map) Directory groups to role or access group mappings. For each directory key, specify either a role or access group id. (see [below for nested schema](#nestedatt--saml--roles))
+- `roles` (Attributes Map) Directory groups to role or access group mappings. For each directory group, specify either a role or access group id. (see [below for nested schema](#nestedatt--saml--roles))
 
 <a id="nestedatt--saml--roles"></a>
 ### Nested Schema for `saml.roles`
@@ -86,4 +86,4 @@ Optional:
 Optional:
 
 - `access_group_id` (String) The access group id to assign to the user.
-- `role` (String) The role to assign to the user. One of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'.
+- `role` (String) The team level role to assign to the user. One of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'.

--- a/docs/resources/team_config.md
+++ b/docs/resources/team_config.md
@@ -78,5 +78,12 @@ Required:
 
 Optional:
 
-- `access_group_id` (String) The ID of the access group to use for the team.
-- `roles` (Map of String) Directory groups to role or access group mappings.
+- `roles` (Map of Object) Directory groups to role or access group mappings. For each directory key, specify either a role or access group id. The role should be one of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'. The access group id should be the id of an access group. (see [below for nested schema](#nestedatt--saml--roles))
+
+<a id="nestedatt--saml--roles"></a>
+### Nested Schema for `saml.roles`
+
+Optional:
+
+- `access_group_id` (String)
+- `role` (String)

--- a/vercel/data_source_team_config.go
+++ b/vercel/data_source_team_config.go
@@ -112,14 +112,19 @@ func (d *teamConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 						Description: "Indicates if SAML is enforced for the team.",
 						Computed:    true,
 					},
-					"roles": schema.MapAttribute{
+					"roles": schema.SingleNestedAttribute{
 						Description: "Directory groups to role or access group mappings.",
-						Computed:    true,
-						ElementType: types.StringType,
-					},
-					"access_group_id": schema.StringAttribute{
-						Description: "The ID of the access group to use for the team.",
-						Computed:    true,
+						Optional:    true,
+						Attributes: map[string]schema.Attribute{
+							"role": schema.StringAttribute{
+								Description: "The role that the user should have in the project. One of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'. Depending on your Team's plan, some of these roles may be unavailable.",
+								Computed:    true,
+							},
+							"access_group_id": schema.StringAttribute{
+								Description: "The ID of the access group to use for the team.",
+								Computed:    true,
+							},
+						},
 					},
 				},
 				Computed:    true,

--- a/vercel/data_source_team_config.go
+++ b/vercel/data_source_team_config.go
@@ -113,16 +113,16 @@ func (d *teamConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 						Computed:    true,
 					},
 					"roles": schema.MapNestedAttribute{
-						Description: "Directory groups to role or access group mappings. For each directory key, specify either a role or access group id.",
+						Description: "Directory groups to role or access group mappings. For each directory group, either a role or access group id is specified.",
 						Computed:    true,
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"role": schema.StringAttribute{
-									Description: "The role to assign to the user. One of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'.",
+									Description: "The team level role the user is assigned. One of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'.",
 									Computed:    true,
 								},
 								"access_group_id": schema.StringAttribute{
-									Description: "The access group id to assign to the user.",
+									Description: "The access group the assign is assigned to.",
 									Computed:    true,
 								},
 							},

--- a/vercel/data_source_team_config.go
+++ b/vercel/data_source_team_config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -113,13 +112,19 @@ func (d *teamConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 						Description: "Indicates if SAML is enforced for the team.",
 						Computed:    true,
 					},
-					"roles": schema.MapAttribute{
-						Description: "Directory groups to role or access group mappings. For each directory key, either a role or access group id is specified. The role is one of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'. The access group id is the id of an access group.",
+					"roles": schema.MapNestedAttribute{
+						Description: "Directory groups to role or access group mappings. For each directory key, specify either a role or access group id.",
 						Computed:    true,
-						ElementType: types.ObjectType{
-							AttrTypes: map[string]attr.Type{
-								"role":            types.StringType,
-								"access_group_id": types.StringType,
+						NestedObject: schema.NestedAttributeObject{
+							Attributes: map[string]schema.Attribute{
+								"role": schema.StringAttribute{
+									Description: "The role to assign to the user. One of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'.",
+									Computed:    true,
+								},
+								"access_group_id": schema.StringAttribute{
+									Description: "The access group id to assign to the user.",
+									Computed:    true,
+								},
 							},
 						},
 					},

--- a/vercel/data_source_team_config.go
+++ b/vercel/data_source_team_config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -112,17 +113,13 @@ func (d *teamConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 						Description: "Indicates if SAML is enforced for the team.",
 						Computed:    true,
 					},
-					"roles": schema.SingleNestedAttribute{
-						Description: "Directory groups to role or access group mappings.",
-						Optional:    true,
-						Attributes: map[string]schema.Attribute{
-							"role": schema.StringAttribute{
-								Description: "The role that the user should have in the project. One of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'. Depending on your Team's plan, some of these roles may be unavailable.",
-								Computed:    true,
-							},
-							"access_group_id": schema.StringAttribute{
-								Description: "The ID of the access group to use for the team.",
-								Computed:    true,
+					"roles": schema.MapAttribute{
+						Description: "Directory groups to role or access group mappings. For each directory key, either a role or access group id is specified. The role is one of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'. The access group id is the id of an access group.",
+						Computed:    true,
+						ElementType: types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"role":            types.StringType,
+								"access_group_id": types.StringType,
 							},
 						},
 					},

--- a/vercel/resource_team_config.go
+++ b/vercel/resource_team_config.go
@@ -5,9 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
-
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -129,7 +128,7 @@ func (r *teamConfigResource) Schema(_ context.Context, req resource.SchemaReques
 						Required:    true,
 					},
 					"roles": schema.MapNestedAttribute{
-						Description: "Directory groups to role or access group mappings. For each directory key, specify either a role or access group id. The role should be one of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'. The access group id should be the id of an access group.",
+						Description: "Directory groups to role or access group mappings. For each directory key, specify either a role or access group id.",
 						Optional:    true,
 						Computed:    true,
 						NestedObject: schema.NestedAttributeObject{

--- a/vercel/resource_team_config.go
+++ b/vercel/resource_team_config.go
@@ -141,14 +141,8 @@ func (r *teamConfigResource) Schema(_ context.Context, req resource.SchemaReques
 									Optional:    true,
 								},
 							},
-							// Not sure why, but this does not work
-							// Validators: []validator.Object{
-							// 	objectvalidator.ExactlyOneOf(
-							// 		path.MatchRelative().AtName("role"),
-							// 		path.MatchRelative().AtName("access_group_id"),
-							// 	),
-							// },
 						},
+						Validators: []validator.Map{validateSamlRoles()},
 						Default: mapdefault.StaticValue(types.MapValueMust(types.ObjectType{
 							AttrTypes: map[string]attr.Type{
 								"role":            types.StringType,

--- a/vercel/resource_team_config.go
+++ b/vercel/resource_team_config.go
@@ -128,13 +128,13 @@ func (r *teamConfigResource) Schema(_ context.Context, req resource.SchemaReques
 						Required:    true,
 					},
 					"roles": schema.MapNestedAttribute{
-						Description: "Directory groups to role or access group mappings. For each directory key, specify either a role or access group id.",
+						Description: "Directory groups to role or access group mappings. For each directory group, specify either a role or access group id.",
 						Optional:    true,
 						Computed:    true,
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"role": schema.StringAttribute{
-									Description: "The role to assign to the user. One of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'.",
+									Description: "The team level role to assign to the user. One of 'MEMBER', 'OWNER', 'VIEWER', 'DEVELOPER', 'BILLING' or 'CONTRIBUTOR'.",
 									Optional:    true,
 									Validators: []validator.String{
 										stringvalidator.OneOf("MEMBER", "OWNER", "VIEWER", "DEVELOPER", "BILLING", "CONTRIBUTOR"),

--- a/vercel/validator_saml_roles.go
+++ b/vercel/validator_saml_roles.go
@@ -1,0 +1,71 @@
+package vercel
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type samlRolesValidator struct{}
+
+var _ validator.Map = &samlRolesValidator{}
+
+func validateSamlRoles() validator.Map {
+	return &samlRolesValidator{}
+}
+
+func (v *samlRolesValidator) Description(ctx context.Context) string {
+	return "Validates that exactly one of role or access_group_id is defined for each SAML role entry"
+}
+
+func (v *samlRolesValidator) MarkdownDescription(ctx context.Context) string {
+	return "Validates that exactly one of role or access_group_id is defined for each SAML role entry"
+}
+
+func (v *samlRolesValidator) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// Get all the map keys
+	keys := req.ConfigValue.Elements()
+
+	// For each key in the map
+	for key, value := range keys {
+		// Convert the value to an object
+		obj, ok := value.(types.Object)
+
+		if !ok || obj.IsNull() || obj.IsUnknown() {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtMapKey(key),
+				"Invalid SAML Role Configuration: "+key,
+				"Expected an object with role or access_group_id",
+			)
+			continue
+		}
+
+		role := obj.Attributes()["role"]
+		accessGroupID := obj.Attributes()["access_group_id"]
+
+		// Check if both are set
+		if !role.IsNull() && !role.IsUnknown() && !accessGroupID.IsNull() && !accessGroupID.IsUnknown() {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtMapKey(key),
+				"Invalid SAML Role Configuration: "+key,
+				"Only one of 'role' or 'access_group_id' can be set, not both",
+			)
+			continue
+		}
+
+		// Check if neither is set
+		if (role.IsNull() || role.IsUnknown()) && (accessGroupID.IsNull() || accessGroupID.IsUnknown()) {
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtMapKey(key),
+				"Invalid SAML Role Configuration: "+key,
+				"Either 'role' or 'access_group_id' must be set",
+			)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
At the moment, the `vercel_team_config` resource incorrectly implements Access Group support. If a team has SAML roles mapped access groups, the provider deletes the mappings.

**This is a breaking change**

steps for upgrading 👇 

1. Update schema for `vercel_team_config.saml`
   1. If `vercel_team_config.saml.access_group_id` is specified: remove it
   1. If `vercel_team_config.saml.roles` is specified: change the values of the object from strings to objects with the format `{ role = "<role e.g. VIEWER>" }` | `{ access_group_id = "<access_group_id>" }`
3. Refresh the terraform state with `terraform refresh` or `terraform apply`

```
// before
resource "vercel_team_config" "test_team" {
  ...
  saml = {
    enforced = <boolean>
    access_group_id = "<access_group_id>"
    roles = {
     <directory_group_id> = "<role e.g. VIEWER>"
    }
  }
}
```

```
// after
resource "vercel_team_config" "test_team" {
  ...
  saml = {
    enforced = <boolean>
    roles = {
      <directory_group_id> = {
        role = "<role e.g. VIEWER>"
      }
      <directory_group_id> = {
        access_group_id = "<access_group_id>"
      }
    }
  }
}
```