### PR TITLE
fix CI: adds email_domain and preview_deployment_suffix

### DIFF
--- a/vercel/resource_team_config_test.go
+++ b/vercel/resource_team_config_test.go
@@ -19,6 +19,8 @@ func TestAcc_TeamConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", "Vercel Terraform Testing"),
 					resource.TestCheckResourceAttr(resourceName, "slug", "terraform-testing-vtest314"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "email_domain"),
+					resource.TestCheckResourceAttrSet(resourceName, "preview_deployment_suffix"),
 				),
 			},
 			{

--- a/vercel/resource_team_config_test.go
+++ b/vercel/resource_team_config_test.go
@@ -59,7 +59,9 @@ data "vercel_file" "test" {
 
 resource "vercel_team_config" "test" {
   id                                    = "%s"
-  avatar                                =  data.vercel_file.test.file
+  avatar                                = data.vercel_file.test.file
+  email_domain                          = example.com
+	preview_deployment_suffix             = preview.example.com
   name                                  = "Vercel Terraform Testing o_o"
   slug                                  = "terraform-testing-vtest314"
   description                           = "Vercel Terraform Testing"


### PR DESCRIPTION
noticed a CI failure blocking multiple PRs ([example](https://github.com/vercel/terraform-provider-vercel/actions/runs/15645217782/job/44081445903?pr=336), [example](https://github.com/vercel/terraform-provider-vercel/actions/runs/15635012950/job/44047906585?pr=345), [example](https://github.com/vercel/terraform-provider-vercel/actions/runs/15609245873/job/43966025368?pr=344)) -> attempting to fix