### PR TITLE
Fix: Initialize SRV field as null for non-SRV DNS records

### DIFF
--- a/vercel/resource_dns_record.go
+++ b/vercel/resource_dns_record.go
@@ -314,6 +314,7 @@ func convertResponseToDNSRecord(r client.DNSRecord, value types.String, srvObj t
 		if split[1] == fmt.Sprintf("%s.", value.ValueString()) {
 			record.Value = value
 		}
+		record.SRV = types.ObjectNull(srvAttrType.AttrTypes)
 		return record, nil
 	}
 
@@ -321,6 +322,7 @@ func convertResponseToDNSRecord(r client.DNSRecord, value types.String, srvObj t
 	if r.Value == fmt.Sprintf("%s.", value.ValueString()) {
 		record.Value = value
 	}
+	record.SRV = types.ObjectNull(srvAttrType.AttrTypes)
 	return record, nil
 }
 

--- a/vercel/resource_dns_record_unit_test.go
+++ b/vercel/resource_dns_record_unit_test.go
@@ -1,0 +1,41 @@
+package vercel
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/vercel/terraform-provider-vercel/v3/client"
+)
+
+// TestConvertResponseToDNSRecord_InitializesSRVField ensures non-SRV records
+// have their SRV field properly initialized to prevent "Value Conversion Error"
+// Regression test for issue introduced in commit e7dd870
+func TestConvertResponseToDNSRecord_InitializesSRVField(t *testing.T) {
+	// Test a non-SRV record (CNAME)
+	cnameRecord := client.DNSRecord{
+		ID:         "test-id",
+		Domain:     "example.com",
+		Name:       "subdomain",
+		RecordType: "CNAME",
+		Value:      "target.example.com",
+		TTL:        60,
+	}
+
+	result, err := convertResponseToDNSRecord(
+		cnameRecord,
+		types.StringValue("target.example.com"),
+		types.ObjectNull(srvAttrType.AttrTypes),
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The critical check: SRV must be initialized (not unknown) and must be null
+	if result.SRV.IsUnknown() {
+		t.Fatal("SRV field is unknown, should be null for non-SRV records")
+	}
+	if !result.SRV.IsNull() {
+		t.Fatal("SRV field is not null for CNAME record")
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes a critical bug introduced in #392 (commit e7dd870) that causes all non-SRV DNS records to fail with a "Value Conversion Error" in version 3.15.1.

## Problem

After the changes to support Unknown values in #392, the `SRV` field in the `DNSRecord` struct was changed from a pointer (`*SRV`) to `types.Object`. However, the `convertResponseToDNSRecord` function was not updated to properly initialize this field for non-SRV record types.

This results in the following error for all CNAME, TXT, A, AAAA, MX, and other non-SRV records:

```
Error: Value Conversion Error

An unexpected error was encountered while verifying an attribute value
matched its expected type to prevent unexpected behavior or panics. This is
always an error in the provider.

Expected framework type from provider logic:
types.ObjectType["port":basetypes.Int64Type, "priority":basetypes.Int64Type,
"target":basetypes.StringType, "weight":basetypes.Int64Type]
Received framework type from provider logic: types.ObjectType[]
Path: srv
```

## Solution

The fix ensures that for non-SRV records (MX, CNAME, TXT, A, etc.), the `SRV` field is explicitly initialized as `types.ObjectNull(srvAttrType.AttrTypes)` to match the expected type structure. This follows the same pattern used throughout the codebase for nullable Object fields.

## Changes Made

- Added `record.SRV = types.ObjectNull(srvAttrType.AttrTypes)` for MX records (line 317)
- Added `record.SRV = types.ObjectNull(srvAttrType.AttrTypes)` for all other non-SRV records (line 325)

## Testing

### Unit Test
I've added a minimal unit test to prevent regression. **Note:** I noticed there are virtually no other unit tests in the repository (only acceptance tests), so this might seem out of place. I'm happy to remove the test if you prefer to keep the codebase consistent with only acceptance tests.

### Manual Testing
The fix has been verified in production Terraform with multiple DNS record types (CNAME, TXT, etc.) and resolves the issue completely.

## Impact

This bug affects all users of version 3.15.1 who have DNS records that are not of type SRV. The fix is minimal (2 lines) and only affects the initialization of the SRV field for non-SRV records.

## Related Issues

- Introduced by: #392 (Fix typings internally to support Unknown values)
- Affects: All DNS record resources except SRV type in v3.15.1