### PR TITLE
Fix saml property on team config resource

### DIFF
--- a/docs/resources/team_config.md
+++ b/docs/resources/team_config.md
@@ -72,12 +72,9 @@ Optional:
 <a id="nestedatt--saml"></a>
 ### Nested Schema for `saml`
 
-Required:
-
-- `enforced` (Boolean) Indicates if SAML is enforced for the team.
-
 Optional:
 
+- `enforced` (Boolean) Indicates if SAML is enforced for the team.
 - `roles` (Attributes Map) Directory groups to role or access group mappings. For each directory group, specify either a role or access group id. (see [below for nested schema](#nestedatt--saml--roles))
 
 <a id="nestedatt--saml--roles"></a>


### PR DESCRIPTION
This is causing refresh plans to be non-empty, as it continually thinks
the saml property is changing, even though it is not. The plan shows
zero changes (daft TF!).

Fix by removing the default, which conflicts when you have computed
state + UseStateForUnknown.
