### PR TITLE
Add firewall as a source on log_drain

### DIFF
--- a/vercel/resource_log_drain.go
+++ b/vercel/resource_log_drain.go
@@ -141,7 +141,7 @@ Teams on Pro and Enterprise plans can subscribe to log drains that are generic a
 				ElementType:   types.StringType,
 				PlanModifiers: []planmodifier.Set{setplanmodifier.RequiresReplace()},
 				Validators: []validator.Set{
-					setvalidator.ValueStringsAre(stringvalidator.OneOf("static", "edge", "external", "build", "lambda")),
+					setvalidator.ValueStringsAre(stringvalidator.OneOf("static", "edge", "external", "build", "lambda", "firewall")),
 					setvalidator.SizeAtLeast(1),
 				},
 			},

--- a/vercel/resource_log_drain_test.go
+++ b/vercel/resource_log_drain_test.go
@@ -75,12 +75,13 @@ func TestAcc_LogDrainResource(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_log_drain.maximal", "environments.#", "2"),
 					resource.TestCheckResourceAttr("vercel_log_drain.maximal", "environments.0", "preview"),
 					resource.TestCheckResourceAttr("vercel_log_drain.maximal", "environments.1", "production"),
-					resource.TestCheckResourceAttr("vercel_log_drain.maximal", "sources.#", "5"),
+					resource.TestCheckResourceAttr("vercel_log_drain.maximal", "sources.#", "6"),
 					resource.TestCheckResourceAttr("vercel_log_drain.maximal", "sources.0", "build"),
 					resource.TestCheckResourceAttr("vercel_log_drain.maximal", "sources.1", "edge"),
 					resource.TestCheckResourceAttr("vercel_log_drain.maximal", "sources.2", "external"),
-					resource.TestCheckResourceAttr("vercel_log_drain.maximal", "sources.3", "lambda"),
-					resource.TestCheckResourceAttr("vercel_log_drain.maximal", "sources.4", "static"),
+					resource.TestCheckResourceAttr("vercel_log_drain.maximal", "sources.3", "firewall"),
+					resource.TestCheckResourceAttr("vercel_log_drain.maximal", "sources.4", "lambda"),
+					resource.TestCheckResourceAttr("vercel_log_drain.maximal", "sources.5", "static"),
 					resource.TestCheckResourceAttr("vercel_log_drain.maximal", "secret", "a_very_long_and_very_well_specified_secret"),
 					resource.TestCheckResourceAttr("vercel_log_drain.maximal", "headers.%", "1"),
 					resource.TestCheckResourceAttrSet("vercel_log_drain.maximal", "endpoint"),
@@ -121,7 +122,7 @@ resource "vercel_log_drain" "maximal" {
     project_ids             = [vercel_project.test.id]
     sampling_rate           = 0.8
     secret                  = "a_very_long_and_very_well_specified_secret"
-    sources                 = ["static", "edge", "external", "build", "lambda"]
+    sources                 = ["static", "edge", "external", "build", "lambda", "firewall"]
     endpoint = "https://verify-test-rouge.vercel.app/api?${data.vercel_endpoint_verification.test.verification_code}"
 
     %[2]s


### PR DESCRIPTION
Turns out it was missing. 