### PR TITLE
Add Node.js 24.x version support

### DIFF
--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -133,6 +133,7 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 						"18.x",
 						"20.x",
 						"22.x",
+						"24.x",
 					),
 				},
 				Description: "The version of Node.js that is used in the Build Step and for Serverless Functions. A new Deployment is required for your changes to take effect.",


### PR DESCRIPTION
Since Vercel started supporting Node.js 24, Terraform provider should have the corresponding validation.
This PR adds Node.js 24.x version support.

- ref: https://vercel.com/changelog/node-js-24-lts-is-now-generally-available-for-builds-and-functions
