### PR TITLE
fix(go): update module path to v4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vercel/terraform-provider-vercel/v3
+module github.com/vercel/terraform-provider-vercel/v4
 
 go 1.24.0
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/vercel/terraform-provider-vercel/v3/vercel"
+	"github.com/vercel/terraform-provider-vercel/v4/vercel"
 )
 
 func main() {

--- a/sweep/main.go
+++ b/sweep/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func main() {

--- a/vercel/data_source_access_group.go
+++ b/vercel/data_source_access_group.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_access_group_project.go
+++ b/vercel/data_source_access_group_project.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_alias.go
+++ b/vercel/data_source_alias.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_attack_challenge_mode.go
+++ b/vercel/data_source_attack_challenge_mode.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_custom_environment.go
+++ b/vercel/data_source_custom_environment.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_deployment.go
+++ b/vercel/data_source_deployment.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_domain_config.go
+++ b/vercel/data_source_domain_config.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_dsync_groups.go
+++ b/vercel/data_source_dsync_groups.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/data_source_edge_config.go
+++ b/vercel/data_source_edge_config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_edge_config_item.go
+++ b/vercel/data_source_edge_config_item.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_edge_config_schema.go
+++ b/vercel/data_source_edge_config_schema.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_edge_config_token.go
+++ b/vercel/data_source_edge_config_token.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_endpoint_verification.go
+++ b/vercel/data_source_endpoint_verification.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_file.go
+++ b/vercel/data_source_file.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_log_drain.go
+++ b/vercel/data_source_log_drain.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_microfrontend_group.go
+++ b/vercel/data_source_microfrontend_group.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_microfrontend_group_membership.go
+++ b/vercel/data_source_microfrontend_group_membership.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_prebuilt_project.go
+++ b/vercel/data_source_prebuilt_project.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
-	"github.com/vercel/terraform-provider-vercel/v3/file"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v4/file"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_project_deployment_retention.go
+++ b/vercel/data_source_project_deployment_retention.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/data_source_project_directory.go
+++ b/vercel/data_source_project_directory.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
-	"github.com/vercel/terraform-provider-vercel/v3/file"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v4/file"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_project_members.go
+++ b/vercel/data_source_project_members.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/data_source_project_rolling_release.go
+++ b/vercel/data_source_project_rolling_release.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/data_source_shared_environment_variable.go
+++ b/vercel/data_source_shared_environment_variable.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_team_config.go
+++ b/vercel/data_source_team_config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/data_source_team_member.go
+++ b/vercel/data_source_team_member.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/git_metadata.go
+++ b/vercel/git_metadata.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // findRepoRoot traverses upward from startDir until it finds either

--- a/vercel/provider.go
+++ b/vercel/provider.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 type vercelProvider struct{}

--- a/vercel/provider_test.go
+++ b/vercel/provider_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
-	"github.com/vercel/terraform-provider-vercel/v3/vercel"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v4/vercel"
 )
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){

--- a/vercel/resource_access_group.go
+++ b/vercel/resource_access_group.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_access_group_project.go
+++ b/vercel/resource_access_group_project.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_access_group_project_test.go
+++ b/vercel/resource_access_group_project_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func TestAcc_AccessGroupProjectResource(t *testing.T) {

--- a/vercel/resource_access_group_test.go
+++ b/vercel/resource_access_group_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func TestAcc_AccessGroupResource(t *testing.T) {

--- a/vercel/resource_alias.go
+++ b/vercel/resource_alias.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_alias_test.go
+++ b/vercel/resource_alias_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testCheckAliasExists(testClient *client.Client, teamID, alias string) resource.TestCheckFunc {

--- a/vercel/resource_attack_challenge_mode.go
+++ b/vercel/resource_attack_challenge_mode.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_custom_certificate.go
+++ b/vercel/resource_custom_certificate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_custom_certificate_test.go
+++ b/vercel/resource_custom_certificate_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testCheckCustomCertificateDoesNotExist(testClient *client.Client, teamID string, n string) resource.TestCheckFunc {

--- a/vercel/resource_custom_environment.go
+++ b/vercel/resource_custom_environment.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/resource_custom_environment_test.go
+++ b/vercel/resource_custom_environment_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testCheckCustomEnvironmentExists(testClient *client.Client, teamID string, n string) resource.TestCheckFunc {

--- a/vercel/resource_deployment.go
+++ b/vercel/resource_deployment.go
@@ -23,8 +23,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
-	"github.com/vercel/terraform-provider-vercel/v3/file"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v4/file"
 )
 
 var (

--- a/vercel/resource_deployment_test.go
+++ b/vercel/resource_deployment_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testAccDeploymentExists(testClient *client.Client, n string, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_dns_record.go
+++ b/vercel/resource_dns_record.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/resource_dns_record_test.go
+++ b/vercel/resource_dns_record_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testAccDNSRecordDestroy(testClient *client.Client, n, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_edge_config.go
+++ b/vercel/resource_edge_config.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_edge_config_item.go
+++ b/vercel/resource_edge_config_item.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_edge_config_item_test.go
+++ b/vercel/resource_edge_config_item_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func getEdgeConfigItemImportID(n string) resource.ImportStateIdFunc {

--- a/vercel/resource_edge_config_schema.go
+++ b/vercel/resource_edge_config_schema.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_edge_config_schema_test.go
+++ b/vercel/resource_edge_config_schema_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testCheckEdgeConfigSchemaExists(testClient *client.Client, teamID, n string) resource.TestCheckFunc {

--- a/vercel/resource_edge_config_test.go
+++ b/vercel/resource_edge_config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testCheckEdgeConfigExists(testClient *client.Client, teamID, n string) resource.TestCheckFunc {

--- a/vercel/resource_edge_config_token.go
+++ b/vercel/resource_edge_config_token.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_edge_config_token_test.go
+++ b/vercel/resource_edge_config_token_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testCheckEdgeConfigTokenExists(testClient *client.Client, teamID, n string) resource.TestCheckFunc {

--- a/vercel/resource_firewall_bypass.go
+++ b/vercel/resource_firewall_bypass.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_firewall_config.go
+++ b/vercel/resource_firewall_config.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_integration_project_access.go
+++ b/vercel/resource_integration_project_access.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/resource_integration_project_access_test.go
+++ b/vercel/resource_integration_project_access_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testCheckIntegrationProjectAccessDestroyed(testClient *client.Client, n, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_log_drain.go
+++ b/vercel/resource_log_drain.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_log_drain_test.go
+++ b/vercel/resource_log_drain_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testCheckLogDrainExists(testClient *client.Client, teamID, n string) resource.TestCheckFunc {

--- a/vercel/resource_microfrontend_group.go
+++ b/vercel/resource_microfrontend_group.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/resource_microfrontend_group_membership.go
+++ b/vercel/resource_microfrontend_group_membership.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/resource_microfrontend_group_test.go
+++ b/vercel/resource_microfrontend_group_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testCheckMicrofrontendGroupExists(testClient *client.Client, teamID, n string) resource.TestCheckFunc {

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/resource_project_crons.go
+++ b/vercel/resource_project_crons.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Compile-time assertions to ensure the implementation conforms to the expected interfaces.

--- a/vercel/resource_project_crons_test.go
+++ b/vercel/resource_project_crons_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testAccProjectCronsExists(testClient *client.Client, n, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_project_deployment_retention.go
+++ b/vercel/resource_project_deployment_retention.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/resource_project_deployment_retention_test.go
+++ b/vercel/resource_project_deployment_retention_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testAccProjectDeploymentRetentionExists(testClient *client.Client, n, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_project_domain.go
+++ b/vercel/resource_project_domain.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/resource_project_domain_test.go
+++ b/vercel/resource_project_domain_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func TestAcc_ProjectDomain(t *testing.T) {

--- a/vercel/resource_project_environment_variable.go
+++ b/vercel/resource_project_environment_variable.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/resource_project_environment_variable_test.go
+++ b/vercel/resource_project_environment_variable_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testAccProjectEnvironmentVariableExists(testClient *client.Client, n, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_project_environment_variables.go
+++ b/vercel/resource_project_environment_variables.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func strPtrEqual(a, b *string) bool {

--- a/vercel/resource_project_members.go
+++ b/vercel/resource_project_members.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/resource_project_rolling_release.go
+++ b/vercel/resource_project_rolling_release.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/resource_project_rolling_release_test.go
+++ b/vercel/resource_project_rolling_release_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func getRollingReleaseImportId(n string) resource.ImportStateIdFunc {

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func TestAcc_Project(t *testing.T) {

--- a/vercel/resource_shared_environment_variable.go
+++ b/vercel/resource_shared_environment_variable.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/resource_shared_environment_variable_project_link.go
+++ b/vercel/resource_shared_environment_variable_project_link.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 var (

--- a/vercel/resource_shared_environment_variable_project_link_test.go
+++ b/vercel/resource_shared_environment_variable_project_link_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testCheckSharedEnvironmentVariableProjectUnlinked(testClient *client.Client, envVarName, projectName, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_shared_environment_variable_test.go
+++ b/vercel/resource_shared_environment_variable_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testAccSharedEnvironmentVariableExists(testClient *client.Client, n, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_team_config.go
+++ b/vercel/resource_team_config.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_team_member.go
+++ b/vercel/resource_team_member.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_webhook.go
+++ b/vercel/resource_webhook.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_webhook_test.go
+++ b/vercel/resource_webhook_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v3/client"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func testCheckWebhookExists(testClient *client.Client, teamID, n string) resource.TestCheckFunc {


### PR DESCRIPTION
## Summary

Updates the Go module path from `github.com/vercel/terraform-provider-vercel/v3` to `github.com/vercel/terraform-provider-vercel/v4` to align with the v4.x release tags.

## What changed

- Updated `go.mod` module declaration
- Updated all internal imports across 86 files

## Why

Go modules require the major version suffix in the module path for versions >= 2. Since v4.0.0 has been released, the module path needs to reflect this for proper `go get` compatibility.

---

👋 Hey team! Happy to help keep the module path aligned with releases — I did the same for [v2 in #227](https://github.com/vercel/terraform-provider-vercel/pull/227) and [offered for v3 in #315](https://github.com/vercel/terraform-provider-vercel/pull/315). 

I maintain the [Pulumi bridge for Vercel](https://github.com/pulumiverse/pulumi-vercel), so keeping the module path in sync helps me (and other downstream consumers) stay up to date with your releases.

Feel free to let me know if you'd like any changes, or if there's a preferred workflow for these updates going forward!