### PR TITLE
Support custom environments in vercel_deployment data source + resource

### DIFF
--- a/client/deployment.go
+++ b/client/deployment.go
@@ -38,14 +38,15 @@ type CreateDeploymentRequest struct {
 	Build       struct {
 		Environment map[string]string `json:"env,omitempty"`
 	} `json:"build,omitempty"`
-	ProjectID       string         `json:"project,omitempty"`
-	ProjectSettings map[string]any `json:"projectSettings"`
-	Name            string         `json:"name"`
-	Regions         []string       `json:"regions,omitempty"`
-	Routes          []any          `json:"routes,omitempty"`
-	Target          string         `json:"target,omitempty"`
-	GitSource       *gitSource     `json:"gitSource,omitempty"`
-	Ref             string         `json:"-"`
+	ProjectID                 string         `json:"project,omitempty"`
+	ProjectSettings           map[string]any `json:"projectSettings"`
+	Name                      string         `json:"name"`
+	Regions                   []string       `json:"regions,omitempty"`
+	Routes                    []any          `json:"routes,omitempty"`
+	Target                    string         `json:"target,omitempty"`
+	GitSource                 *gitSource     `json:"gitSource,omitempty"`
+	CustomEnvironmentSlugOrID string         `json:"customEnvironmentSlugOrId,omitempty"`
+	Ref                       string         `json:"-"`
 }
 
 // DeploymentResponse defines the response the Vercel API returns when a deployment is created or updated.
@@ -70,17 +71,20 @@ type DeploymentResponse struct {
 	Build struct {
 		Environment []string `json:"env"`
 	} `json:"build"`
-	AliasAssigned    bool      `json:"aliasAssigned"`
-	ChecksConclusion string    `json:"checksConclusion"`
-	ErrorCode        string    `json:"errorCode"`
-	ErrorMessage     string    `json:"errorMessage"`
-	ID               string    `json:"id"`
-	ProjectID        string    `json:"projectId"`
-	TeamID           string    `json:"-"`
-	ReadyState       string    `json:"readyState"`
-	Target           *string   `json:"target"`
-	URL              string    `json:"url"`
-	GitSource        gitSource `json:"gitSource"`
+	AliasAssigned     bool      `json:"aliasAssigned"`
+	ChecksConclusion  string    `json:"checksConclusion"`
+	ErrorCode         string    `json:"errorCode"`
+	ErrorMessage      string    `json:"errorMessage"`
+	ID                string    `json:"id"`
+	ProjectID         string    `json:"projectId"`
+	TeamID            string    `json:"-"`
+	ReadyState        string    `json:"readyState"`
+	Target            *string   `json:"target"`
+	URL               string    `json:"url"`
+	GitSource         gitSource `json:"gitSource"`
+	CustomEnvironment *struct {
+		ID string `json:"id"`
+	} `json:"customEnvironment"`
 }
 
 // IsComplete is used to determine whether a deployment is still processing, or whether it is fully done.

--- a/docs/data-sources/deployment.md
+++ b/docs/data-sources/deployment.md
@@ -34,6 +34,7 @@ data "vercel_deployment" "example" {
 
 ### Read-Only
 
+- `custom_environment_id` (String) The ID of the Custom Environment that the deployment was deployed to, if any.
 - `domains` (List of String) A list of all the domains (default domains, staging domains and production domains) that were assigned upon deployment creation.
 - `production` (Boolean) true if the deployment is a production deployment, meaning production aliases will be assigned.
 - `project_id` (String) The project ID to add the deployment to.

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -104,6 +104,7 @@ resource "vercel_deployment" "prebuilt_example" {
 
 ### Optional
 
+- `custom_environment_id` (String) The ID of the Custom Environment to deploy to. If not specified, the deployment will use the standard environments (production/preview).
 - `delete_on_destroy` (Boolean) Set to true to hard delete the Vercel deployment when destroying the Terraform resource. If unspecified, deployments are retained indefinitely. Note that deleted deployments are not recoverable.
 - `environment` (Map of String) A map of environment variable names to values. These are specific to a Deployment, and can also be configured on the `vercel_project` resource.
 - `files` (Map of String) A map of files to be uploaded for the deployment. This should be provided by a `vercel_project_directory` or `vercel_file` data source. Required if `git_source` is not set.

--- a/vercel/data_source_deployment.go
+++ b/vercel/data_source_deployment.go
@@ -87,18 +87,23 @@ A Deployment is the result of building your Project and making it available thro
 				Description: "The branch or commit hash that has been deployed. Note this will only work if the project is configured to use a Git repository.",
 				Computed:    true,
 			},
+			"custom_environment_id": schema.StringAttribute{
+				Description: "The ID of the Custom Environment that the deployment was deployed to, if any.",
+				Computed:    true,
+			},
 		},
 	}
 }
 
 type DeploymentDataSource struct {
-	Domains    types.List   `tfsdk:"domains"`
-	ID         types.String `tfsdk:"id"`
-	Production types.Bool   `tfsdk:"production"`
-	ProjectID  types.String `tfsdk:"project_id"`
-	TeamID     types.String `tfsdk:"team_id"`
-	URL        types.String `tfsdk:"url"`
-	Ref        types.String `tfsdk:"ref"`
+	Domains             types.List   `tfsdk:"domains"`
+	ID                  types.String `tfsdk:"id"`
+	Production          types.Bool   `tfsdk:"production"`
+	ProjectID           types.String `tfsdk:"project_id"`
+	TeamID              types.String `tfsdk:"team_id"`
+	URL                 types.String `tfsdk:"url"`
+	Ref                 types.String `tfsdk:"ref"`
+	CustomEnvironmentID types.String `tfsdk:"custom_environment_id"`
 }
 
 func convertResponseToDeploymentDataSource(in client.DeploymentResponse) DeploymentDataSource {
@@ -111,14 +116,21 @@ func convertResponseToDeploymentDataSource(in client.DeploymentResponse) Deploym
 	for _, a := range in.Aliases {
 		domains = append(domains, types.StringValue(a))
 	}
+
+	customEnvironmentID := types.StringNull()
+	if in.CustomEnvironment != nil && in.CustomEnvironment.ID != "" {
+		customEnvironmentID = types.StringValue(in.CustomEnvironment.ID)
+	}
+
 	return DeploymentDataSource{
-		Domains:    types.ListValueMust(types.StringType, domains),
-		Production: types.BoolValue(in.Target != nil && *in.Target == "production"),
-		TeamID:     toTeamID(in.TeamID),
-		ProjectID:  types.StringValue(in.ProjectID),
-		ID:         types.StringValue(in.ID),
-		URL:        types.StringValue(in.URL),
-		Ref:        ref,
+		Domains:             types.ListValueMust(types.StringType, domains),
+		Production:          types.BoolValue(in.Target != nil && *in.Target == "production"),
+		TeamID:              toTeamID(in.TeamID),
+		ProjectID:           types.StringValue(in.ProjectID),
+		ID:                  types.StringValue(in.ID),
+		URL:                 types.StringValue(in.URL),
+		Ref:                 ref,
+		CustomEnvironmentID: customEnvironmentID,
 	}
 }
 


### PR DESCRIPTION
This was missed from initial custom environment support. 

Closes #293 