### PR TITLE
Check env vars for tests are set when used

### DIFF
--- a/vercel/data_source_access_group_project_test.go
+++ b/vercel/data_source_access_group_project_test.go
@@ -11,11 +11,10 @@ import (
 func TestAcc_AccessGroupProjectDataSource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessGroupProjectDataSource(name),
+				Config: testAccAccessGroupProjectDataSource(teamIDConfig(t), name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vercel_access_group_project.test", "role", "ADMIN"),
 				),
@@ -24,7 +23,7 @@ func TestAcc_AccessGroupProjectDataSource(t *testing.T) {
 	})
 }
 
-func testAccAccessGroupProjectDataSource(name string) string {
+func testAccAccessGroupProjectDataSource(teamIdConfig string, name string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
 	%[1]s
@@ -51,5 +50,5 @@ data "vercel_access_group_project" "test" {
       vercel_access_group_project.test
   ]
 }
-`, teamIDConfig(), name)
+`, teamIdConfig, name)
 }

--- a/vercel/data_source_access_group_project_test.go
+++ b/vercel/data_source_access_group_project_test.go
@@ -23,7 +23,7 @@ func TestAcc_AccessGroupProjectDataSource(t *testing.T) {
 	})
 }
 
-func testAccAccessGroupProjectDataSource(teamIdConfig string, name string) string {
+func testAccAccessGroupProjectDataSource(teamIDConfig string, name string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
 	%[1]s
@@ -50,5 +50,5 @@ data "vercel_access_group_project" "test" {
       vercel_access_group_project.test
   ]
 }
-`, teamIdConfig, name)
+`, teamIDConfig, name)
 }

--- a/vercel/data_source_access_group_test.go
+++ b/vercel/data_source_access_group_test.go
@@ -23,7 +23,7 @@ func TestAcc_AccessGroupDataSource(t *testing.T) {
 	})
 }
 
-func testAccAccessGroupDataSource(teamIdConfig string, name string) string {
+func testAccAccessGroupDataSource(teamIDConfig string, name string) string {
 	return fmt.Sprintf(`
 resource "vercel_access_group" "test" {
   name = "test-acc-%[2]s"
@@ -34,5 +34,5 @@ data "vercel_access_group" "test" {
 	id = vercel_access_group.test.id
 	%[1]s
 }
-`, teamIdConfig, name)
+`, teamIDConfig, name)
 }

--- a/vercel/data_source_access_group_test.go
+++ b/vercel/data_source_access_group_test.go
@@ -11,11 +11,10 @@ import (
 func TestAcc_AccessGroupDataSource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessGroupDataSource(name),
+				Config: testAccAccessGroupDataSource(teamIDConfig(t), name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vercel_access_group.test", "name", "test-acc-"+name),
 				),
@@ -24,7 +23,7 @@ func TestAcc_AccessGroupDataSource(t *testing.T) {
 	})
 }
 
-func testAccAccessGroupDataSource(name string) string {
+func testAccAccessGroupDataSource(teamIdConfig string, name string) string {
 	return fmt.Sprintf(`
 resource "vercel_access_group" "test" {
   name = "test-acc-%[2]s"
@@ -35,5 +34,5 @@ data "vercel_access_group" "test" {
 	id = vercel_access_group.test.id
 	%[1]s
 }
-`, teamIDConfig(), name)
+`, teamIdConfig, name)
 }

--- a/vercel/data_source_alias_test.go
+++ b/vercel/data_source_alias_test.go
@@ -11,14 +11,13 @@ import (
 func TestAcc_AliasDataSource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAliasDataSourceConfig(name, teamIDConfig()),
+				Config: testAccAliasDataSourceConfig(name, teamIDConfig(t), testGithubRepo(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vercel_alias.test", "alias", fmt.Sprintf("test-acc-%s.vercel.app", name)),
-					resource.TestCheckResourceAttr("data.vercel_alias.test", "team_id", testTeam()),
+					resource.TestCheckResourceAttr("data.vercel_alias.test", "team_id", testTeam(t)),
 					resource.TestCheckResourceAttrSet("data.vercel_alias.test", "id"),
 					resource.TestCheckResourceAttrSet("data.vercel_alias.test", "deployment_id"),
 				),
@@ -27,7 +26,7 @@ func TestAcc_AliasDataSource(t *testing.T) {
 	})
 }
 
-func testAccAliasDataSourceConfig(name, team string) string {
+func testAccAliasDataSourceConfig(name, team string, testGithubRepo string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
     name = "test-acc-%[1]s"
@@ -54,5 +53,5 @@ data "vercel_alias" "test" {
     alias = vercel_alias.test.alias
     %[2]s
 }
-`, name, team, testGithubRepo())
+`, name, team, testGithubRepo)
 }

--- a/vercel/data_source_attack_challenge_mode_test.go
+++ b/vercel/data_source_attack_challenge_mode_test.go
@@ -11,11 +11,10 @@ import (
 func TestAcc_AttackChallengeModeDataSource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAttackChallengeModeConfig(name, teamIDConfig()),
+				Config: testAccAttackChallengeModeConfig(name, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vercel_attack_challenge_mode.never_enabled", "enabled", "false"),
 					resource.TestCheckResourceAttr("data.vercel_attack_challenge_mode.enabled", "enabled", "true"),

--- a/vercel/data_source_custom_environment_test.go
+++ b/vercel/data_source_custom_environment_test.go
@@ -29,7 +29,7 @@ func TestAcc_CustomEnvironmentDataSource(t *testing.T) {
 	})
 }
 
-func testAccCustomEnvironmentDataSource(projectSuffix, teamIdConfig string) string {
+func testAccCustomEnvironmentDataSource(projectSuffix, teamIDConfig string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "test-acc-custom-env-data-source-%[1]s"
@@ -52,5 +52,5 @@ data "vercel_custom_environment" "test" {
   %[2]s
   name = vercel_custom_environment.test.name
 }
-`, projectSuffix, teamIdConfig)
+`, projectSuffix, teamIDConfig)
 }

--- a/vercel/data_source_custom_environment_test.go
+++ b/vercel/data_source_custom_environment_test.go
@@ -11,12 +11,11 @@ import (
 func TestAcc_CustomEnvironmentDataSource(t *testing.T) {
 	projectSuffix := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:             testAccProjectDestroy("vercel_project.test", testTeam()),
+		CheckDestroy:             testAccProjectDestroy(testClient(t), "vercel_project.test", testTeam(t)),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomEnvironmentDataSource(projectSuffix),
+				Config: testAccCustomEnvironmentDataSource(projectSuffix, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.vercel_custom_environment.test", "id"),
 					resource.TestCheckResourceAttrSet("data.vercel_custom_environment.test", "project_id"),
@@ -30,7 +29,7 @@ func TestAcc_CustomEnvironmentDataSource(t *testing.T) {
 	})
 }
 
-func testAccCustomEnvironmentDataSource(projectSuffix string) string {
+func testAccCustomEnvironmentDataSource(projectSuffix, teamIdConfig string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "test-acc-custom-env-data-source-%[1]s"
@@ -53,5 +52,5 @@ data "vercel_custom_environment" "test" {
   %[2]s
   name = vercel_custom_environment.test.name
 }
-`, projectSuffix, teamIDConfig())
+`, projectSuffix, teamIdConfig)
 }

--- a/vercel/data_source_deployment_test.go
+++ b/vercel/data_source_deployment_test.go
@@ -11,11 +11,10 @@ import (
 func TestAcc_DeploymentDataSource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDeploymentDataSourceConfig(name, teamIDConfig()),
+				Config: testAccDeploymentDataSourceConfig(name, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.vercel_deployment.by_id", "id"),
 					resource.TestCheckResourceAttrSet("data.vercel_deployment.by_id", "project_id"),

--- a/vercel/data_source_edge_config_item_test.go
+++ b/vercel/data_source_edge_config_item_test.go
@@ -12,11 +12,10 @@ import (
 func TestAcc_EdgeConfigItemDataSource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEdgeConfigItemDataSourceConfig(name, teamIDConfig()),
+				Config: testAccEdgeConfigItemDataSourceConfig(name, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.vercel_edge_config_item.test", "id"),
 					resource.TestCheckResourceAttrSet("data.vercel_edge_config_item.test", "team_id"),
@@ -25,7 +24,7 @@ func TestAcc_EdgeConfigItemDataSource(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccEdgeConfigItemDataSourceConfigNoItem(name, teamIDConfig()),
+				Config:      testAccEdgeConfigItemDataSourceConfigNoItem(name, teamIDConfig(t)),
 				ExpectError: regexp.MustCompile("not_found"),
 			},
 		},

--- a/vercel/data_source_edge_config_schema_test.go
+++ b/vercel/data_source_edge_config_schema_test.go
@@ -12,11 +12,10 @@ import (
 func TestAcc_EdgeConfigSchemaDataSource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEdgeConfigSchemaDataSourceConfig(name, teamIDConfig()),
+				Config: testAccEdgeConfigSchemaDataSourceConfig(name, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.vercel_edge_config_schema.test", "id"),
 					resource.TestCheckResourceAttrSet("data.vercel_edge_config_schema.test", "team_id"),
@@ -24,7 +23,7 @@ func TestAcc_EdgeConfigSchemaDataSource(t *testing.T) {
 				),
 			},
 			{
-				Config:      testAccEdgeConfigSchemaDataSourceConfigNoSchema(name, teamIDConfig()),
+				Config:      testAccEdgeConfigSchemaDataSourceConfigNoSchema(name, teamIDConfig(t)),
 				ExpectError: regexp.MustCompile("not_found"),
 			},
 		},

--- a/vercel/data_source_edge_config_test.go
+++ b/vercel/data_source_edge_config_test.go
@@ -11,11 +11,10 @@ import (
 func TestAcc_EdgeConfigDataSource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEdgeConfigDataSourceConfig(name, teamIDConfig()),
+				Config: testAccEdgeConfigDataSourceConfig(name, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vercel_edge_config.test", "name", name),
 				),

--- a/vercel/data_source_edge_config_token_test.go
+++ b/vercel/data_source_edge_config_token_test.go
@@ -11,11 +11,10 @@ import (
 func TestAcc_EdgeConfigTokenDataSource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEdgeConfigTokenDataSourceConfig(name, teamIDConfig()),
+				Config: testAccEdgeConfigTokenDataSourceConfig(name, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vercel_edge_config_token.test", "label", "test-acc-token"),
 					resource.TestCheckResourceAttrSet("data.vercel_edge_config_token.test", "edge_config_id"),

--- a/vercel/data_source_endpoint_verification_test.go
+++ b/vercel/data_source_endpoint_verification_test.go
@@ -9,11 +9,10 @@ import (
 
 func TestAcc_EndpointVerificationDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointVerificationDataSourceConfig(teamIDConfig()),
+				Config: testAccEndpointVerificationDataSourceConfig(teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.vercel_endpoint_verification.test", "verification_code"),
 				),

--- a/vercel/data_source_file_test.go
+++ b/vercel/data_source_file_test.go
@@ -40,7 +40,6 @@ func testChecksum(n, attribute string, checksums Checksums) resource.TestCheckFu
 
 func TestAcc_DataSourceFile(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/vercel/data_source_microfrontend_group_test.go
+++ b/vercel/data_source_microfrontend_group_test.go
@@ -11,7 +11,6 @@ import (
 func TestAcc_MicrofrontendGroupDataSource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -45,7 +44,7 @@ func TestAcc_MicrofrontendGroupDataSource(t *testing.T) {
 						project_id = vercel_project.test_project_2.id
 						%[2]s
 					}	
-				`, name, teamIDConfig()),
+				`, name, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vercel_microfrontend_group.test_group", "name", "test-acc-microfrontend-group-"+name),
 					resource.TestCheckResourceAttrSet("data.vercel_microfrontend_group.test_group", "default_app.project_id"),

--- a/vercel/data_source_prebuilt_project_test.go
+++ b/vercel/data_source_prebuilt_project_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestAcc_DataSourcePrebuiltProject(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/vercel/data_source_project_deployment_retention_test.go
+++ b/vercel/data_source_project_deployment_retention_test.go
@@ -11,16 +11,15 @@ import (
 func TestAcc_ProjectDeploymentRetentionDataSource(t *testing.T) {
 	nameSuffix := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccProjectDestroy("vercel_project.example", testTeam()),
+			testAccProjectDestroy(testClient(t), "vercel_project.example", testTeam(t)),
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectDeploymentRetentionDataSourceConfig(nameSuffix),
+				Config: testAccProjectDeploymentRetentionDataSourceConfig(nameSuffix, testGithubRepo(t), teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccProjectDeploymentRetentionExists("vercel_project_deployment_retention.example", testTeam()),
+					testAccProjectDeploymentRetentionExists(testClient(t), "vercel_project_deployment_retention.example", testTeam(t)),
 					resource.TestCheckResourceAttr("data.vercel_project_deployment_retention.example", "expiration_preview", "1m"),
 					resource.TestCheckResourceAttr("data.vercel_project_deployment_retention.example", "expiration_production", "unlimited"),
 					resource.TestCheckResourceAttr("data.vercel_project_deployment_retention.example", "expiration_canceled", "unlimited"),
@@ -36,7 +35,7 @@ func TestAcc_ProjectDeploymentRetentionDataSource(t *testing.T) {
 	})
 }
 
-func testAccProjectDeploymentRetentionDataSourceConfig(projectName string) string {
+func testAccProjectDeploymentRetentionDataSourceConfig(projectName string, githubRepo string, teamIDConfig string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "example" {
 	name = "test-acc-example-project-%[1]s"
@@ -73,5 +72,5 @@ data "vercel_project_deployment_retention" "example_2" {
 	project_id = vercel_project.example_2.id
 	%[3]s
 }
-`, projectName, testGithubRepo(), teamIDConfig())
+`, projectName, githubRepo, teamIDConfig)
 }

--- a/vercel/data_source_project_directory_test.go
+++ b/vercel/data_source_project_directory_test.go
@@ -9,7 +9,6 @@ import (
 
 func TestAcc_DataSourceProjectDirectory(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/vercel/data_source_project_members_test.go
+++ b/vercel/data_source_project_members_test.go
@@ -25,7 +25,7 @@ func TestAcc_ProjectMembersDataSource(t *testing.T) {
 	})
 }
 
-func testAccProjectMembersDataSourceConfig(projectSuffix string, teamIdConfig string) string {
+func testAccProjectMembersDataSourceConfig(projectSuffix string, teamIDConfig string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "test-acc-project-members-%[1]s"
@@ -46,5 +46,5 @@ data "vercel_project_members" "test" {
   project_id = vercel_project_members.test.project_id
   %[2]s
 }
-`, projectSuffix, teamIdConfig)
+`, projectSuffix, teamIDConfig)
 }

--- a/vercel/data_source_project_members_test.go
+++ b/vercel/data_source_project_members_test.go
@@ -11,12 +11,11 @@ import (
 func TestAcc_ProjectMembersDataSource(t *testing.T) {
 	projectSuffix := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:             testAccProjectDestroy("vercel_project.test", testTeam()),
+		CheckDestroy:             testAccProjectDestroy(testClient(t), "vercel_project.test", testTeam(t)),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectMembersDataSourceConfig(projectSuffix),
+				Config: testAccProjectMembersDataSourceConfig(projectSuffix, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.vercel_project_members.test", "project_id"),
 					resource.TestCheckResourceAttr("data.vercel_project_members.test", "members.#", "1"),
@@ -26,7 +25,7 @@ func TestAcc_ProjectMembersDataSource(t *testing.T) {
 	})
 }
 
-func testAccProjectMembersDataSourceConfig(projectSuffix string) string {
+func testAccProjectMembersDataSourceConfig(projectSuffix string, teamIdConfig string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "test-acc-project-members-%[1]s"
@@ -47,5 +46,5 @@ data "vercel_project_members" "test" {
   project_id = vercel_project_members.test.project_id
   %[2]s
 }
-`, projectSuffix, teamIDConfig())
+`, projectSuffix, teamIdConfig)
 }

--- a/vercel/data_source_project_test.go
+++ b/vercel/data_source_project_test.go
@@ -11,11 +11,10 @@ import (
 func TestAcc_ProjectDataSource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectDataSourceConfig(name, teamIDConfig()),
+				Config: testAccProjectDataSourceConfig(name, teamIDConfig(t), testGithubRepo(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vercel_project.test", "name", "test-acc-"+name),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "build_command", "npm run build"),
@@ -63,7 +62,7 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 	})
 }
 
-func testAccProjectDataSourceConfig(name, teamID string) string {
+func testAccProjectDataSourceConfig(name, teamID, githubRepo string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "test-acc-%s"
@@ -144,5 +143,5 @@ data "vercel_project" "test" {
     name = vercel_project.test.name
     %[2]s
 }
-`, name, teamID, testGithubRepo())
+`, name, teamID, githubRepo)
 }

--- a/vercel/data_source_shared_environment_variable_test.go
+++ b/vercel/data_source_shared_environment_variable_test.go
@@ -11,11 +11,10 @@ import (
 func TestAcc_SharedEnvironmentVariableDataSource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSharedEnvironmentVariableDataSource(name, teamIDConfig()),
+				Config: testAccSharedEnvironmentVariableDataSource(name, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vercel_shared_environment_variable.test", "key", "test_acc_"+name),
 					resource.TestCheckResourceAttr("data.vercel_shared_environment_variable.test", "value", "foobar"),

--- a/vercel/data_source_team_config_test.go
+++ b/vercel/data_source_team_config_test.go
@@ -11,11 +11,10 @@ func TestAcc_TeamConfigDataSource(t *testing.T) {
 	resourceName := "data.vercel_team_config.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVercelTeamConfigDataSource(testTeam()),
+				Config: testAccVercelTeamConfigDataSource(testTeam(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "name"),

--- a/vercel/data_source_team_member_test.go
+++ b/vercel/data_source_team_member_test.go
@@ -9,11 +9,10 @@ import (
 
 func TestAcc_TeamMemberDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTeamMemberDataSourceConfig(),
+				Config: testAccTeamMemberDataSourceConfig(teamIDConfig(t), testAdditionalUser(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.vercel_team_member.test", "team_id"),
 					resource.TestCheckResourceAttrSet("data.vercel_team_member.test", "user_id"),
@@ -24,7 +23,7 @@ func TestAcc_TeamMemberDataSource(t *testing.T) {
 	})
 }
 
-func testAccTeamMemberDataSourceConfig() string {
+func testAccTeamMemberDataSourceConfig(teamIdConfig string, user string) string {
 	return fmt.Sprintf(`
 resource "vercel_team_member" "test" {
   %[1]s
@@ -36,5 +35,5 @@ data "vercel_team_member" "test" {
     user_id = vercel_team_member.test.user_id
     team_id = vercel_team_member.test.team_id
 }
-`, teamIDConfig(), testAdditionalUser())
+`, teamIdConfig, user)
 }

--- a/vercel/data_source_team_member_test.go
+++ b/vercel/data_source_team_member_test.go
@@ -23,7 +23,7 @@ func TestAcc_TeamMemberDataSource(t *testing.T) {
 	})
 }
 
-func testAccTeamMemberDataSourceConfig(teamIdConfig string, user string) string {
+func testAccTeamMemberDataSourceConfig(teamIDConfig string, user string) string {
 	return fmt.Sprintf(`
 resource "vercel_team_member" "test" {
   %[1]s
@@ -35,5 +35,5 @@ data "vercel_team_member" "test" {
     user_id = vercel_team_member.test.user_id
     team_id = vercel_team_member.test.team_id
 }
-`, teamIdConfig, user)
+`, teamIDConfig, user)
 }

--- a/vercel/provider_test.go
+++ b/vercel/provider_test.go
@@ -49,14 +49,6 @@ func testBitbucketRepo(t *testing.T) string {
 	return value
 }
 
-func testGitlabRepo(t *testing.T) string {
-	value := os.Getenv("VERCEL_TERRAFORM_TESTING_GITLAB_REPO")
-	if value == "" {
-		t.Fatalf("Missing required environment variable VERCEL_TERRAFORM_TESTING_GITLAB_REPO")
-	}
-	return value
-}
-
 func testTeam(t *testing.T) string {
 	value := os.Getenv("VERCEL_TERRAFORM_TESTING_TEAM")
 	if value == "" {

--- a/vercel/provider_test.go
+++ b/vercel/provider_test.go
@@ -15,64 +15,80 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 	"vercel": providerserver.NewProtocol6WithError(vercel.New()),
 }
 
-func mustHaveEnv(t *testing.T, name string) {
-	if os.Getenv(name) == "" {
-		t.Fatalf("%s environment variable must be set for acceptance tests", name)
-	}
-}
-
-func testAccPreCheck(t *testing.T) {
-	mustHaveEnv(t, "VERCEL_API_TOKEN")
-	mustHaveEnv(t, "VERCEL_TERRAFORM_TESTING_TEAM")
-	mustHaveEnv(t, "VERCEL_TERRAFORM_TESTING_GITHUB_REPO")
-	mustHaveEnv(t, "VERCEL_TERRAFORM_TESTING_GITLAB_REPO")
-	mustHaveEnv(t, "VERCEL_TERRAFORM_TESTING_BITBUCKET_REPO")
-	mustHaveEnv(t, "VERCEL_TERRAFORM_TESTING_DOMAIN")
-	mustHaveEnv(t, "VERCEL_TERRAFORM_TESTING_ADDITIONAL_USER")
-	mustHaveEnv(t, "VERCEL_TERRAFORM_TESTING_EXISTING_INTEGRATION")
-}
-
 var tc *client.Client
 
-func testClient() *client.Client {
+func testClient(t *testing.T) *client.Client {
 	if tc == nil {
-		tc = client.New(apiToken())
+		tc = client.New(apiToken(t))
 	}
 
 	return tc
 }
 
-func apiToken() string {
-	return os.Getenv("VERCEL_API_TOKEN")
-}
-
-func testGithubRepo() string {
-	return os.Getenv("VERCEL_TERRAFORM_TESTING_GITHUB_REPO")
-}
-
-func testBitbucketRepo() string {
-	return os.Getenv("VERCEL_TERRAFORM_TESTING_BITBUCKET_REPO")
-}
-
-func testTeam() string {
-	return os.Getenv("VERCEL_TERRAFORM_TESTING_TEAM")
-}
-
-func teamIDConfig() string {
-	if testTeam() == "" {
-		return ""
+func apiToken(t *testing.T) string {
+	value := os.Getenv("VERCEL_API_TOKEN")
+	if value == "" {
+		t.Fatalf("Missing required environment variable VERCEL_API_TOKEN")
 	}
-	return fmt.Sprintf("team_id = \"%s\"", testTeam())
+	return value
 }
 
-func testDomain() string {
-	return os.Getenv("VERCEL_TERRAFORM_TESTING_DOMAIN")
+func testGithubRepo(t *testing.T) string {
+	value := os.Getenv("VERCEL_TERRAFORM_TESTING_GITHUB_REPO")
+	if value == "" {
+		t.Fatalf("Missing required environment variable VERCEL_TERRAFORM_TESTING_GITHUB_REPO")
+	}
+	return value
 }
 
-func testAdditionalUser() string {
-	return os.Getenv("VERCEL_TERRAFORM_TESTING_ADDITIONAL_USER")
+func testBitbucketRepo(t *testing.T) string {
+	value := os.Getenv("VERCEL_TERRAFORM_TESTING_BITBUCKET_REPO")
+	if value == "" {
+		t.Fatalf("Missing required environment variable VERCEL_TERRAFORM_TESTING_BITBUCKET_REPO")
+	}
+	return value
 }
 
-func testExistingIntegration() string {
-	return os.Getenv("VERCEL_TERRAFORM_TESTING_EXISTING_INTEGRATION")
+func testGitlabRepo(t *testing.T) string {
+	value := os.Getenv("VERCEL_TERRAFORM_TESTING_GITLAB_REPO")
+	if value == "" {
+		t.Fatalf("Missing required environment variable VERCEL_TERRAFORM_TESTING_GITLAB_REPO")
+	}
+	return value
+}
+
+func testTeam(t *testing.T) string {
+	value := os.Getenv("VERCEL_TERRAFORM_TESTING_TEAM")
+	if value == "" {
+		t.Fatalf("Missing required environment variable VERCEL_TERRAFORM_TESTING_TEAM")
+	}
+	return value
+}
+
+func teamIDConfig(t *testing.T) string {
+	return fmt.Sprintf("team_id = \"%s\"", testTeam(t))
+}
+
+func testDomain(t *testing.T) string {
+	value := os.Getenv("VERCEL_TERRAFORM_TESTING_DOMAIN")
+	if value == "" {
+		t.Fatalf("Missing required environment variable VERCEL_TERRAFORM_TESTING_DOMAIN")
+	}
+	return value
+}
+
+func testAdditionalUser(t *testing.T) string {
+	value := os.Getenv("VERCEL_TERRAFORM_TESTING_ADDITIONAL_USER")
+	if value == "" {
+		t.Fatalf("Missing required environment variable VERCEL_TERRAFORM_TESTING_ADDITIONAL_USER")
+	}
+	return value
+}
+
+func testExistingIntegration(t *testing.T) string {
+	value := os.Getenv("VERCEL_TERRAFORM_TESTING_EXISTING_INTEGRATION")
+	if value == "" {
+		t.Fatalf("Missing required environment variable VERCEL_TERRAFORM_TESTING_EXISTING_INTEGRATION")
+	}
+	return value
 }

--- a/vercel/resource_access_group_project_test.go
+++ b/vercel/resource_access_group_project_test.go
@@ -15,14 +15,13 @@ func TestAcc_AccessGroupProjectResource(t *testing.T) {
 	name := acctest.RandString(16)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:             testAccAccessGroupProjectDoesNotExist("vercel_access_group_project.test"),
+		CheckDestroy:             testAccAccessGroupProjectDoesNotExist(testClient(t), testTeam(t), "vercel_access_group_project.test"),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceAccessGroupProject(name),
+				Config: testAccResourceAccessGroupProject(teamIDConfig(t), name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testCheckAccessGroupProjectExists("vercel_access_group_project.test"),
+					testCheckAccessGroupProjectExists(testClient(t), testTeam(t), "vercel_access_group_project.test"),
 					resource.TestCheckResourceAttrSet("vercel_access_group_project.test", "access_group_id"),
 					resource.TestCheckResourceAttrSet("vercel_access_group_project.test", "project_id"),
 					resource.TestCheckResourceAttr("vercel_access_group_project.test", "role", "ADMIN"),
@@ -34,9 +33,9 @@ func TestAcc_AccessGroupProjectResource(t *testing.T) {
 				ImportStateIdFunc: getAccessGroupProjectImportID("vercel_access_group_project.test"),
 			},
 			{
-				Config: testAccResourceAccessGroupProjectUpdated(name),
+				Config: testAccResourceAccessGroupProjectUpdated(teamIDConfig(t), name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testCheckAccessGroupProjectExists("vercel_access_group_project.test"),
+					testCheckAccessGroupProjectExists(testClient(t), testTeam(t), "vercel_access_group_project.test"),
 					resource.TestCheckResourceAttrSet("vercel_access_group_project.test", "project_id"),
 					resource.TestCheckResourceAttrSet("vercel_access_group_project.test", "access_group_id"),
 					resource.TestCheckResourceAttr("vercel_access_group_project.test", "role", "PROJECT_DEVELOPER"),
@@ -62,15 +61,15 @@ func getAccessGroupProjectImportID(n string) resource.ImportStateIdFunc {
 	}
 }
 
-func testCheckAccessGroupProjectExists(n string) resource.TestCheckFunc {
+func testCheckAccessGroupProjectExists(testClient *client.Client, teamID string, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("not found: %s", n)
 		}
 
-		_, err := testClient().GetAccessGroupProject(context.TODO(), client.GetAccessGroupProjectRequest{
-			TeamID:        testTeam(),
+		_, err := testClient.GetAccessGroupProject(context.TODO(), client.GetAccessGroupProjectRequest{
+			TeamID:        teamID,
 			AccessGroupID: rs.Primary.Attributes["access_group_id"],
 			ProjectID:     rs.Primary.Attributes["project_id"],
 		})
@@ -78,15 +77,15 @@ func testCheckAccessGroupProjectExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccAccessGroupProjectDoesNotExist(n string) resource.TestCheckFunc {
+func testAccAccessGroupProjectDoesNotExist(testClient *client.Client, teamID string, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("not found: %s", n)
 		}
 
-		_, err := testClient().GetAccessGroupProject(context.TODO(), client.GetAccessGroupProjectRequest{
-			TeamID:        testTeam(),
+		_, err := testClient.GetAccessGroupProject(context.TODO(), client.GetAccessGroupProjectRequest{
+			TeamID:        teamID,
 			AccessGroupID: rs.Primary.Attributes["access_group_id"],
 			ProjectID:     rs.Primary.Attributes["project_id"],
 		})
@@ -101,7 +100,7 @@ func testAccAccessGroupProjectDoesNotExist(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccResourceAccessGroupProject(name string) string {
+func testAccResourceAccessGroupProject(teamIdConfig string, name string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   %[1]s
@@ -119,10 +118,10 @@ resource "vercel_access_group_project" "test" {
 	access_group_id = vercel_access_group.test.id
 	role = "ADMIN"
 }
-`, teamIDConfig(), name)
+`, teamIDConfig, name)
 }
 
-func testAccResourceAccessGroupProjectUpdated(name string) string {
+func testAccResourceAccessGroupProjectUpdated(teamIdConfig string, name string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   %[1]s
@@ -140,5 +139,5 @@ resource "vercel_access_group_project" "test" {
 	access_group_id = vercel_access_group.test.id
 	role = "PROJECT_DEVELOPER"
 }
-`, teamIDConfig(), name)
+`, teamIdConfig, name)
 }

--- a/vercel/resource_access_group_project_test.go
+++ b/vercel/resource_access_group_project_test.go
@@ -100,7 +100,7 @@ func testAccAccessGroupProjectDoesNotExist(testClient *client.Client, teamID str
 	}
 }
 
-func testAccResourceAccessGroupProject(teamIdConfig string, name string) string {
+func testAccResourceAccessGroupProject(teamIDConfig string, name string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   %[1]s
@@ -121,7 +121,7 @@ resource "vercel_access_group_project" "test" {
 `, teamIDConfig, name)
 }
 
-func testAccResourceAccessGroupProjectUpdated(teamIdConfig string, name string) string {
+func testAccResourceAccessGroupProjectUpdated(teamIDConfig string, name string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   %[1]s
@@ -139,5 +139,5 @@ resource "vercel_access_group_project" "test" {
 	access_group_id = vercel_access_group.test.id
 	role = "PROJECT_DEVELOPER"
 }
-`, teamIdConfig, name)
+`, teamIDConfig, name)
 }

--- a/vercel/resource_access_group_test.go
+++ b/vercel/resource_access_group_test.go
@@ -113,7 +113,7 @@ func testCheckAccessGroupDoesNotExist(testClient *client.Client, teamID string, 
 	}
 }
 
-func testAccResourceAccessGroup(teamIdConfig string, name string) string {
+func testAccResourceAccessGroup(teamIDConfig string, name string) string {
 	return fmt.Sprintf(`
 resource "vercel_access_group" "test" {
   %[1]s
@@ -122,11 +122,11 @@ resource "vercel_access_group" "test" {
 `, teamIDConfig, name)
 }
 
-func testAccResourceAccessGroupUpdated(teamIdConfig string, name string) string {
+func testAccResourceAccessGroupUpdated(teamIDConfig string, name string) string {
 	return fmt.Sprintf(`
 resource "vercel_access_group" "test" {
   %[1]s
   name  = "test-acc-%[2]s-updated"
 }
-`, teamIdConfig, name)
+`, teamIDConfig, name)
 }

--- a/vercel/resource_access_group_test.go
+++ b/vercel/resource_access_group_test.go
@@ -15,16 +15,15 @@ import (
 func TestAcc_AccessGroupResource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testCheckAccessGroupDoesNotExist("vercel_access_group.test"),
+			testCheckAccessGroupDoesNotExist(testClient(t), testTeam(t), "vercel_access_group.test"),
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceAccessGroup(name),
+				Config: testAccResourceAccessGroup(teamIDConfig(t), name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testCheckAccessGroupExists("vercel_access_group.test"),
+					testCheckAccessGroupExists(testClient(t), testTeam(t), "vercel_access_group.test"),
 					resource.TestCheckResourceAttrSet("vercel_access_group.test", "id"),
 					resource.TestCheckResourceAttr("vercel_access_group.test", "name", fmt.Sprintf("test-acc-%s", name)),
 				),
@@ -35,9 +34,9 @@ func TestAcc_AccessGroupResource(t *testing.T) {
 				ImportStateIdFunc: getAccessGroupImportID("vercel_access_group.test"),
 			},
 			{
-				Config: testAccResourceAccessGroupUpdated(name),
+				Config: testAccResourceAccessGroupUpdated(teamIDConfig(t), name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testCheckAccessGroupExists("vercel_access_group.test"),
+					testCheckAccessGroupExists(testClient(t), testTeam(t), "vercel_access_group.test"),
 					resource.TestCheckResourceAttrSet("vercel_access_group.test", "id"),
 					resource.TestCheckResourceAttr("vercel_access_group.test", "name", fmt.Sprintf("test-acc-%s-updated", name)),
 				),
@@ -65,7 +64,7 @@ func getAccessGroupImportID(n string) resource.ImportStateIdFunc {
 	}
 }
 
-func testCheckAccessGroupExists(n string) resource.TestCheckFunc {
+func testCheckAccessGroupExists(testClient *client.Client, teamID string, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -76,15 +75,15 @@ func testCheckAccessGroupExists(n string) resource.TestCheckFunc {
 			return fmt.Errorf("no ID is set")
 		}
 
-		_, err := testClient().GetAccessGroup(context.TODO(), client.GetAccessGroupRequest{
-			TeamID:        testTeam(),
+		_, err := testClient.GetAccessGroup(context.TODO(), client.GetAccessGroupRequest{
+			TeamID:        teamID,
 			AccessGroupID: rs.Primary.ID,
 		})
 		return err
 	}
 }
 
-func testCheckAccessGroupDoesNotExist(n string) resource.TestCheckFunc {
+func testCheckAccessGroupDoesNotExist(testClient *client.Client, teamID string, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -99,8 +98,8 @@ func testCheckAccessGroupDoesNotExist(n string) resource.TestCheckFunc {
 		// small amount of time.
 		time.Sleep(time.Second * 2)
 
-		_, err := testClient().GetAccessGroup(context.TODO(), client.GetAccessGroupRequest{
-			TeamID:        testTeam(),
+		_, err := testClient.GetAccessGroup(context.TODO(), client.GetAccessGroupRequest{
+			TeamID:        teamID,
 			AccessGroupID: rs.Primary.ID,
 		})
 		if err == nil {
@@ -114,20 +113,20 @@ func testCheckAccessGroupDoesNotExist(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccResourceAccessGroup(name string) string {
+func testAccResourceAccessGroup(teamIdConfig string, name string) string {
 	return fmt.Sprintf(`
 resource "vercel_access_group" "test" {
   %[1]s
   name = "test-acc-%[2]s"
 }
-`, teamIDConfig(), name)
+`, teamIDConfig, name)
 }
 
-func testAccResourceAccessGroupUpdated(name string) string {
+func testAccResourceAccessGroupUpdated(teamIdConfig string, name string) string {
 	return fmt.Sprintf(`
 resource "vercel_access_group" "test" {
   %[1]s
   name  = "test-acc-%[2]s-updated"
 }
-`, teamIDConfig(), name)
+`, teamIdConfig, name)
 }

--- a/vercel/resource_attack_challenge_mode_test.go
+++ b/vercel/resource_attack_challenge_mode_test.go
@@ -12,11 +12,10 @@ import (
 func TestAcc_AttackChallengeModeResource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAttackChallengeModeConfigResource(name, teamIDConfig()),
+				Config: testAccAttackChallengeModeConfigResource(name, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("vercel_attack_challenge_mode.enabled", "enabled", "true"),
 					resource.TestCheckResourceAttr("vercel_attack_challenge_mode.disabled", "enabled", "false"),
@@ -45,7 +44,7 @@ func TestAcc_AttackChallengeModeResource(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccAttackChallengeModeConfigResourceUpdated(name, teamIDConfig()),
+				Config: testAccAttackChallengeModeConfigResourceUpdated(name, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("vercel_attack_challenge_mode.enabled", "enabled", "false"),
 				),

--- a/vercel/resource_custom_environment_test.go
+++ b/vercel/resource_custom_environment_test.go
@@ -105,7 +105,7 @@ func getCustomEnvImportID(n string) resource.ImportStateIdFunc {
 	}
 }
 
-func testAccCustomEnvironment(projectSuffix string, teamIdConfig string) string {
+func testAccCustomEnvironment(projectSuffix string, teamIDConfig string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "test-acc-custom-env-%[1]s"
@@ -152,7 +152,7 @@ resource "vercel_custom_environment" "test_bt" {
 `, projectSuffix, teamIDConfig)
 }
 
-func testAccCustomEnvironmentUpdated(projectSuffix string, teamIdConfig string) string {
+func testAccCustomEnvironmentUpdated(projectSuffix string, teamIDConfig string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "test-acc-custom-env-%[1]s"

--- a/vercel/resource_dns_record_test.go
+++ b/vercel/resource_dns_record_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/vercel/terraform-provider-vercel/v2/client"
 )
 
-func testAccDNSRecordDestroy(n, teamID string) resource.TestCheckFunc {
+func testAccDNSRecordDestroy(testClient *client.Client, n, teamID string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -22,7 +22,7 @@ func testAccDNSRecordDestroy(n, teamID string) resource.TestCheckFunc {
 			return fmt.Errorf("no ID is set")
 		}
 
-		_, err := testClient().GetDNSRecord(context.TODO(), rs.Primary.ID, teamID)
+		_, err := testClient.GetDNSRecord(context.TODO(), rs.Primary.ID, teamID)
 
 		if err == nil {
 			return fmt.Errorf("Found project but expected it to have been deleted")
@@ -35,7 +35,7 @@ func testAccDNSRecordDestroy(n, teamID string) resource.TestCheckFunc {
 	}
 }
 
-func testAccDNSRecordExists(n, teamID string) resource.TestCheckFunc {
+func testAccDNSRecordExists(testClient *client.Client, n, teamID string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -46,7 +46,7 @@ func testAccDNSRecordExists(n, teamID string) resource.TestCheckFunc {
 			return fmt.Errorf("no ID is set")
 		}
 
-		_, err := testClient().GetDNSRecord(context.TODO(), rs.Primary.ID, teamID)
+		_, err := testClient.GetDNSRecord(context.TODO(), rs.Primary.ID, teamID)
 		return err
 	}
 }
@@ -55,68 +55,67 @@ func TestAcc_DNSRecord(t *testing.T) {
 	t.Skip("Skipping until i have a domain in a suitable location to test with")
 	nameSuffix := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccDNSRecordDestroy("vercel_dns_record.a_without_ttl", testTeam()),
-			testAccDNSRecordDestroy("vercel_dns_record.a", testTeam()),
-			testAccDNSRecordDestroy("vercel_dns_record.aaaa", testTeam()),
-			testAccDNSRecordDestroy("vercel_dns_record.alias", testTeam()),
-			testAccDNSRecordDestroy("vercel_dns_record.caa", testTeam()),
-			testAccDNSRecordDestroy("vercel_dns_record.cname", testTeam()),
-			testAccDNSRecordDestroy("vercel_dns_record.mx", testTeam()),
-			testAccDNSRecordDestroy("vercel_dns_record.srv", testTeam()),
-			testAccDNSRecordDestroy("vercel_dns_record.txt", testTeam()),
+			testAccDNSRecordDestroy(testClient(t), "vercel_dns_record.a_without_ttl", testTeam(t)),
+			testAccDNSRecordDestroy(testClient(t), "vercel_dns_record.a", testTeam(t)),
+			testAccDNSRecordDestroy(testClient(t), "vercel_dns_record.aaaa", testTeam(t)),
+			testAccDNSRecordDestroy(testClient(t), "vercel_dns_record.alias", testTeam(t)),
+			testAccDNSRecordDestroy(testClient(t), "vercel_dns_record.caa", testTeam(t)),
+			testAccDNSRecordDestroy(testClient(t), "vercel_dns_record.cname", testTeam(t)),
+			testAccDNSRecordDestroy(testClient(t), "vercel_dns_record.mx", testTeam(t)),
+			testAccDNSRecordDestroy(testClient(t), "vercel_dns_record.srv", testTeam(t)),
+			testAccDNSRecordDestroy(testClient(t), "vercel_dns_record.txt", testTeam(t)),
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSRecordConfig(testDomain(), nameSuffix, teamIDConfig()),
+				Config: testAccDNSRecordConfig(testDomain(t), nameSuffix, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccDNSRecordExists("vercel_dns_record.a_without_ttl", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.a_without_ttl", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.a_without_ttl", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.a_without_ttl", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.a_without_ttl", "type", "A"),
 					resource.TestCheckResourceAttr("vercel_dns_record.a_without_ttl", "ttl", "60"),
 					resource.TestCheckResourceAttr("vercel_dns_record.a_without_ttl", "value", "127.0.0.1"),
 					resource.TestCheckResourceAttr("vercel_dns_record.a_without_ttl", "comment", "a without ttl"),
-					testAccDNSRecordExists("vercel_dns_record.a", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.a", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.a", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.a", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.a", "type", "A"),
 					resource.TestCheckResourceAttr("vercel_dns_record.a", "ttl", "120"),
 					resource.TestCheckResourceAttr("vercel_dns_record.a", "value", "127.0.0.1"),
 					resource.TestCheckResourceAttr("vercel_dns_record.a", "comment", "a"),
-					testAccDNSRecordExists("vercel_dns_record.aaaa", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.aaaa", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.aaaa", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.aaaa", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.aaaa", "type", "AAAA"),
 					resource.TestCheckResourceAttr("vercel_dns_record.aaaa", "ttl", "120"),
 					resource.TestCheckResourceAttr("vercel_dns_record.aaaa", "value", "::1"),
 					resource.TestCheckResourceAttr("vercel_dns_record.aaaa", "comment", "aaaa"),
-					testAccDNSRecordExists("vercel_dns_record.alias", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.alias", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.alias", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.alias", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.alias", "type", "ALIAS"),
 					resource.TestCheckResourceAttr("vercel_dns_record.alias", "ttl", "120"),
 					resource.TestCheckResourceAttr("vercel_dns_record.alias", "value", "example.com."),
 					resource.TestCheckResourceAttr("vercel_dns_record.alias", "comment", "alias"),
-					testAccDNSRecordExists("vercel_dns_record.caa", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.caa", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.caa", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.caa", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.caa", "type", "CAA"),
 					resource.TestCheckResourceAttr("vercel_dns_record.caa", "ttl", "120"),
 					resource.TestCheckResourceAttr("vercel_dns_record.caa", "value", "0 issue \"letsencrypt.org\""),
 					resource.TestCheckResourceAttr("vercel_dns_record.caa", "comment", "caa"),
-					testAccDNSRecordExists("vercel_dns_record.cname", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.cname", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.cname", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.cname", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.cname", "type", "CNAME"),
 					resource.TestCheckResourceAttr("vercel_dns_record.cname", "ttl", "120"),
 					resource.TestCheckResourceAttr("vercel_dns_record.cname", "value", "example.com."),
 					resource.TestCheckResourceAttr("vercel_dns_record.cname", "comment", "cname"),
-					testAccDNSRecordExists("vercel_dns_record.mx", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.mx", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.mx", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.mx", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.mx", "type", "MX"),
 					resource.TestCheckResourceAttr("vercel_dns_record.mx", "ttl", "120"),
 					resource.TestCheckResourceAttr("vercel_dns_record.mx", "mx_priority", "123"),
 					resource.TestCheckResourceAttr("vercel_dns_record.mx", "value", "example.com."),
 					resource.TestCheckResourceAttr("vercel_dns_record.mx", "comment", "mx"),
-					testAccDNSRecordExists("vercel_dns_record.srv", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.srv", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.srv", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.srv", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv", "type", "SRV"),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv", "ttl", "120"),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv", "srv.port", "5000"),
@@ -124,22 +123,22 @@ func TestAcc_DNSRecord(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_dns_record.srv", "srv.priority", "27"),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv", "srv.target", "example.com."),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv", "comment", "srv"),
-					testAccDNSRecordExists("vercel_dns_record.srv_no_target", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.srv_no_target", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.srv_no_target", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.srv_no_target", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv_no_target", "type", "SRV"),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv_no_target", "ttl", "120"),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv_no_target", "srv.port", "5000"),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv_no_target", "srv.weight", "120"),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv_no_target", "srv.priority", "27"),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv_no_target", "comment", "srv no target"),
-					testAccDNSRecordExists("vercel_dns_record.txt", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.txt", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.txt", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.txt", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.txt", "type", "TXT"),
 					resource.TestCheckResourceAttr("vercel_dns_record.txt", "ttl", "120"),
 					resource.TestCheckResourceAttr("vercel_dns_record.txt", "value", "terraform testing"),
 					resource.TestCheckResourceAttr("vercel_dns_record.txt", "comment", "txt"),
-					testAccDNSRecordExists("vercel_dns_record.ns", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.ns", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.ns", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.ns", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.ns", "type", "NS"),
 					resource.TestCheckResourceAttr("vercel_dns_record.ns", "ttl", "120"),
 					resource.TestCheckResourceAttr("vercel_dns_record.ns", "value", "example.com."),
@@ -147,58 +146,58 @@ func TestAcc_DNSRecord(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDNSRecordConfigUpdated(testDomain(), nameSuffix, teamIDConfig()),
+				Config: testAccDNSRecordConfigUpdated(testDomain(t), nameSuffix, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccDNSRecordExists("vercel_dns_record.a_without_ttl", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.a_without_ttl", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.a_without_ttl", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.a_without_ttl", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.a_without_ttl", "type", "A"),
 					resource.TestCheckResourceAttr("vercel_dns_record.a_without_ttl", "value", "127.0.0.1"),
-					testAccDNSRecordExists("vercel_dns_record.a", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.a", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.a", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.a", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.a", "type", "A"),
 					resource.TestCheckResourceAttr("vercel_dns_record.a", "ttl", "60"),
 					resource.TestCheckResourceAttr("vercel_dns_record.a", "value", "192.168.0.1"),
-					testAccDNSRecordExists("vercel_dns_record.aaaa", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.aaaa", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.aaaa", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.aaaa", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.aaaa", "type", "AAAA"),
 					resource.TestCheckResourceAttr("vercel_dns_record.aaaa", "ttl", "60"),
 					resource.TestCheckResourceAttr("vercel_dns_record.aaaa", "value", "::0"),
-					testAccDNSRecordExists("vercel_dns_record.alias", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.alias", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.alias", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.alias", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.alias", "type", "ALIAS"),
 					resource.TestCheckResourceAttr("vercel_dns_record.alias", "ttl", "60"),
 					resource.TestCheckResourceAttr("vercel_dns_record.alias", "value", "example2.com."),
-					testAccDNSRecordExists("vercel_dns_record.caa", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.caa", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.caa", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.caa", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.caa", "type", "CAA"),
 					resource.TestCheckResourceAttr("vercel_dns_record.caa", "ttl", "60"),
 					resource.TestCheckResourceAttr("vercel_dns_record.caa", "value", "1 issue \"letsencrypt.org\""),
-					testAccDNSRecordExists("vercel_dns_record.cname", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.cname", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.cname", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.cname", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.cname", "type", "CNAME"),
 					resource.TestCheckResourceAttr("vercel_dns_record.cname", "ttl", "60"),
 					resource.TestCheckResourceAttr("vercel_dns_record.cname", "value", "example2.com."),
-					testAccDNSRecordExists("vercel_dns_record.mx", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.mx", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.mx", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.mx", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.mx", "type", "MX"),
 					resource.TestCheckResourceAttr("vercel_dns_record.mx", "ttl", "60"),
 					resource.TestCheckResourceAttr("vercel_dns_record.mx", "mx_priority", "333"),
 					resource.TestCheckResourceAttr("vercel_dns_record.mx", "value", "example2.com."),
-					testAccDNSRecordExists("vercel_dns_record.srv", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.srv", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.srv", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.srv", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv", "type", "SRV"),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv", "ttl", "60"),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv", "srv.port", "6000"),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv", "srv.weight", "60"),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv", "srv.priority", "127"),
 					resource.TestCheckResourceAttr("vercel_dns_record.srv", "srv.target", "example2.com."),
-					testAccDNSRecordExists("vercel_dns_record.txt", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.txt", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.txt", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.txt", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.txt", "type", "TXT"),
 					resource.TestCheckResourceAttr("vercel_dns_record.txt", "ttl", "60"),
 					resource.TestCheckResourceAttr("vercel_dns_record.txt", "value", "terraform testing two"),
-					testAccDNSRecordExists("vercel_dns_record.ns", testTeam()),
-					resource.TestCheckResourceAttr("vercel_dns_record.ns", "domain", testDomain()),
+					testAccDNSRecordExists(testClient(t), "vercel_dns_record.ns", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_dns_record.ns", "domain", testDomain(t)),
 					resource.TestCheckResourceAttr("vercel_dns_record.ns", "type", "NS"),
 					resource.TestCheckResourceAttr("vercel_dns_record.ns", "ttl", "60"),
 					resource.TestCheckResourceAttr("vercel_dns_record.ns", "value", "example2.com."),

--- a/vercel/resource_firewall_bypass_test.go
+++ b/vercel/resource_firewall_bypass_test.go
@@ -13,11 +13,10 @@ import (
 func TestAcc_FirewallBypassResource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirewallBypassConfigResource(name, teamIDConfig()),
+				Config: testAccFirewallBypassConfigResource(name, teamIDConfig(t), testGithubRepo(&testing.T{})),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("vercel_firewall_bypass.bypass_one", "domain", "test-acc-domain-"+name+".vercel.app"),
 					resource.TestCheckResourceAttr("vercel_firewall_bypass.bypass_some", "domain", "*"),
@@ -60,7 +59,7 @@ func TestAcc_FirewallBypassResource(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccFirewallBypassConfigResourceUpdated(name, teamIDConfig()),
+				Config: testAccFirewallBypassConfigResourceUpdated(name, teamIDConfig(t), testGithubRepo(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("vercel_firewall_bypass.bypass_one", "source_ip", "0.0.0.0/0"),
 					resource.TestCheckResourceAttrWith("vercel_firewall_bypass.bypass_one", "id", func(id string) error {
@@ -75,7 +74,7 @@ func TestAcc_FirewallBypassResource(t *testing.T) {
 	})
 }
 
-func testAccFirewallBypassConfigResource(name, teamID string) string {
+func testAccFirewallBypassConfigResource(name, teamID string, githubRepo string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "bypass_project" {
   name = "test-acc-%[1]s-enabled"
@@ -110,10 +109,10 @@ resource "vercel_firewall_bypass" "bypass_some" {
   depends_on = [vercel_project_domain.test]
 }
 
-`, name, teamID, testGithubRepo())
+`, name, teamID, githubRepo)
 }
 
-func testAccFirewallBypassConfigResourceUpdated(name, teamID string) string {
+func testAccFirewallBypassConfigResourceUpdated(name, teamID string, githubRepo string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "bypass_project" {
   name = "test-acc-%[1]s-enabled"
@@ -139,5 +138,5 @@ resource "vercel_firewall_bypass" "bypass_one" {
   depends_on = [vercel_project_domain.test]
 }
 
-`, name, teamID, testGithubRepo())
+`, name, teamID, githubRepo)
 }

--- a/vercel/resource_firewall_config_test.go
+++ b/vercel/resource_firewall_config_test.go
@@ -31,11 +31,10 @@ func getFirewallImportID(n string) resource.ImportStateIdFunc {
 func TestAcc_FirewallConfigResource(t *testing.T) {
 	name := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirewallConfigResource(name, teamIDConfig()),
+				Config: testAccFirewallConfigResource(name, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"vercel_firewall_config.managed",
@@ -188,7 +187,7 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 				ImportStateIdFunc: getFirewallImportID("vercel_firewall_config.ips"),
 			},
 			{
-				Config: testAccFirewallConfigResourceUpdated(name, teamIDConfig()),
+				Config: testAccFirewallConfigResourceUpdated(name, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"vercel_firewall_config.managed",

--- a/vercel/resource_project_domain_test.go
+++ b/vercel/resource_project_domain_test.go
@@ -224,7 +224,7 @@ resource "vercel_project" "test" {
 `, projectSuffix, extra)
 }
 
-func testAccProjectDomainConfigWithCustomEnvironment(randomSuffix string, teamIdConfig string) string {
+func testAccProjectDomainConfigWithCustomEnvironment(randomSuffix string, teamIDConfig string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "test-acc-domain-%[1]s"
@@ -246,7 +246,7 @@ resource "vercel_project_domain" "test" {
 `, randomSuffix, teamIDConfig)
 }
 
-func testAccProjectDomainConfigWithCustomEnvironmentAndGitBranch(randomSuffix string, teamIdConfig string, githubRepo string) string {
+func testAccProjectDomainConfigWithCustomEnvironmentAndGitBranch(randomSuffix string, teamIDConfig string, githubRepo string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "test-acc-domain-%[1]s"
@@ -270,5 +270,5 @@ resource "vercel_project_domain" "test" {
     git_branch = "staging"
     %[2]s
 }
-`, randomSuffix, teamIdConfig, githubRepo)
+`, randomSuffix, teamIDConfig, githubRepo)
 }

--- a/vercel/resource_project_environment_variables_test.go
+++ b/vercel/resource_project_environment_variables_test.go
@@ -13,14 +13,13 @@ func TestAcc_ProjectEnvironmentVariables(t *testing.T) {
 	resourceName := "vercel_project_environment_variables.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccProjectDestroy("vercel_project.test", testTeam()),
+			testAccProjectDestroy(testClient(t), "vercel_project.test", testTeam(t)),
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectEnvironmentVariablesConfig(projectName),
+				Config: testAccProjectEnvironmentVariablesConfig(projectName, teamIDConfig(t), testGithubRepo(t)),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "variables.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "variables.*", map[string]string{
@@ -37,7 +36,7 @@ func TestAcc_ProjectEnvironmentVariables(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccProjectEnvironmentVariablesConfigUpdated(projectName),
+				Config: testAccProjectEnvironmentVariablesConfigUpdated(projectName, teamIDConfig(t), testGithubRepo(t)),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "variables.#", "4"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "variables.*", map[string]string{
@@ -66,7 +65,7 @@ func TestAcc_ProjectEnvironmentVariables(t *testing.T) {
 	})
 }
 
-func testAccProjectEnvironmentVariablesConfig(projectName string) string {
+func testAccProjectEnvironmentVariablesConfig(projectName string, teamIDConfig string, githubRepo string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "%s"
@@ -95,10 +94,10 @@ resource "vercel_project_environment_variables" "test" {
     }
   ]
 }
-`, projectName, teamIDConfig(), testGithubRepo())
+`, projectName, teamIDConfig, githubRepo)
 }
 
-func testAccProjectEnvironmentVariablesConfigUpdated(projectName string) string {
+func testAccProjectEnvironmentVariablesConfigUpdated(projectName string, teamIDConfig string, githubRepo string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "%s"
@@ -137,5 +136,5 @@ resource "vercel_project_environment_variables" "test" {
     }
   ]
 }
-`, projectName, teamIDConfig(), testGithubRepo())
+`, projectName, teamIDConfig, githubRepo)
 }

--- a/vercel/resource_project_members_test.go
+++ b/vercel/resource_project_members_test.go
@@ -11,26 +11,25 @@ import (
 func TestAcc_ProjectMembers(t *testing.T) {
 	projectSuffix := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:             testAccProjectDestroy("vercel_project.test", testTeam()),
+		CheckDestroy:             testAccProjectDestroy(testClient(t), "vercel_project.test", testTeam(t)),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectMembersConfig(projectSuffix),
+				Config: testAccProjectMembersConfig(projectSuffix, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vercel_project_members.test", "project_id"),
 					resource.TestCheckResourceAttr("vercel_project_members.test", "members.#", "1"),
 				),
 			},
 			{
-				Config: testAccProjectMembersConfigUpdated(projectSuffix),
+				Config: testAccProjectMembersConfigUpdated(projectSuffix, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vercel_project_members.test", "project_id"),
 					resource.TestCheckResourceAttr("vercel_project_members.test", "members.#", "2"),
 				),
 			},
 			{
-				Config: testAccProjectMembersConfigUpdatedAgain(projectSuffix),
+				Config: testAccProjectMembersConfigUpdatedAgain(projectSuffix, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vercel_project_members.test", "project_id"),
 					resource.TestCheckResourceAttr("vercel_project_members.test", "members.#", "1"),
@@ -40,7 +39,7 @@ func TestAcc_ProjectMembers(t *testing.T) {
 	})
 }
 
-func testAccProjectMembersConfig(projectSuffix string) string {
+func testAccProjectMembersConfig(projectSuffix string, teamIDConfig string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "test-acc-project-members-%[1]s"
@@ -56,10 +55,10 @@ resource "vercel_project_members" "test" {
     role  = "PROJECT_VIEWER"
   }]
 }
-`, projectSuffix, teamIDConfig())
+`, projectSuffix, teamIDConfig)
 }
 
-func testAccProjectMembersConfigUpdated(projectSuffix string) string {
+func testAccProjectMembersConfigUpdated(projectSuffix string, teamIDConfig string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "test-acc-project-members-%[1]s"
@@ -80,10 +79,10 @@ resource "vercel_project_members" "test" {
     }
   ]
 }
-`, projectSuffix, teamIDConfig())
+`, projectSuffix, teamIDConfig)
 }
 
-func testAccProjectMembersConfigUpdatedAgain(projectSuffix string) string {
+func testAccProjectMembersConfigUpdatedAgain(projectSuffix string, teamIDConfig string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "test-acc-project-members-%[1]s"
@@ -101,5 +100,5 @@ resource "vercel_project_members" "test" {
     }
   ]
 }
-`, projectSuffix, teamIDConfig())
+`, projectSuffix, teamIDConfig)
 }

--- a/vercel/resource_shared_environment_variable_test.go
+++ b/vercel/resource_shared_environment_variable_test.go
@@ -8,9 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/vercel/terraform-provider-vercel/v2/client"
 )
 
-func testAccSharedEnvironmentVariableExists(n, teamID string) resource.TestCheckFunc {
+func testAccSharedEnvironmentVariableExists(testClient *client.Client, n, teamID string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -21,7 +22,7 @@ func testAccSharedEnvironmentVariableExists(n, teamID string) resource.TestCheck
 			return fmt.Errorf("no ID is set")
 		}
 
-		_, err := testClient().GetSharedEnvironmentVariable(context.TODO(), teamID, rs.Primary.ID)
+		_, err := testClient.GetSharedEnvironmentVariable(context.TODO(), teamID, rs.Primary.ID)
 		return err
 	}
 }
@@ -29,28 +30,27 @@ func testAccSharedEnvironmentVariableExists(n, teamID string) resource.TestCheck
 func TestAcc_SharedEnvironmentVariables(t *testing.T) {
 	nameSuffix := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccProjectDestroy("vercel_project.example", testTeam()),
+			testAccProjectDestroy(testClient(t), "vercel_project.example", testTeam(t)),
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSharedEnvironmentVariablesConfig(nameSuffix),
+				Config: testAccSharedEnvironmentVariablesConfig(nameSuffix, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccSharedEnvironmentVariableExists("vercel_shared_environment_variable.example", testTeam()),
+					testAccSharedEnvironmentVariableExists(testClient(t), "vercel_shared_environment_variable.example", testTeam(t)),
 					resource.TestCheckResourceAttr("vercel_shared_environment_variable.example", "key", fmt.Sprintf("test_acc_foo_%s", nameSuffix)),
 					resource.TestCheckResourceAttr("vercel_shared_environment_variable.example", "value", "bar"),
 					resource.TestCheckResourceAttr("vercel_shared_environment_variable.example", "comment", "Test comment for example"),
 					resource.TestCheckTypeSetElemAttr("vercel_shared_environment_variable.example", "target.*", "production"),
 
-					testAccSharedEnvironmentVariableExists("vercel_shared_environment_variable.sensitive_example", testTeam()),
+					testAccSharedEnvironmentVariableExists(testClient(t), "vercel_shared_environment_variable.sensitive_example", testTeam(t)),
 					resource.TestCheckResourceAttr("vercel_shared_environment_variable.sensitive_example", "key", fmt.Sprintf("test_acc_foo_sensitive_%s", nameSuffix)),
 					resource.TestCheckResourceAttr("vercel_shared_environment_variable.sensitive_example", "value", "bar"),
 					resource.TestCheckResourceAttr("vercel_shared_environment_variable.sensitive_example", "comment", "Test comment for sensitive example"),
 					resource.TestCheckTypeSetElemAttr("vercel_shared_environment_variable.sensitive_example", "target.*", "production"),
 
-					testAccSharedEnvironmentVariableExists("vercel_shared_environment_variable.no_comment_example", testTeam()),
+					testAccSharedEnvironmentVariableExists(testClient(t), "vercel_shared_environment_variable.no_comment_example", testTeam(t)),
 					resource.TestCheckResourceAttr("vercel_shared_environment_variable.no_comment_example", "key", fmt.Sprintf("test_acc_foo_no_comment_%s", nameSuffix)),
 					resource.TestCheckResourceAttr("vercel_shared_environment_variable.no_comment_example", "value", "baz"),
 					resource.TestCheckResourceAttr("vercel_shared_environment_variable.no_comment_example", "comment", ""),
@@ -58,9 +58,9 @@ func TestAcc_SharedEnvironmentVariables(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSharedEnvironmentVariablesConfigUpdated(nameSuffix),
+				Config: testAccSharedEnvironmentVariablesConfigUpdated(nameSuffix, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccSharedEnvironmentVariableExists("vercel_shared_environment_variable.example", testTeam()),
+					testAccSharedEnvironmentVariableExists(testClient(t), "vercel_shared_environment_variable.example", testTeam(t)),
 					resource.TestCheckResourceAttr("vercel_shared_environment_variable.example", "key", fmt.Sprintf("test_acc_foo_%s", nameSuffix)),
 					resource.TestCheckResourceAttr("vercel_shared_environment_variable.example", "value", "updated-bar"),
 					resource.TestCheckTypeSetElemAttr("vercel_shared_environment_variable.example", "target.*", "development"),
@@ -78,7 +78,7 @@ func TestAcc_SharedEnvironmentVariables(t *testing.T) {
 				ImportStateIdFunc: getSharedEnvironmentVariableImportID("vercel_shared_environment_variable.example"),
 			},
 			{
-				Config: testAccSharedEnvironmentVariablesConfigDeleted(nameSuffix),
+				Config: testAccSharedEnvironmentVariablesConfigDeleted(nameSuffix, teamIDConfig(t)),
 			},
 		},
 	})
@@ -99,7 +99,7 @@ func getSharedEnvironmentVariableImportID(n string) resource.ImportStateIdFunc {
 	}
 }
 
-func testAccSharedEnvironmentVariablesConfig(projectName string) string {
+func testAccSharedEnvironmentVariablesConfig(projectName string, teamIDConfig string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "example" {
 	name = "test-acc-example-project-%[1]s"
@@ -138,10 +138,10 @@ resource "vercel_shared_environment_variable" "no_comment_example" {
         vercel_project.example.id
     ]
 }
-`, projectName, teamIDConfig())
+`, projectName, teamIDConfig)
 }
 
-func testAccSharedEnvironmentVariablesConfigUpdated(projectName string) string {
+func testAccSharedEnvironmentVariablesConfigUpdated(projectName string, teamIDConfig string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "example" {
 	name = "test-acc-example-project-%[1]s"
@@ -175,10 +175,10 @@ resource "vercel_shared_environment_variable" "sensitive_example" {
         vercel_project.example2.id
     ]
 }
-`, projectName, teamIDConfig())
+`, projectName, teamIDConfig)
 }
 
-func testAccSharedEnvironmentVariablesConfigDeleted(projectName string) string {
+func testAccSharedEnvironmentVariablesConfigDeleted(projectName string, teamIDConfig string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "example" {
 	name = "test-acc-example-project-%[1]s"
@@ -189,5 +189,5 @@ resource "vercel_project" "example2" {
 	name = "test-acc-example-project-2-%[1]s"
 	%[2]s
 }
-    `, projectName, teamIDConfig())
+    `, projectName, teamIDConfig)
 }

--- a/vercel/resource_team_config_test.go
+++ b/vercel/resource_team_config_test.go
@@ -11,11 +11,10 @@ func TestAcc_TeamConfig(t *testing.T) {
 	resourceName := "vercel_team_config.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccVercelTeamConfigBasic(testTeam()),
+				Config: testAccVercelTeamConfigBasic(testTeam(t)),
 				// Added since vercel_team_config schema version upgraded
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -25,7 +24,7 @@ func TestAcc_TeamConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccVercelTeamConfigUpdated(testTeam()),
+				Config: testAccVercelTeamConfigUpdated(testTeam(t)),
 				// Added since vercel_team_config schema version upgraded
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/vercel/resource_team_member_test.go
+++ b/vercel/resource_team_member_test.go
@@ -23,12 +23,11 @@ func getTeamMemberImportID(n string) resource.ImportStateIdFunc {
 func TestAcc_TeamMemberResource(t *testing.T) {
 	randomSuffix := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccTeamMemberResourceConfig("MEMBER"),
+				Config: testAccTeamMemberResourceConfig("MEMBER", teamIDConfig(t), testAdditionalUser(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vercel_team_member.test", "team_id"),
 					resource.TestCheckResourceAttrSet("vercel_team_member.test", "user_id"),
@@ -45,7 +44,7 @@ func TestAcc_TeamMemberResource(t *testing.T) {
 			},
 			// Update testing
 			{
-				Config: testAccTeamMemberResourceConfig("VIEWER"),
+				Config: testAccTeamMemberResourceConfig("VIEWER", teamIDConfig(t), testAdditionalUser(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vercel_team_member.test", "team_id"),
 					resource.TestCheckResourceAttrSet("vercel_team_member.test", "user_id"),
@@ -54,7 +53,7 @@ func TestAcc_TeamMemberResource(t *testing.T) {
 			},
 			// Test with projects
 			{
-				Config: testAccTeamMemberResourceConfigWithProjects(randomSuffix),
+				Config: testAccTeamMemberResourceConfigWithProjects(randomSuffix, teamIDConfig(t), testAdditionalUser(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vercel_team_member.test", "team_id"),
 					resource.TestCheckResourceAttrSet("vercel_team_member.test", "user_id"),
@@ -64,7 +63,7 @@ func TestAcc_TeamMemberResource(t *testing.T) {
 			},
 			// Test with access groups
 			{
-				Config: testAccTeamMemberResourceConfigWithAccessGroups(randomSuffix),
+				Config: testAccTeamMemberResourceConfigWithAccessGroups(randomSuffix, teamIDConfig(t), testAdditionalUser(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vercel_team_member.test", "team_id"),
 					resource.TestCheckResourceAttrSet("vercel_team_member.test", "user_id"),
@@ -76,17 +75,17 @@ func TestAcc_TeamMemberResource(t *testing.T) {
 	})
 }
 
-func testAccTeamMemberResourceConfig(role string) string {
+func testAccTeamMemberResourceConfig(role string, teamIDConfig string, user string) string {
 	return fmt.Sprintf(`
 resource "vercel_team_member" "test" {
   %[1]s
   user_id = "%s"
   role    = "%s"
 }
-`, teamIDConfig(), testAdditionalUser(), role)
+`, teamIDConfig, user, role)
 }
 
-func testAccTeamMemberResourceConfigWithProjects(randomSuffix string) string {
+func testAccTeamMemberResourceConfigWithProjects(randomSuffix string, teamIDConfig string, user string) string {
 	return fmt.Sprintf(`
 resource "vercel_project" "test" {
   name = "test-acc-example-project-%[1]s"
@@ -102,10 +101,10 @@ resource "vercel_team_member" "test" {
     role       = "PROJECT_VIEWER"
   }]
 }
-`, randomSuffix, teamIDConfig(), testAdditionalUser())
+`, randomSuffix, teamIDConfig, user)
 }
 
-func testAccTeamMemberResourceConfigWithAccessGroups(randomSuffix string) string {
+func testAccTeamMemberResourceConfigWithAccessGroups(randomSuffix string, teamIDConfig string, user string) string {
 	return fmt.Sprintf(`
 resource "vercel_access_group" "test" {
     %[1]s
@@ -119,5 +118,5 @@ resource "vercel_team_member" "test" {
 
   access_groups = [vercel_access_group.test.id]
 }
-`, teamIDConfig(), testAdditionalUser(), randomSuffix)
+`, teamIDConfig, user, randomSuffix)
 }


### PR DESCRIPTION
At the moment, all env vars are required to run any test. This means running an individual test requires all env vars (which is annoying). This PR updates the code so that env vars only throw an error when they are used

This change also revealed that `VERCEL_TERRAFORM_TESTING_GITLAB_REPO` is unused