### PR TITLE
Add missing documentation of firewall as a source for log_drain 

### DIFF
--- a/docs/data-sources/log_drain.md
+++ b/docs/data-sources/log_drain.md
@@ -43,4 +43,4 @@ data "vercel_log_drain" "example" {
 - `headers` (Map of String) Custom headers to include in requests to the log drain endpoint.
 - `project_ids` (Set of String) A list of project IDs that the log drain should be associated with. Logs from these projects will be sent log events to the specified endpoint. If omitted, logs will be sent for all projects.
 - `sampling_rate` (Number) A ratio of logs matching the sampling rate will be sent to your log drain. Should be a value between 0 and 1. If unspecified, all logs are sent.
-- `sources` (Set of String) A set of sources that the log drain should send logs for. Valid values are `static`, `edge`, `external`, `build` and `function`.
+- `sources` (Set of String) A set of sources that the log drain should send logs for. Valid values are `static`, `edge`, `external`, `build`, `lambda` and `firewall`.

--- a/docs/resources/log_drain.md
+++ b/docs/resources/log_drain.md
@@ -56,7 +56,7 @@ resource "vercel_project" "example" {
 - `delivery_format` (String) The format log data should be delivered in. Can be `json` or `ndjson`.
 - `endpoint` (String) Logs will be sent as POST requests to this URL. The endpoint will be verified, and must return a `200` status code and an `x-vercel-verify` header taken from the endpoint_verification data source. The value the `x-vercel-verify` header should be can be read from the `vercel_endpoint_verification_code` data source.
 - `environments` (Set of String) Logs from the selected environments will be forwarded to your webhook. At least one must be present.
-- `sources` (Set of String) A set of sources that the log drain should send logs for. Valid values are `static`, `edge`, `external`, `build` and `lambda`.
+- `sources` (Set of String) A set of sources that the log drain should send logs for. Valid values are `static`, `edge`, `external`, `build`, `lambda` and `firewall`.
 
 ### Optional
 

--- a/vercel/data_source_log_drain.go
+++ b/vercel/data_source_log_drain.go
@@ -92,7 +92,7 @@ Teams on Pro and Enterprise plans can subscribe to log drains that are generic a
 				Computed:    true,
 			},
 			"sources": schema.SetAttribute{
-				Description: "A set of sources that the log drain should send logs for. Valid values are `static`, `edge`, `external`, `build` and `function`.",
+				Description: "A set of sources that the log drain should send logs for. Valid values are `static`, `edge`, `external`, `build`, `lambda` and `firewall`.",
 				Computed:    true,
 				ElementType: types.StringType,
 			},

--- a/vercel/resource_log_drain.go
+++ b/vercel/resource_log_drain.go
@@ -136,7 +136,7 @@ Teams on Pro and Enterprise plans can subscribe to log drains that are generic a
 				},
 			},
 			"sources": schema.SetAttribute{
-				Description:   "A set of sources that the log drain should send logs for. Valid values are `static`, `edge`, `external`, `build` and `lambda`.",
+				Description:   "A set of sources that the log drain should send logs for. Valid values are `static`, `edge`, `external`, `build`, `lambda` and `firewall`.",
 				Required:      true,
 				ElementType:   types.StringType,
 				PlanModifiers: []planmodifier.Set{setplanmodifier.RequiresReplace()},


### PR DESCRIPTION
Turns out this was already supported, just missing from docs. 

Closes #361 