### PR TITLE
[enhanced builds] add build_machine_type option to project creation

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -225,6 +225,7 @@ type ResourceConfigResponse struct {
 	FunctionDefaultTimeout    *int64  `json:"functionDefaultTimeout"`
 	Fluid                     bool    `json:"fluid"`
 	ElasticConcurrencyEnabled bool    `json:"elasticConcurrencyEnabled"`
+	BuildMachineType          *string `json:"buildMachineType"`
 }
 
 type ResourceConfig struct {
@@ -232,6 +233,7 @@ type ResourceConfig struct {
 	FunctionDefaultTimeout    *int64  `json:"functionDefaultTimeout,omitempty"`
 	Fluid                     *bool   `json:"fluid,omitempty"`
 	ElasticConcurrencyEnabled *bool   `json:"elasticConcurrencyEnabled,omitempty"`
+	BuildMachineType          *string `json:"buildMachineType,omitempty"`
 }
 
 // GetProject retrieves information about an existing project from Vercel.

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -393,6 +393,14 @@ For more detailed information, please see the [Vercel documentation](https://ver
 				Optional:    true,
 				Computed:    true,
 			},
+			"build_machine_type": schema.StringAttribute{
+				Description: "When `on_demand_concurrent_builds` is enabled, choose the build machine: `standard` (4 vCPU, 8 GB) or `enhanced` (8 vCPU, 16GB)",
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("standard", "enhanced"),
+				},
+			},
 		},
 	}
 }
@@ -437,6 +445,7 @@ type ProjectDataSource struct {
 	ResourceConfig                      types.Object          `tfsdk:"resource_config"`
 	NodeVersion                         types.String          `tfsdk:"node_version"`
 	OnDemandConcurrentBuilds            types.Bool            `tfsdk:"on_demand_concurrent_builds"`
+	BuildMachineType                    types.String          `tfsdk:"build_machine_type"`
 }
 
 func convertResponseToProjectDataSource(ctx context.Context, response client.ProjectResponse, plan Project, environmentVariables []client.EnvironmentVariable) (ProjectDataSource, error) {
@@ -503,6 +512,7 @@ func convertResponseToProjectDataSource(ctx context.Context, response client.Pro
 		ResourceConfig:                      project.ResourceConfig,
 		NodeVersion:                         project.NodeVersion,
 		OnDemandConcurrentBuilds:            project.OnDemandConcurrentBuilds,
+		BuildMachineType:                    project.BuildMachineType,
 	}, nil
 }
 


### PR DESCRIPTION
After the release of on-demand enhanced builds, we are adding support for this feature at the project level. We are adding a new option, `build_machine_type`, to the project.

Requisites of this feature:
- The project option `on_demand_concurrent_builds` must be set to true. If it is set to false and `build_machine_type` is set to something, we should error.
- It is optional (no need to set it, even if `on_demand_concurrent_builds` is set to true).
- It can have two values: `standard` and `enhanced`.

## CURL Examples

Setting the `build_machine_type` to enhanced:

```
curl --request PATCH \
  --url https://api.vercel.com/v9/projects/<project_id>\
  --header 'Authorization: Bearer <token>' \
  --header 'Content-Type: application/json' \
  --data '{
  "resourceConfig": {
    "elasticConcurrencyEnabled": true,
    "buildMachineType": "enhanced"
  }
}'
```

Setting the `build_machine_type` to standard (notice that we send null instead of standard):

```
curl --request PATCH \
  --url https://api.vercel.com/v9/projects/<project_id>\
  --header 'Authorization: Bearer <token>' \
  --header 'Content-Type: application/json' \
  --data '{
  "resourceConfig": {
    "elasticConcurrencyEnabled": true,
    "buildMachineType": null
  }
}'
```
