### PR TITLE
Add support for Vercel Toolbar settings at project level

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -59,6 +59,8 @@ type CreateProjectRequest struct {
 	RootDirectory                     *string               `json:"rootDirectory"`
 	ServerlessFunctionRegion          string                `json:"serverlessFunctionRegion,omitempty"`
 	ResourceConfig                    *ResourceConfig       `json:"resourceConfig,omitempty"`
+	EnablePreviewFeedback             *bool                 `json:"enablePreviewFeedback,omitempty"`
+	EnableProductionFeedback          *bool                 `json:"enableProductionFeedback,omitempty"`
 }
 
 // CreateProject will create a project within Vercel.
@@ -192,6 +194,7 @@ type ProjectResponse struct {
 	ProtectionBypass                     map[string]ProtectionBypass `json:"protectionBypass"`
 	AutoExposeSystemEnvVars              *bool                       `json:"autoExposeSystemEnvs"`
 	EnablePreviewFeedback                *bool                       `json:"enablePreviewFeedback"`
+	EnableProductionFeedback             *bool                       `json:"enableProductionFeedback"`
 	EnableAffectedProjectsDeployments    *bool                       `json:"enableAffectedProjectsDeployments"`
 	AutoAssignCustomDomains              bool                        `json:"autoAssignCustomDomains"`
 	GitLFS                               bool                        `json:"gitLFS"`
@@ -301,6 +304,7 @@ type UpdateProjectRequest struct {
 	OptionsAllowlist                     *OptionsAllowlist               `json:"optionsAllowlist"`
 	AutoExposeSystemEnvVars              bool                            `json:"autoExposeSystemEnvs"`
 	EnablePreviewFeedback                *bool                           `json:"enablePreviewFeedback"`
+	EnableProductionFeedback             *bool                           `json:"enableProductionFeedback"`
 	EnableAffectedProjectsDeployments    *bool                           `json:"enableAffectedProjectsDeployments,omitempty"`
 	AutoAssignCustomDomains              bool                            `json:"autoAssignCustomDomains"`
 	GitLFS                               bool                            `json:"gitLFS"`

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -44,6 +44,8 @@ data "vercel_project" "example" {
 - `dev_command` (String) The dev command for this project. If omitted, this value will be automatically detected.
 - `directory_listing` (Boolean) If no index file is present within a directory, the directory contents will be displayed.
 - `enable_affected_projects_deployments` (Boolean) When enabled, Vercel will automatically deploy all projects that are affected by a change to this project.
+- `enable_preview_feedback` (Boolean) Whether the Vercel Toolbar is enabled on your preview deployments. If unspecified, defaults to team setting.
+- `enable_production_feedback` (Boolean) Whether the Vercel Toolbar is enabled on your production deployments. If unspecified, defaults to team setting.
 - `environment` (Attributes Set) A list of environment variables that should be configured for the project. (see [below for nested schema](#nestedatt--environment))
 - `framework` (String) The framework that is being used for this project. If omitted, no framework is selected.
 - `function_failover` (Boolean) Automatically failover Serverless Functions to the nearest region. You can customize regions through vercel.json. A new Deployment is required for your changes to take effect.
@@ -59,7 +61,7 @@ data "vercel_project" "example" {
 - `options_allowlist` (Attributes) Disable Deployment Protection for CORS preflight `OPTIONS` requests for a list of paths. (see [below for nested schema](#nestedatt--options_allowlist))
 - `output_directory` (String) The output directory of the project. When null is used this value will be automatically detected.
 - `password_protection` (Attributes) Ensures visitors of your Preview Deployments must enter a password in order to gain access. (see [below for nested schema](#nestedatt--password_protection))
-- `preview_comments` (Boolean) Whether comments are enabled on your Preview Deployments.
+- `preview_comments` (Boolean, Deprecated) Whether comments are enabled on your Preview Deployments.
 - `prioritise_production_builds` (Boolean) If enabled, builds for the Production environment will be prioritized over Preview environments.
 - `protection_bypass_for_automation` (Boolean) Allows automation services to bypass Deployment Protection on this project when using an HTTP header named `x-vercel-protection-bypass` with the value from `protection_bypass_for_automation_secret`.
 - `protection_bypass_for_automation_secret` (String, Sensitive) If `protection_bypass_for_automation` is enabled, optionally set this value to specify a 32 character secret, otherwise a secret will be generated.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -62,6 +62,8 @@ resource "vercel_project" "example" {
 - `dev_command` (String) The dev command for this project. If omitted, this value will be automatically detected.
 - `directory_listing` (Boolean) If no index file is present within a directory, the directory contents will be displayed.
 - `enable_affected_projects_deployments` (Boolean) When enabled, Vercel will automatically deploy all projects that are affected by a change to this project.
+- `enable_preview_feedback` (Boolean) Enables the Vercel Toolbar on your preview deployments.
+- `enable_production_feedback` (Boolean) Enables the Vercel Toolbar on your production deployments: one of on, off or default.
 - `environment` (Attributes Set) A set of Environment Variables that should be configured for the project. (see [below for nested schema](#nestedatt--environment))
 - `framework` (String) The framework that is being used for this project. If omitted, no framework is selected.
 - `function_failover` (Boolean) Automatically failover Serverless Functions to the nearest region. You can customize regions through vercel.json. A new Deployment is required for your changes to take effect.
@@ -76,7 +78,7 @@ resource "vercel_project" "example" {
 - `options_allowlist` (Attributes) Disable Deployment Protection for CORS preflight `OPTIONS` requests for a list of paths. (see [below for nested schema](#nestedatt--options_allowlist))
 - `output_directory` (String) The output directory of the project. If omitted, this value will be automatically detected.
 - `password_protection` (Attributes) Ensures visitors of your Preview Deployments must enter a password in order to gain access. (see [below for nested schema](#nestedatt--password_protection))
-- `preview_comments` (Boolean) Whether to enable comments on your Preview Deployments. If omitted, comments are controlled at the team level (default behaviour).
+- `preview_comments` (Boolean, Deprecated) Enables the Vercel Toolbar on your preview deployments.
 - `prioritise_production_builds` (Boolean) If enabled, builds for the Production environment will be prioritized over Preview environments.
 - `protection_bypass_for_automation` (Boolean) Allow automation services to bypass Deployment Protection on this project when using an HTTP header named `x-vercel-protection-bypass` with a value of the `protection_bypass_for_automation_secret` field.
 - `protection_bypass_for_automation_secret` (String, Sensitive) If `protection_bypass_for_automation` is enabled, optionally set this value to specify a 32 character secret, otherwise a secret will be generated.

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -325,8 +325,17 @@ For more detailed information, please see the [Vercel documentation](https://ver
 				},
 			},
 			"preview_comments": schema.BoolAttribute{
+				Computed:           true,
+				DeprecationMessage: "Use `enable_preview_feedback` instead. This attribute will be removed in a future version.",
+				Description:        "Whether comments are enabled on your Preview Deployments.",
+			},
+			"enable_preview_feedback": schema.BoolAttribute{
 				Computed:    true,
-				Description: "Whether comments are enabled on your Preview Deployments.",
+				Description: "Whether the Vercel Toolbar is enabled on your preview deployments. If unspecified, defaults to team setting.",
+			},
+			"enable_production_feedback": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Whether the Vercel Toolbar is enabled on your production deployments. If unspecified, defaults to team setting.",
 			},
 			"auto_assign_custom_domains": schema.BoolAttribute{
 				Computed:    true,
@@ -409,6 +418,8 @@ type ProjectDataSource struct {
 	AutoExposeSystemEnvVars             types.Bool            `tfsdk:"automatically_expose_system_environment_variables"`
 	GitComments                         types.Object          `tfsdk:"git_comments"`
 	PreviewComments                     types.Bool            `tfsdk:"preview_comments"`
+	EnablePreviewFeedback               types.Bool            `tfsdk:"enable_preview_feedback"`
+	EnableProductionFeedback            types.Bool            `tfsdk:"enable_production_feedback"`
 	AutoAssignCustomDomains             types.Bool            `tfsdk:"auto_assign_custom_domains"`
 	GitLFS                              types.Bool            `tfsdk:"git_lfs"`
 	FunctionFailover                    types.Bool            `tfsdk:"function_failover"`
@@ -472,6 +483,8 @@ func convertResponseToProjectDataSource(ctx context.Context, response client.Pro
 		ProtectionBypassForAutomationSecret: project.ProtectionBypassForAutomationSecret,
 		GitComments:                         project.GitComments,
 		PreviewComments:                     project.PreviewComments,
+		EnablePreviewFeedback:               project.EnablePreviewFeedback,
+		EnableProductionFeedback:            project.EnableProductionFeedback,
 		AutoAssignCustomDomains:             project.AutoAssignCustomDomains,
 		GitLFS:                              project.GitLFS,
 		FunctionFailover:                    project.FunctionFailover,

--- a/vercel/data_source_project_test.go
+++ b/vercel/data_source_project_test.go
@@ -44,6 +44,8 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vercel_project.test", "git_comments.on_pull_request", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "git_comments.on_commit", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "preview_comments", "true"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "enable_preview_feedback", "true"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "enable_production_feedback", "false"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "auto_assign_custom_domains", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "git_lfs", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "function_failover", "true"),
@@ -109,7 +111,8 @@ resource "vercel_project" "test" {
       on_pull_request = true,
       on_commit = true
   }
-  preview_comments = true
+  enable_preview_feedback = true
+  enable_production_feedback = false
   auto_assign_custom_domains = true
   git_lfs = true
   function_failover = true

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -470,17 +470,15 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				DeprecationMessage: "Use `enable_preview_feedback` instead. This attribute will be removed in a future version.",
 				Optional:           true,
 				Computed:           true,
-				PlanModifiers:      []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
 				Validators: []validator.Bool{boolvalidator.ConflictsWith(
 					path.MatchRoot("preview_comments"),
 					path.MatchRoot("enable_preview_feedback"),
 				)},
 			},
 			"enable_preview_feedback": schema.BoolAttribute{
-				Description:   "Enables the Vercel Toolbar on your preview deployments.",
-				Optional:      true,
-				Computed:      true,
-				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+				Description: "Enables the Vercel Toolbar on your preview deployments.",
+				Optional:    true,
+				Computed:    true,
 				Validators: []validator.Bool{boolvalidator.ConflictsWith(
 					path.MatchRoot("preview_comments"),
 					path.MatchRoot("enable_preview_feedback"),

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -746,7 +746,7 @@ func (p *Project) toCreateProjectRequest(ctx context.Context, envs []Environment
 		RootDirectory:                     p.RootDirectory.ValueStringPointer(),
 		ServerlessFunctionRegion:          p.ServerlessFunctionRegion.ValueString(),
 		ResourceConfig:                    resourceConfig.toClientResourceConfig(),
-		EnablePreviewFeedback:             oneBoolPointer(p.EnablePreviewFeedback.ValueBoolPointer(), p.PreviewComments.ValueBoolPointer()),
+		EnablePreviewFeedback:             oneBoolPointer(p.EnablePreviewFeedback, p.PreviewComments),
 		EnableProductionFeedback:          p.EnableProductionFeedback.ValueBoolPointer(),
 	}, diags
 }
@@ -769,11 +769,14 @@ func toSkewProtectionAge(sp types.String) int {
 	return v
 }
 
-func oneBoolPointer(a, b *bool) *bool {
-	if a == nil {
-		return b
+func oneBoolPointer(a, b types.Bool) *bool {
+	if !a.IsNull() && !a.IsUnknown() {
+		return a.ValueBoolPointer()
 	}
-	return a
+	if !b.IsNull() && !b.IsUnknown() {
+		return b.ValueBoolPointer()
+	}
+	return nil
 }
 
 func (p *Project) toUpdateProjectRequest(ctx context.Context, oldName string) (req client.UpdateProjectRequest, diags diag.Diagnostics) {
@@ -811,7 +814,7 @@ func (p *Project) toUpdateProjectRequest(ctx context.Context, oldName string) (r
 		OIDCTokenConfig:                      p.OIDCTokenConfig.toUpdateProjectRequest(),
 		OptionsAllowlist:                     p.OptionsAllowlist.toUpdateProjectRequest(),
 		AutoExposeSystemEnvVars:              p.AutoExposeSystemEnvVars.ValueBool(),
-		EnablePreviewFeedback:                oneBoolPointer(p.EnablePreviewFeedback.ValueBoolPointer(), p.PreviewComments.ValueBoolPointer()),
+		EnablePreviewFeedback:                oneBoolPointer(p.EnablePreviewFeedback, p.PreviewComments),
 		EnableProductionFeedback:             p.EnableProductionFeedback.ValueBoolPointer(),
 		EnableAffectedProjectsDeployments:    p.EnableAffectedProjectsDeployments.ValueBoolPointer(),
 		AutoAssignCustomDomains:              p.AutoAssignCustomDomains.ValueBool(),

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -72,6 +72,8 @@ func TestAcc_Project(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_project.test", "git_comments.on_pull_request", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_comments.on_commit", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "preview_comments", "true"),
+					resource.TestCheckResourceAttr("vercel_project.test", "enable_preview_feedback", "true"),
+					resource.TestCheckResourceAttr("vercel_project.test", "enable_production_feedback", "false"),
 					resource.TestCheckResourceAttr("vercel_project.test", "auto_assign_custom_domains", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_lfs", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "function_failover", "true"),
@@ -97,6 +99,32 @@ func TestAcc_Project(t *testing.T) {
 						"value": "baz",
 					}),
 					resource.TestCheckResourceAttr("vercel_project.test", "oidc_token_config.enabled", "false"),
+					resource.TestCheckResourceAttr("vercel_project.test", "preview_comments", "false"),
+					resource.TestCheckResourceAttr("vercel_project.test", "enable_preview_feedback", "false"),
+					resource.TestCheckResourceAttr("vercel_project.test", "enable_production_feedback", "true"),
+				),
+			},
+			// Test mutual exclusivity validation
+			{
+				Config: testAccProjectConfigPreviewFeedbackConflict(projectSuffix, teamIDConfig(t)),
+				ExpectError: regexp.MustCompile(
+					strings.ReplaceAll("Attribute \"preview_comments\" cannot be specified when \"enable_preview_feedback\" is specified", " ", `\s*`),
+				),
+			},
+			// Test using only the deprecated field
+			{
+				Config: testAccProjectConfigPreviewCommentsOnly(projectSuffix, teamIDConfig(t)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("vercel_project.test", "preview_comments", "true"),
+					resource.TestCheckResourceAttr("vercel_project.test", "enable_preview_feedback", "true"),
+				),
+			},
+			// Test updating from deprecated field to new field
+			{
+				Config: testAccProjectConfigPreviewFeedbackOnly(projectSuffix, teamIDConfig(t)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("vercel_project.test", "preview_comments", "true"),
+					resource.TestCheckResourceAttr("vercel_project.test", "enable_preview_feedback", "true"),
 				),
 			},
 		},
@@ -627,6 +655,39 @@ resource "vercel_project" "test" {
       sensitive = true
     }
   ]
+  enable_preview_feedback = false
+  enable_production_feedback = true
+}
+`, projectSuffix, teamID)
+}
+
+func testAccProjectConfigPreviewFeedbackConflict(projectSuffix, teamID string) string {
+	return fmt.Sprintf(`
+resource "vercel_project" "test" {
+  name = "test-acc-two-%s"
+  %s
+  preview_comments = true
+  enable_preview_feedback = true"
+}
+`, projectSuffix, teamID)
+}
+
+func testAccProjectConfigPreviewCommentsOnly(projectSuffix, teamID string) string {
+	return fmt.Sprintf(`
+resource "vercel_project" "test" {
+  name = "test-acc-two-%s"
+  %s
+  preview_comments = true # Use deprecated field
+}
+`, projectSuffix, teamID)
+}
+
+func testAccProjectConfigPreviewFeedbackOnly(projectSuffix, teamID string) string {
+	return fmt.Sprintf(`
+resource "vercel_project" "test" {
+  name = "test-acc-two-%s"
+  %s
+  enable_preview_feedback = true
 }
 `, projectSuffix, teamID)
 }
@@ -984,7 +1045,8 @@ resource "vercel_project" "test" {
       on_pull_request = true,
       on_commit = true
   }
-  preview_comments = true
+  enable_preview_feedback = true
+  enable_production_feedback = false
   auto_assign_custom_domains = true
   git_lfs = true
   function_failover = true

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -18,10 +18,6 @@ import (
 )
 
 func TestAcc_Project(t *testing.T) {
-	testTeamID := resource.TestCheckNoResourceAttr("vercel_project.test", "team_id")
-	if testTeam(t) != "" {
-		testTeamID = resource.TestCheckResourceAttr("vercel_project.test", "team_id", testTeam(t))
-	}
 	projectSuffix := acctest.RandString(16)
 
 	resource.Test(t, resource.TestCase{
@@ -52,7 +48,7 @@ func TestAcc_Project(t *testing.T) {
 				Config: testAccProjectConfig(projectSuffix, teamIDConfig(t)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccProjectExists(testClient(t), "vercel_project.test", testTeam(t)),
-					testTeamID,
+					resource.TestCheckResourceAttr("vercel_project.test", "team_id", testTeam(t)),
 					resource.TestCheckResourceAttr("vercel_project.test", "name", fmt.Sprintf("test-acc-project-%s", projectSuffix)),
 					resource.TestCheckResourceAttr("vercel_project.test", "build_command", "npm run build"),
 					resource.TestCheckResourceAttr("vercel_project.test", "dev_command", "npm run serve"),

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -31,20 +31,20 @@ func TestAcc_Project(t *testing.T) {
 			// Ensure we get nice framework / serverless_function_region errors
 			{
 				Config: `
-                    resource "vercel_project" "test" {
-                        name = "foo"
-                        serverless_function_region = "notexist"
-                    }
-                `,
+				                    resource "vercel_project" "test" {
+				                        name = "foo"
+				                        serverless_function_region = "notexist"
+				                    }
+				                `,
 				ExpectError: regexp.MustCompile("Invalid Serverless Function Region"),
 			},
 			{
 				Config: `
-                    resource "vercel_project" "test" {
-                        name = "foo"
-                        framework = "notexist"
-                    }
-                `,
+				                    resource "vercel_project" "test" {
+				                        name = "foo"
+				                        framework = "notexist"
+				                    }
+				                `,
 				ExpectError: regexp.MustCompile("Invalid Framework"),
 			},
 			// Create and Read testing
@@ -667,7 +667,7 @@ resource "vercel_project" "test" {
   name = "test-acc-two-%s"
   %s
   preview_comments = true
-  enable_preview_feedback = true"
+  enable_preview_feedback = true
 }
 `, projectSuffix, teamID)
 }
@@ -677,7 +677,7 @@ func testAccProjectConfigPreviewCommentsOnly(projectSuffix, teamID string) strin
 resource "vercel_project" "test" {
   name = "test-acc-two-%s"
   %s
-  preview_comments = true # Use deprecated field
+  preview_comments = true
 }
 `, projectSuffix, teamID)
 }


### PR DESCRIPTION
<img width="960" alt="Screenshot 2025-05-01 at 21 07 23" src="https://github.com/user-attachments/assets/3187b3d7-a59a-4696-a2e0-df163a04aad1" />


Support for these settings, but on a per-project basis. 

They can already be configured at the team basis in the `team_config` resource. 

Technically, the preview environments one already exists, in the `preview_comments` field on the `vercel_project` resource, but the name is kinda outdated, and mismatches the team settings. This should hopefully clarity that. 