### PR TITLE
Mark resource_environment_variables value as sensitive

### DIFF
--- a/docs/resources/project_environment_variables.md
+++ b/docs/resources/project_environment_variables.md
@@ -75,7 +75,7 @@ resource "vercel_project_environment_variables" "example" {
 Required:
 
 - `key` (String) The name of the Environment Variable.
-- `value` (String) The value of the Environment Variable.
+- `value` (String, Sensitive) The value of the Environment Variable.
 
 Optional:
 

--- a/vercel/resource_project_environment_variables.go
+++ b/vercel/resource_project_environment_variables.go
@@ -98,7 +98,7 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 						"value": schema.StringAttribute{
 							Required:    true,
 							Description: "The value of the Environment Variable.",
-							// Sensitive:   true,
+							Sensitive:   true,
 						},
 						"target": schema.SetAttribute{
 							Optional:    true,


### PR DESCRIPTION
Seems this was accidentally comitted as commented out. Uncomment to mark them as sensitive. Note that this only affects the output of the Terraform CLI, and does not prevent the value from being stored in plaintext in the terraform state.

Closes #351 