### PR TITLE
[firewall config resource] Add AI bots support

### DIFF
--- a/docs/resources/firewall_config.md
+++ b/docs/resources/firewall_config.md
@@ -162,6 +162,11 @@ resource "vercel_firewall_config" "managed" {
       action = "log"
       active = true
     }
+
+    ai_bots {
+      action = "log"
+      active = true
+    }
   }
 }
 

--- a/docs/resources/firewall_config.md
+++ b/docs/resources/firewall_config.md
@@ -235,8 +235,18 @@ Read-Only:
 
 Optional:
 
+- `ai_bots` (Block, Optional) Enable the ai_bots managed ruleset and select action (see [below for nested schema](#nestedblock--managed_rulesets--ai_bots))
 - `bot_filter` (Block, Optional) Enable the bot_filter managed ruleset and select action (see [below for nested schema](#nestedblock--managed_rulesets--bot_filter))
 - `owasp` (Block, Optional) Enable the owasp managed rulesets and select ruleset behaviors (see [below for nested schema](#nestedblock--managed_rulesets--owasp))
+
+<a id="nestedblock--managed_rulesets--ai_bots"></a>
+### Nested Schema for `managed_rulesets.ai_bots`
+
+Optional:
+
+- `action` (String)
+- `active` (Boolean)
+
 
 <a id="nestedblock--managed_rulesets--bot_filter"></a>
 ### Nested Schema for `managed_rulesets.bot_filter`

--- a/examples/resources/vercel_firewall_config/resource.tf
+++ b/examples/resources/vercel_firewall_config/resource.tf
@@ -147,6 +147,11 @@ resource "vercel_firewall_config" "managed" {
       action = "log"
       active = true
     }
+
+    ai_bots {
+      action = "log"
+      active = true
+    }
   }
 }
 

--- a/vercel/resource_firewall_config_test.go
+++ b/vercel/resource_firewall_config_test.go
@@ -169,7 +169,6 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 						"vercel_firewall_config.ips",
 						"ip_rules.rule.2.hostname",
 						"*"),
-
 					resource.TestCheckResourceAttr(
 						"vercel_firewall_config.botfilter",
 						"managed_rulesets.bot_filter.action",
@@ -177,6 +176,14 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"vercel_firewall_config.botfilter",
 						"managed_rulesets.bot_filter.active",
+						"true"),
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.aibots",
+						"managed_rulesets.ai_bots.action",
+						"challenge"),
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.aibots",
+						"managed_rulesets.ai_bots.active",
 						"true"),
 				),
 			},
@@ -199,6 +206,11 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 				ImportState:       true,
 				ResourceName:      "vercel_firewall_config.botfilter",
 				ImportStateIdFunc: getFirewallImportID("vercel_firewall_config.botfilter"),
+			},
+			{
+				ImportState:       true,
+				ResourceName:      "vercel_firewall_config.aibots",
+				ImportStateIdFunc: getFirewallImportID("vercel_firewall_config.aibots"),
 			},
 			{
 				Config: cfg(testAccFirewallConfigResourceUpdated(name)),
@@ -343,7 +355,6 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 						"vercel_firewall_config.ips",
 						"ip_rules.rule.2.hostname",
 						"*"),
-
 					resource.TestCheckResourceAttr(
 						"vercel_firewall_config.botfilter",
 						"managed_rulesets.bot_filter.action",
@@ -351,6 +362,14 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"vercel_firewall_config.botfilter",
 						"managed_rulesets.bot_filter.active",
+						"false"),
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.aibots",
+						"managed_rulesets.ai_bots.action",
+						"deny"),
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.aibots",
+						"managed_rulesets.ai_bots.active",
 						"false"),
 				),
 			},
@@ -511,6 +530,21 @@ resource "vercel_firewall_config" "botfilter" {
 
     managed_rulesets {
         bot_filter {
+            action = "challenge"
+            active = true
+        }
+    }
+}
+
+resource "vercel_project" "aibots" {
+    name = "test-acc-%[1]s-aibots"
+}
+
+resource "vercel_firewall_config" "aibots" {
+    project_id = vercel_project.aibots.id
+
+    managed_rulesets {
+        ai_bots {
             action = "challenge"
             active = true
         }
@@ -689,6 +723,21 @@ resource "vercel_firewall_config" "botfilter" {
 
     managed_rulesets {
         bot_filter {
+            action = "deny"
+            active = false
+        }
+    }
+}
+
+resource "vercel_project" "aibots" {
+    name = "test-acc-%[1]s-aibots"
+}
+
+resource "vercel_firewall_config" "aibots" {
+    project_id = vercel_project.aibots.id
+
+    managed_rulesets {
+        ai_bots {
             action = "deny"
             active = false
         }


### PR DESCRIPTION
Add terraform support for ai_bots managed ruleset.

API already supports this.
Tested locally with a project