### PR TITLE
Allow 1d and 1w for deployment retention policy

### DIFF
--- a/docs/resources/project_deployment_retention.md
+++ b/docs/resources/project_deployment_retention.md
@@ -60,10 +60,10 @@ resource "vercel_project_deployment_retention" "example_customized" {
 
 ### Optional
 
-- `expiration_canceled` (String) The retention period for canceled deployments. Should be one of '1m', '2m', '3m', '6m', '1y', 'unlimited'.
-- `expiration_errored` (String) The retention period for errored deployments. Should be one of '1m', '2m', '3m', '6m', '1y', 'unlimited'.
-- `expiration_preview` (String) The retention period for preview deployments. Should be one of '1m', '2m', '3m', '6m', '1y', 'unlimited'.
-- `expiration_production` (String) The retention period for production deployments. Should be one of '1m', '2m', '3m', '6m', '1y', 'unlimited'.
+- `expiration_canceled` (String) The retention period for canceled deployments. Should be one of '1d', '1w', '1m', '2m', '3m', '6m', '1y', 'unlimited'.
+- `expiration_errored` (String) The retention period for errored deployments. Should be one of '1d', '1w', '1m', '2m', '3m', '6m', '1y', 'unlimited'.
+- `expiration_preview` (String) The retention period for preview deployments. Should be one of '1d', '1w', '1m', '2m', '3m', '6m', '1y', 'unlimited'.
+- `expiration_production` (String) The retention period for production deployments. Should be one of '1d', '1w', '1m', '2m', '3m', '6m', '1y', 'unlimited'.
 - `team_id` (String) The ID of the Vercel team.
 
 ## Import

--- a/vercel/resource_project_deployment_retention.go
+++ b/vercel/resource_project_deployment_retention.go
@@ -66,37 +66,37 @@ For more detailed information, please see the [Vercel documentation](https://ver
 			"expiration_preview": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "The retention period for preview deployments. Should be one of '1m', '2m', '3m', '6m', '1y', 'unlimited'.",
+				Description: "The retention period for preview deployments. Should be one of '1d', '1w', '1m', '2m', '3m', '6m', '1y', 'unlimited'.",
 				Default:     stringdefault.StaticString("unlimited"),
 				Validators: []validator.String{
-					stringvalidator.OneOf("1m", "2m", "3m", "6m", "1y", "unlimited"),
+					stringvalidator.OneOf("1d", "1w", "1m", "2m", "3m", "6m", "1y", "unlimited"),
 				},
 			},
 			"expiration_production": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "The retention period for production deployments. Should be one of '1m', '2m', '3m', '6m', '1y', 'unlimited'.",
+				Description: "The retention period for production deployments. Should be one of '1d', '1w', '1m', '2m', '3m', '6m', '1y', 'unlimited'.",
 				Default:     stringdefault.StaticString("unlimited"),
 				Validators: []validator.String{
-					stringvalidator.OneOf("1m", "2m", "3m", "6m", "1y", "unlimited"),
+					stringvalidator.OneOf("1d", "1w", "1m", "2m", "3m", "6m", "1y", "unlimited"),
 				},
 			},
 			"expiration_canceled": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "The retention period for canceled deployments. Should be one of '1m', '2m', '3m', '6m', '1y', 'unlimited'.",
+				Description: "The retention period for canceled deployments. Should be one of '1d', '1w', '1m', '2m', '3m', '6m', '1y', 'unlimited'.",
 				Default:     stringdefault.StaticString("unlimited"),
 				Validators: []validator.String{
-					stringvalidator.OneOf("1m", "2m", "3m", "6m", "1y", "unlimited"),
+					stringvalidator.OneOf("1d", "1w", "1m", "2m", "3m", "6m", "1y", "unlimited"),
 				},
 			},
 			"expiration_errored": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "The retention period for errored deployments. Should be one of '1m', '2m', '3m', '6m', '1y', 'unlimited'.",
+				Description: "The retention period for errored deployments. Should be one of '1d', '1w', '1m', '2m', '3m', '6m', '1y', 'unlimited'.",
 				Default:     stringdefault.StaticString("unlimited"),
 				Validators: []validator.String{
-					stringvalidator.OneOf("1m", "2m", "3m", "6m", "1y", "unlimited"),
+					stringvalidator.OneOf("1d", "1w", "1m", "2m", "3m", "6m", "1y", "unlimited"),
 				},
 			},
 			"project_id": schema.StringAttribute{

--- a/vercel/resource_project_deployment_retention_test.go
+++ b/vercel/resource_project_deployment_retention_test.go
@@ -49,9 +49,10 @@ func TestAcc_ProjectDeploymentRetention(t *testing.T) {
 				Config: cfg(testAccProjectDeploymentRetentionsConfig(nameSuffix, testGithubRepo(t))),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccProjectDeploymentRetentionExists(testClient(t), "vercel_project_deployment_retention.example", testTeam(t)),
-					resource.TestCheckResourceAttr("vercel_project_deployment_retention.example", "expiration_preview", "1m"),
+
+					resource.TestCheckResourceAttr("vercel_project_deployment_retention.example", "expiration_preview", "1w"),
 					resource.TestCheckResourceAttr("vercel_project_deployment_retention.example", "expiration_production", "2m"),
-					resource.TestCheckResourceAttr("vercel_project_deployment_retention.example", "expiration_canceled", "3m"),
+					resource.TestCheckResourceAttr("vercel_project_deployment_retention.example", "expiration_canceled", "1d"),
 					resource.TestCheckResourceAttr("vercel_project_deployment_retention.example", "expiration_errored", "1y"),
 				),
 			},
@@ -92,9 +93,9 @@ resource "vercel_project" "example" {
 
 resource "vercel_project_deployment_retention" "example" {
 	project_id = vercel_project.example.id
-	expiration_preview    = "1m"
+	expiration_preview    = "1w"
 	expiration_production = "2m"
-	expiration_canceled   = "3m"
+	expiration_canceled   = "1d"
 	expiration_errored    = "1y"
 }
 `, projectName, githubRepo)


### PR DESCRIPTION
This adds support for the 1 day and 1 week values for deployment retention policy. Not offered in the UI either but it does not break when changed to either of these values.
