### PR TITLE
[firewall config resource] Add bot filter support

### DIFF
--- a/client/firewall_config.go
+++ b/client/firewall_config.go
@@ -16,7 +16,8 @@ type FirewallConfig struct {
 	CRS     map[string]CoreRuleSet `json:"crs,omitempty"`
 }
 type ManagedRule struct {
-	Active bool `json:"active"`
+	Active bool   `json:"active"`
+	Action string `json:"action"`
 }
 
 type FirewallRule struct {

--- a/examples/resources/vercel_firewall_config/resource.tf
+++ b/examples/resources/vercel_firewall_config/resource.tf
@@ -142,6 +142,11 @@ resource "vercel_firewall_config" "managed" {
       rfi  = { action = "deny" }
       gen  = { action = "deny" }
     }
+
+    bot_filter {
+      action = "log"
+      active = true
+    }
   }
 }
 

--- a/vercel/resource_firewall_config.go
+++ b/vercel/resource_firewall_config.go
@@ -171,7 +171,7 @@ Define Custom Rules to shape the way your traffic is handled by the Vercel Edge 
 						},
 					},
 					"bot_filter": schema.SingleNestedBlock{
-						Description: "Enable the bot_filter managed rulesets and select action",
+						Description: "Enable the bot_filter managed ruleset and select action",
 						Attributes: map[string]schema.Attribute{
 							"active": schema.BoolAttribute{
 								Optional: true,

--- a/vercel/resource_firewall_config.go
+++ b/vercel/resource_firewall_config.go
@@ -861,11 +861,11 @@ func fromClient(conf client.FirewallConfig, state FirewallConfig) (FirewallConfi
 		if conf.CRS != nil {
 			cfg.ManagedRulesets.OWASP = fromCRS(conf.CRS, state.ManagedRulesets)
 		}
-		v, exist := conf.ManagedRulesets["bot_filter"]
-		if exist {
+		botFilter, botFilterExist := conf.ManagedRulesets["bot_filter"]
+		if botFilterExist {
 			botFilterConf := &BotFilterConfig{
-				Active: types.BoolValue(v.Active),
-				Action: types.StringValue(v.Action),
+				Active: types.BoolValue(botFilter.Active),
+				Action: types.StringValue(botFilter.Action),
 			}
 			cfg.ManagedRulesets.BotFilter = botFilterConf
 		}

--- a/vercel/resource_firewall_config_test.go
+++ b/vercel/resource_firewall_config_test.go
@@ -169,6 +169,15 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 						"vercel_firewall_config.ips",
 						"ip_rules.rule.2.hostname",
 						"*"),
+
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.botfilter",
+						"managed_rulesets.bot_filter.action",
+						"challenge"),
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.botfilter",
+						"managed_rulesets.bot_filter.active",
+						"true"),
 				),
 			},
 			{
@@ -185,6 +194,11 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 				ImportState:       true,
 				ResourceName:      "vercel_firewall_config.ips",
 				ImportStateIdFunc: getFirewallImportID("vercel_firewall_config.ips"),
+			},
+			{
+				ImportState:       true,
+				ResourceName:      "vercel_firewall_config.botfilter",
+				ImportStateIdFunc: getFirewallImportID("vercel_firewall_config.botfilter"),
 			},
 			{
 				Config: testAccFirewallConfigResourceUpdated(name, teamIDConfig(t)),
@@ -329,6 +343,15 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 						"vercel_firewall_config.ips",
 						"ip_rules.rule.2.hostname",
 						"*"),
+
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.botfilter",
+						"managed_rulesets.bot_filter.action",
+						"deny"),
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.botfilter",
+						"managed_rulesets.bot_filter.active",
+						"false"),
 				),
 			},
 		},
@@ -481,6 +504,23 @@ resource "vercel_firewall_config" "ips" {
             action = "deny"
             ip = "2.4.6.8"
             hostname = "*"
+        }
+    }
+}
+
+resource "vercel_project" "botfilter" {
+    name = "test-acc-%[1]s-botfilter"
+    %[2]s
+}
+
+resource "vercel_firewall_config" "botfilter" {
+    project_id = vercel_project.botfilter.id
+    %[2]s
+
+    managed_rulesets {
+        bot_filter {
+            action = "challenge"
+            active = true
         }
     }
 }
@@ -652,6 +692,18 @@ resource "vercel_firewall_config" "neg" {
                 ]
             }]
           }]
+        }
+    }
+}
+
+resource "vercel_firewall_config" "botfilter" {
+    project_id = vercel_project.botfilter.id
+    %[2]s
+
+    managed_rulesets {
+        bot_filter {
+            action = "deny"
+            active = false
         }
     }
 }

--- a/vercel/resource_firewall_config_test.go
+++ b/vercel/resource_firewall_config_test.go
@@ -702,7 +702,7 @@ resource "vercel_firewall_config" "botfilter" {
 
     managed_rulesets {
         bot_filter {
-            action = "deny"
+            action = "log"
             active = false
         }
     }


### PR DESCRIPTION
Add terraform support for `bot_filter` managed ruleset.

API already supports this.
Tested locally with a project