### PR TITLE
Mark enable_affected_deployments as computed if not specified

### DIFF
--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -456,8 +456,10 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				Description:   "Vercel provides a set of Environment Variables that are automatically populated by the System, such as the URL of the Deployment or the name of the Git branch deployed. To expose them to your Deployments, enable this field",
 			},
 			"enable_affected_projects_deployments": schema.BoolAttribute{
-				Optional:    true,
-				Description: "When enabled, Vercel will automatically deploy all projects that are affected by a change to this project.",
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+				Description:   "When enabled, Vercel will automatically deploy all projects that are affected by a change to this project.",
 			},
 			"git_comments": schema.SingleNestedAttribute{
 				Description: "Configuration for Git Comments.",

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -614,7 +614,8 @@ func TestAcc_ProjectEnablingAffectedProjectDeployments(t *testing.T) {
 			{
 				Config: cfg(testAccProjectConfigWithoutEnableAffectedSet(projectSuffix)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckNoResourceAttr("vercel_project.test", "enable_affected_projects_deployments"),
+					// Off by default
+					resource.TestCheckResourceAttr("vercel_project.test", "enable_affected_projects_deployments", "false"),
 				),
 			},
 			{


### PR DESCRIPTION
This way it can be returned by the API, and set.
