### PR TITLE
Update `PreviewDeploymentSuffix` field to be optional

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -323,7 +323,7 @@ type UpdateProjectRequest struct {
 	InstallCommand                       *string                         `json:"installCommand"`
 	Name                                 *string                         `json:"name,omitempty"`
 	OutputDirectory                      *string                         `json:"outputDirectory"`
-	PreviewDeploymentSuffix              *string                         `json:"previewDeploymentSuffix"`
+	PreviewDeploymentSuffix              *string                         `json:"previewDeploymentSuffix,omitempty"`
 	PublicSource                         *bool                           `json:"publicSource"`
 	RootDirectory                        *string                         `json:"rootDirectory"`
 	ServerlessFunctionRegion             string                          `json:"serverlessFunctionRegion,omitempty"`


### PR DESCRIPTION
When deploying a project that has a preview deployment suffix set (for example, through the Vercel UI), we want to ensure that terraform deployment doesn't override with nil if not the value is not specified.