### PR TITLE
Add support for previewDeploymentsDisabled in project

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -61,6 +61,7 @@ type CreateProjectRequest struct {
 	ResourceConfig                    *ResourceConfig       `json:"resourceConfig,omitempty"`
 	EnablePreviewFeedback             *bool                 `json:"enablePreviewFeedback,omitempty"`
 	EnableProductionFeedback          *bool                 `json:"enableProductionFeedback,omitempty"`
+	PreviewDeploymentsDisabled        *bool                 `json:"previewDeploymentsDisabled,omitempty"`
 }
 
 // CreateProject will create a project within Vercel.
@@ -327,6 +328,7 @@ type UpdateProjectRequest struct {
 	GitComments                          *GitComments                    `json:"gitComments"`
 	ResourceConfig                       *ResourceConfig                 `json:"resourceConfig,omitempty"`
 	NodeVersion                          string                          `json:"nodeVersion,omitempty"`
+	PreviewDeploymentsDisabled           *bool                           `json:"previewDeploymentsDisabled,omitempty"`
 }
 
 // UpdateProject updates an existing projects configuration within Vercel.

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -74,6 +74,7 @@ data "vercel_project" "example" {
 - `skew_protection` (String) Ensures that outdated clients always fetch the correct version for a given deployment. This value defines how long Vercel keeps Skew Protection active.
 - `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
 - `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team. (see [below for nested schema](#nestedatt--vercel_authentication))
+- `preview_deployments_disabled` (Boolean) Specifies whether preview deployments are disabled for this project.
 
 <a id="nestedatt--environment"></a>
 ### Nested Schema for `environment`

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -92,6 +92,7 @@ resource "vercel_project" "example" {
 - `team_id` (String) The team ID to add the project to. Required when configuring a team resource if a default team has not been set in the provider.
 - `trusted_ips` (Attributes) Ensures only visitors from an allowed IP address can access your deployment. (see [below for nested schema](#nestedatt--trusted_ips))
 - `vercel_authentication` (Attributes) Ensures visitors to your Preview Deployments are logged into Vercel and have a minimum of Viewer access on your team. (see [below for nested schema](#nestedatt--vercel_authentication))
+- `preview_deployments_disabled` (Boolean) Specifies whether preview deployments are disabled for this project.
 
 ### Read-Only
 

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -399,6 +399,11 @@ For more detailed information, please see the [Vercel documentation](https://ver
 				Optional:    true,
 				Computed:    true,
 			},
+			"preview_deployments_disabled": schema.BoolAttribute{
+				Description: "Specifies whether preview deployments are disabled for this project.",
+				Optional:    true,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -444,6 +449,7 @@ type ProjectDataSource struct {
 	NodeVersion                         types.String          `tfsdk:"node_version"`
 	OnDemandConcurrentBuilds            types.Bool            `tfsdk:"on_demand_concurrent_builds"`
 	BuildMachineTYpe                    types.String          `tfsdk:"build_machine_type"`
+	PreviewDeploymentsDisabled          types.Bool            `tfsdk:"preview_deployments_disabled"`
 }
 
 func convertResponseToProjectDataSource(ctx context.Context, response client.ProjectResponse, plan Project, environmentVariables []client.EnvironmentVariable) (ProjectDataSource, error) {
@@ -511,6 +517,7 @@ func convertResponseToProjectDataSource(ctx context.Context, response client.Pro
 		NodeVersion:                         project.NodeVersion,
 		OnDemandConcurrentBuilds:            project.OnDemandConcurrentBuilds,
 		BuildMachineTYpe:                    project.BuildMachineType,
+		PreviewDeploymentsDisabled:          project.PreviewDeploymentsDisabled,
 	}, nil
 }
 

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -591,6 +591,12 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 					stringvalidator.OneOf("enhanced", "turbo"),
 				},
 			},
+			"preview_deployments_disabled": schema.BoolAttribute{
+				Description:   "Specifies whether preview deployments are disabled for this project.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+			},
 		},
 	}
 }
@@ -644,6 +650,7 @@ type Project struct {
 	ResourceConfig                      types.Object                    `tfsdk:"resource_config"`
 	OnDemandConcurrentBuilds            types.Bool                      `tfsdk:"on_demand_concurrent_builds"`
 	BuildMachineType                    types.String                    `tfsdk:"build_machine_type"`
+	PreviewDeploymentsDisabled          types.Bool                      `tfsdk:"preview_deployments_disabled"`
 }
 
 type GitComments struct {
@@ -766,6 +773,7 @@ func (p *Project) toCreateProjectRequest(ctx context.Context, envs []Environment
 		ResourceConfig:                    resourceConfig.toClientResourceConfig(p.OnDemandConcurrentBuilds, p.BuildMachineType),
 		EnablePreviewFeedback:             oneBoolPointer(p.EnablePreviewFeedback, p.PreviewComments),
 		EnableProductionFeedback:          p.EnableProductionFeedback.ValueBoolPointer(),
+		PreviewDeploymentsDisabled:        p.PreviewDeploymentsDisabled.ValueBoolPointer(),
 	}, diags
 }
 
@@ -846,6 +854,7 @@ func (p *Project) toUpdateProjectRequest(ctx context.Context, oldName string) (r
 		GitComments:                          gc.toUpdateProjectRequest(),
 		ResourceConfig:                       resourceConfig.toClientResourceConfig(p.OnDemandConcurrentBuilds, p.BuildMachineType),
 		NodeVersion:                          p.NodeVersion.ValueString(),
+		PreviewDeploymentsDisabled:           p.PreviewDeploymentsDisabled.ValueBoolPointer(),
 	}, nil
 }
 

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -84,6 +84,7 @@ func TestAcc_Project(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_project.test", "resource_config.function_default_timeout", "60"),
 					resource.TestCheckResourceAttr("vercel_project.test", "on_demand_concurrent_builds", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "build_machine_type", "enhanced"),
+					resource.TestCheckResourceAttr("vercel_project.test", "preview_deployments_disabled", "false"),
 				),
 			},
 			// Update testing
@@ -102,6 +103,7 @@ func TestAcc_Project(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_project.test", "enable_production_feedback", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "on_demand_concurrent_builds", "false"),
 					resource.TestCheckResourceAttr("vercel_project.test", "build_machine_type", ""),
+					resource.TestCheckResourceAttr("vercel_project.test", "preview_deployments_disabled", "true"),
 				),
 			},
 			// Test mutual exclusivity validation
@@ -650,6 +652,7 @@ resource "vercel_project" "test" {
   on_demand_concurrent_builds = false
   enable_preview_feedback = false
   enable_production_feedback = true
+  preview_deployments_disabled = true
 }
 `, projectSuffix)
 }
@@ -1019,6 +1022,7 @@ resource "vercel_project" "test" {
   customer_success_code_visibility = true
   git_fork_protection = true
   prioritise_production_builds = true
+  preview_deployments_disabled = false
   directory_listing = true
   skew_protection = "7 days"
   oidc_token_config = {


### PR DESCRIPTION
This adds the `previewDeploymentsDisabled` boolean flag which can be used to completely disable preview deployments for a project.
