### PR TITLE
Remove OIDC enabled property

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -16,7 +16,6 @@ type GitRepository struct {
 }
 
 type OIDCTokenConfig struct {
-	Enabled    bool   `json:"enabled"`
 	IssuerMode string `json:"issuerMode,omitempty"`
 }
 

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -127,10 +127,6 @@ Optional:
 
 - `issuer_mode` (String) Configures the URL of the `iss` claim. `team` = `https://oidc.vercel.com/[team_slug]` `global` = `https://oidc.vercel.com`
 
-Read-Only:
-
-- `enabled` (Boolean) When true, Vercel issued OpenID Connect (OIDC) tokens will be available on the compute environments. See https://vercel.com/docs/security/secure-backend-access/oidc for more information.
-
 
 <a id="nestedatt--options_allowlist"></a>
 ### Nested Schema for `options_allowlist`

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -157,10 +157,6 @@ Read-Only:
 <a id="nestedatt--oidc_token_config"></a>
 ### Nested Schema for `oidc_token_config`
 
-Required:
-
-- `enabled` (Boolean) When true, Vercel issued OpenID Connect (OIDC) tokens will be available on the compute environments. See https://vercel.com/docs/security/secure-backend-access/oidc for more information.
-
 Optional:
 
 - `issuer_mode` (String) Configures the URL of the `iss` claim. `team` = `https://oidc.vercel.com/[team_slug]` `global` = `https://oidc.vercel.com`

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -238,10 +238,6 @@ For more detailed information, please see the [Vercel documentation](https://ver
 				Description: "Configuration for OpenID Connect (OIDC) tokens.",
 				Computed:    true,
 				Attributes: map[string]schema.Attribute{
-					"enabled": schema.BoolAttribute{
-						Description: "When true, Vercel issued OpenID Connect (OIDC) tokens will be available on the compute environments. See https://vercel.com/docs/security/secure-backend-access/oidc for more information.",
-						Computed:    true,
-					},
 					"issuer_mode": schema.StringAttribute{
 						Description: "Configures the URL of the `iss` claim. `team` = `https://oidc.vercel.com/[team_slug]` `global` = `https://oidc.vercel.com`",
 						Computed:    true,

--- a/vercel/data_source_project_test.go
+++ b/vercel/data_source_project_test.go
@@ -56,7 +56,6 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vercel_project.test", "skew_protection", "7 days"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "resource_config.function_default_cpu_type", "standard_legacy"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "resource_config.function_default_timeout", "30"),
-					resource.TestCheckResourceAttr("data.vercel_project.test", "oidc_token_config.enabled", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "oidc_token_config.issuer_mode", "team"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "on_demand_concurrent_builds", "true"),
 				),
@@ -137,7 +136,6 @@ resource "vercel_project" "test" {
 	fluid = false
   }
   oidc_token_config = {
-    enabled = true
     issuer_mode = "team"
   }
   on_demand_concurrent_builds = true

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -356,10 +356,6 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				Optional:    true,
 				Computed:    true,
 				Attributes: map[string]schema.Attribute{
-					"enabled": schema.BoolAttribute{
-						Description: "When true, Vercel issued OpenID Connect (OIDC) tokens will be available on the compute environments. See https://vercel.com/docs/security/secure-backend-access/oidc for more information.",
-						Required:    true,
-					},
 					"issuer_mode": schema.StringAttribute{
 						Optional:      true,
 						Computed:      true,
@@ -373,12 +369,10 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				},
 				Default: objectdefault.StaticValue(types.ObjectValueMust(
 					map[string]attr.Type{
-						"enabled":     types.BoolType,
 						"issuer_mode": types.StringType,
 					},
 					map[string]attr.Value{
-						"enabled":     types.BoolValue(false),
-						"issuer_mode": types.StringValue("global"),
+						"issuer_mode": types.StringValue("team"),
 					},
 				)),
 			},
@@ -1032,7 +1026,6 @@ func (t *TrustedIps) toUpdateProjectRequest() *client.TrustedIps {
 }
 
 type OIDCTokenConfig struct {
-	Enabled    types.Bool   `tfsdk:"enabled"`
 	IssuerMode types.String `tfsdk:"issuer_mode"`
 }
 
@@ -1042,7 +1035,6 @@ func (o *OIDCTokenConfig) toCreateProjectRequest() *client.OIDCTokenConfig {
 	}
 
 	return &client.OIDCTokenConfig{
-		Enabled:    o.Enabled.ValueBool(),
 		IssuerMode: o.IssuerMode.ValueString(),
 	}
 }
@@ -1050,13 +1042,11 @@ func (o *OIDCTokenConfig) toCreateProjectRequest() *client.OIDCTokenConfig {
 func (o *OIDCTokenConfig) toUpdateProjectRequest() *client.OIDCTokenConfig {
 	if o == nil {
 		return &client.OIDCTokenConfig{
-			Enabled:    types.BoolValue(false).ValueBool(),
 			IssuerMode: types.StringValue("global").ValueString(),
 		}
 	}
 
 	return &client.OIDCTokenConfig{
-		Enabled:    o.Enabled.ValueBool(),
 		IssuerMode: o.IssuerMode.ValueString(),
 	}
 }
@@ -1310,11 +1300,9 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 	}
 
 	var oidcTokenConfig = &OIDCTokenConfig{
-		Enabled:    types.BoolValue(false),
 		IssuerMode: types.StringValue("global"),
 	}
 	if response.OIDCTokenConfig != nil {
-		oidcTokenConfig.Enabled = types.BoolValue(response.OIDCTokenConfig.Enabled)
 		oidcTokenConfig.IssuerMode = types.StringValue(response.OIDCTokenConfig.IssuerMode)
 	}
 

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -78,7 +78,6 @@ func TestAcc_Project(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_project.test", "prioritise_production_builds", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "directory_listing", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "skew_protection", "7 days"),
-					resource.TestCheckResourceAttr("vercel_project.test", "oidc_token_config.enabled", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "oidc_token_config.issuer_mode", "team"),
 					resource.TestCheckResourceAttr("vercel_project.test", "resource_config.function_default_cpu_type", "standard"),
 					resource.TestCheckResourceAttr("vercel_project.test", "resource_config.function_default_timeout", "60"),
@@ -95,7 +94,6 @@ func TestAcc_Project(t *testing.T) {
 						"key":   "bar",
 						"value": "baz",
 					}),
-					resource.TestCheckResourceAttr("vercel_project.test", "oidc_token_config.enabled", "false"),
 					resource.TestCheckResourceAttr("vercel_project.test", "preview_comments", "false"),
 					resource.TestCheckResourceAttr("vercel_project.test", "enable_preview_feedback", "false"),
 					resource.TestCheckResourceAttr("vercel_project.test", "enable_production_feedback", "true"),
@@ -1020,7 +1018,6 @@ resource "vercel_project" "test" {
   directory_listing = true
   skew_protection = "7 days"
   oidc_token_config = {
-    enabled = true
     issuer_mode = "team"
   }
   resource_config = {


### PR DESCRIPTION
The `oidc_token_config.enabled` property is now deprecated. All projects are enabled by default and it is no longer possible to toggle the feature off.