### PR TITLE
[firewall config resource] Rename bot_filter to bot_protection

### DIFF
--- a/docs/resources/firewall_config.md
+++ b/docs/resources/firewall_config.md
@@ -158,7 +158,7 @@ resource "vercel_firewall_config" "managed" {
       gen  = { action = "deny" }
     }
 
-    bot_filter {
+    bot_protection {
       action = "log"
       active = true
     }
@@ -241,7 +241,7 @@ Read-Only:
 Optional:
 
 - `ai_bots` (Block, Optional) Enable the ai_bots managed ruleset and select action (see [below for nested schema](#nestedblock--managed_rulesets--ai_bots))
-- `bot_filter` (Block, Optional) Enable the bot_filter managed ruleset and select action (see [below for nested schema](#nestedblock--managed_rulesets--bot_filter))
+- `bot_protection` (Block, Optional) Enable the bot_protection managed ruleset and select action (see [below for nested schema](#nestedblock--managed_rulesets--bot_protection))
 - `owasp` (Block, Optional) Enable the owasp managed rulesets and select ruleset behaviors (see [below for nested schema](#nestedblock--managed_rulesets--owasp))
 
 <a id="nestedblock--managed_rulesets--ai_bots"></a>
@@ -253,8 +253,8 @@ Optional:
 - `active` (Boolean)
 
 
-<a id="nestedblock--managed_rulesets--bot_filter"></a>
-### Nested Schema for `managed_rulesets.bot_filter`
+<a id="nestedblock--managed_rulesets--bot_protection"></a>
+### Nested Schema for `managed_rulesets.bot_protection`
 
 Optional:
 

--- a/docs/resources/firewall_config.md
+++ b/docs/resources/firewall_config.md
@@ -241,11 +241,21 @@ Read-Only:
 Optional:
 
 - `ai_bots` (Block, Optional) Enable the ai_bots managed ruleset and select action (see [below for nested schema](#nestedblock--managed_rulesets--ai_bots))
+- `bot_filter` (Block, Optional, Deprecated) DEPRECATED: Use bot_protection instead. This block will be removed in a future release. (see [below for nested schema](#nestedblock--managed_rulesets--bot_filter))
 - `bot_protection` (Block, Optional) Enable the bot_protection managed ruleset and select action (see [below for nested schema](#nestedblock--managed_rulesets--bot_protection))
 - `owasp` (Block, Optional) Enable the owasp managed rulesets and select ruleset behaviors (see [below for nested schema](#nestedblock--managed_rulesets--owasp))
 
 <a id="nestedblock--managed_rulesets--ai_bots"></a>
 ### Nested Schema for `managed_rulesets.ai_bots`
+
+Optional:
+
+- `action` (String)
+- `active` (Boolean)
+
+
+<a id="nestedblock--managed_rulesets--bot_filter"></a>
+### Nested Schema for `managed_rulesets.bot_filter`
 
 Optional:
 

--- a/examples/resources/vercel_firewall_config/resource.tf
+++ b/examples/resources/vercel_firewall_config/resource.tf
@@ -143,7 +143,7 @@ resource "vercel_firewall_config" "managed" {
       gen  = { action = "deny" }
     }
 
-    bot_filter {
+    bot_protection {
       action = "log"
       active = true
     }

--- a/vercel/resource_firewall_config_test.go
+++ b/vercel/resource_firewall_config_test.go
@@ -170,12 +170,12 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 						"ip_rules.rule.2.hostname",
 						"*"),
 					resource.TestCheckResourceAttr(
-						"vercel_firewall_config.botfilter",
-						"managed_rulesets.bot_filter.action",
+						"vercel_firewall_config.botprotection",
+						"managed_rulesets.bot_protection.action",
 						"challenge"),
 					resource.TestCheckResourceAttr(
-						"vercel_firewall_config.botfilter",
-						"managed_rulesets.bot_filter.active",
+						"vercel_firewall_config.botprotection",
+						"managed_rulesets.bot_protection.active",
 						"true"),
 					resource.TestCheckResourceAttr(
 						"vercel_firewall_config.aibots",
@@ -204,8 +204,8 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 			},
 			{
 				ImportState:       true,
-				ResourceName:      "vercel_firewall_config.botfilter",
-				ImportStateIdFunc: getFirewallImportID("vercel_firewall_config.botfilter"),
+				ResourceName:      "vercel_firewall_config.botprotection",
+				ImportStateIdFunc: getFirewallImportID("vercel_firewall_config.botprotection"),
 			},
 			{
 				ImportState:       true,
@@ -356,12 +356,12 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 						"ip_rules.rule.2.hostname",
 						"*"),
 					resource.TestCheckResourceAttr(
-						"vercel_firewall_config.botfilter",
-						"managed_rulesets.bot_filter.action",
+						"vercel_firewall_config.botprotection",
+						"managed_rulesets.bot_protection.action",
 						"deny"),
 					resource.TestCheckResourceAttr(
-						"vercel_firewall_config.botfilter",
-						"managed_rulesets.bot_filter.active",
+						"vercel_firewall_config.botprotection",
+						"managed_rulesets.bot_protection.active",
 						"false"),
 					resource.TestCheckResourceAttr(
 						"vercel_firewall_config.aibots",
@@ -521,15 +521,15 @@ resource "vercel_firewall_config" "ips" {
     }
 }
 
-resource "vercel_project" "botfilter" {
-    name = "test-acc-%[1]s-botfilter"
+resource "vercel_project" "botprotection" {
+    name = "test-acc-%[1]s-botprotection"
 }
 
-resource "vercel_firewall_config" "botfilter" {
-    project_id = vercel_project.botfilter.id
+resource "vercel_firewall_config" "botprotection" {
+    project_id = vercel_project.botprotection.id
 
     managed_rulesets {
-        bot_filter {
+        bot_protection {
             action = "challenge"
             active = true
         }
@@ -714,15 +714,15 @@ resource "vercel_firewall_config" "neg" {
     }
 }
 
-resource "vercel_project" "botfilter" {
-    name = "test-acc-%[1]s-botfilter"
+resource "vercel_project" "botprotection" {
+    name = "test-acc-%[1]s-botprotection"
 }
 
-resource "vercel_firewall_config" "botfilter" {
-    project_id = vercel_project.botfilter.id
+resource "vercel_firewall_config" "botprotection" {
+    project_id = vercel_project.botprotection.id
 
     managed_rulesets {
-        bot_filter {
+        bot_protection {
             action = "deny"
             active = false
         }


### PR DESCRIPTION
Rename `bot_filter` to `bot_protection`.

Enforce mutual exclusivity between `bot_filter` and `bot_protection` using `objectvalidator.ConflictsWith`.
Add deprecation notice on `bot_filter` block.

When managing state and interacting with the API, we default to `bot_protection` whenever possible, and fall back to `bot_filter` when necessary.

Update the docs and example.
