### PR TITLE
Fix `vercel_team_config` tests

### DIFF
--- a/vercel/resource_team_config_test.go
+++ b/vercel/resource_team_config_test.go
@@ -16,6 +16,8 @@ func TestAcc_TeamConfig(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVercelTeamConfigBasic(testTeam()),
+				// Added since vercel_team_config schema version upgraded
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "vercel-terraform-test"),
 					resource.TestCheckResourceAttr(resourceName, "slug", "vercel-terraform-test-ci"),
@@ -24,6 +26,8 @@ func TestAcc_TeamConfig(t *testing.T) {
 			},
 			{
 				Config: testAccVercelTeamConfigUpdated(testTeam()),
+				// Added since vercel_team_config schema version upgraded
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "name", "vercel-terraform-test-ci"),


### PR DESCRIPTION
Follow up to 

- https://github.com/vercel/terraform-provider-vercel/pull/298

I originally thought the tests would right themselves once in main, but it looks like the test will always produce a refresh now due to the multiple schema versions

Note that I tested the original change manually, and the refresh is only required once, after it's applied it's business as usual

