### PR TITLE
Expose verification records on vercel_project_domain

### DIFF
--- a/client/project_domain.go
+++ b/client/project_domain.go
@@ -43,7 +43,7 @@ func (c *Client) CreateProjectDomain(ctx context.Context, projectID, teamID stri
 
 // DeleteProjectDomain removes any association of a domain name with a Vercel project.
 func (c *Client) DeleteProjectDomain(ctx context.Context, projectID, domain, teamID string) error {
-	url := fmt.Sprintf("%s/v8/projects/%s/domains/%s", c.baseURL, projectID, domain)
+	url := fmt.Sprintf("%s/v9/projects/%s/domains/%s", c.baseURL, projectID, domain)
 	if c.TeamID(teamID) != "" {
 		url = fmt.Sprintf("%s?teamId=%s", url, c.TeamID(teamID))
 	}
@@ -59,21 +59,32 @@ func (c *Client) DeleteProjectDomain(ctx context.Context, projectID, domain, tea
 	}, nil)
 }
 
+// ProjectDomainVerification describes a DNS challenge that must be satisfied to
+// verify ownership of a project domain.
+type ProjectDomainVerification struct {
+	Type   string `json:"type"`
+	Domain string `json:"domain"`
+	Value  string `json:"value"`
+	Reason string `json:"reason"`
+}
+
 // ProjectDomainResponse defines the information that Vercel exposes about a domain that is
 // associated with a vercel project.
 type ProjectDomainResponse struct {
-	Name                string  `json:"name"`
-	ProjectID           string  `json:"projectId"`
-	TeamID              string  `json:"-"`
-	Redirect            *string `json:"redirect"`
-	RedirectStatusCode  *int64  `json:"redirectStatusCode"`
-	GitBranch           *string `json:"gitBranch"`
-	CustomEnvironmentID *string `json:"customEnvironmentId"`
+	Name                string                      `json:"name"`
+	ProjectID           string                      `json:"projectId"`
+	TeamID              string                      `json:"-"`
+	Redirect            *string                     `json:"redirect"`
+	RedirectStatusCode  *int64                      `json:"redirectStatusCode"`
+	GitBranch           *string                     `json:"gitBranch"`
+	CustomEnvironmentID *string                     `json:"customEnvironmentId"`
+	Verified            bool                        `json:"verified"`
+	Verification        []ProjectDomainVerification `json:"verification"`
 }
 
 // GetProjectDomain retrieves information about a project domain from Vercel.
 func (c *Client) GetProjectDomain(ctx context.Context, projectID, domain, teamID string) (r ProjectDomainResponse, err error) {
-	url := fmt.Sprintf("%s/v8/projects/%s/domains/%s", c.baseURL, projectID, domain)
+	url := fmt.Sprintf("%s/v9/projects/%s/domains/%s", c.baseURL, projectID, domain)
 	if c.TeamID(teamID) != "" {
 		url = fmt.Sprintf("%s?teamId=%s", url, c.TeamID(teamID))
 	}
@@ -101,7 +112,7 @@ type UpdateProjectDomainRequest struct {
 
 // UpdateProjectDomain updates an existing project domain within Vercel.
 func (c *Client) UpdateProjectDomain(ctx context.Context, projectID, domain, teamID string, request UpdateProjectDomainRequest) (r ProjectDomainResponse, err error) {
-	url := fmt.Sprintf("%s/v8/projects/%s/domains/%s", c.baseURL, projectID, domain)
+	url := fmt.Sprintf("%s/v9/projects/%s/domains/%s", c.baseURL, projectID, domain)
 	if c.TeamID(teamID) != "" {
 		url = fmt.Sprintf("%s?teamId=%s", url, c.TeamID(teamID))
 	}

--- a/docs/resources/project_domain.md
+++ b/docs/resources/project_domain.md
@@ -60,6 +60,18 @@ resource "vercel_project_domain" "example_redirect" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `verification` (Attributes List) A list of verification challenges, one of which must be completed to verify the domain for use on the project. Once the challenge is satisfied, the domain will be verified automatically on the next refresh. Typically used to configure DNS records (e.g. a `TXT` record) for domains hosted with an external DNS provider. (see [below for nested schema](#nestedatt--verification))
+- `verified` (Boolean) Whether the domain is verified for use with the project. If `false`, the challenges in `verification` must be completed before the domain will serve traffic for the project.
+
+<a id="nestedatt--verification"></a>
+### Nested Schema for `verification`
+
+Read-Only:
+
+- `domain` (String) The domain name on which the DNS record must be created.
+- `reason` (String) A human-readable explanation of why this challenge was issued.
+- `type` (String) The type of DNS record that must be created to satisfy the challenge (e.g. `TXT`).
+- `value` (String) The value that the DNS record must contain.
 
 ## Import
 

--- a/vercel/resource_project_domain.go
+++ b/vercel/resource_project_domain.go
@@ -113,23 +113,71 @@ By default, Project Domains will be automatically applied to any ` + "`productio
 					),
 				},
 			},
+			"verified": schema.BoolAttribute{
+				Description: "Whether the domain is verified for use with the project. If `false`, the challenges in `verification` must be completed before the domain will serve traffic for the project.",
+				Computed:    true,
+			},
+			"verification": schema.ListNestedAttribute{
+				Description: "A list of verification challenges, one of which must be completed to verify the domain for use on the project. Once the challenge is satisfied, the domain will be verified automatically on the next refresh. Typically used to configure DNS records (e.g. a `TXT` record) for domains hosted with an external DNS provider.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"type": schema.StringAttribute{
+							Description: "The type of DNS record that must be created to satisfy the challenge (e.g. `TXT`).",
+							Computed:    true,
+						},
+						"domain": schema.StringAttribute{
+							Description: "The domain name on which the DNS record must be created.",
+							Computed:    true,
+						},
+						"value": schema.StringAttribute{
+							Description: "The value that the DNS record must contain.",
+							Computed:    true,
+						},
+						"reason": schema.StringAttribute{
+							Description: "A human-readable explanation of why this challenge was issued.",
+							Computed:    true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
 
+// ProjectDomainVerification mirrors a single verification challenge returned by the Vercel API.
+type ProjectDomainVerification struct {
+	Type   types.String `tfsdk:"type"`
+	Domain types.String `tfsdk:"domain"`
+	Value  types.String `tfsdk:"value"`
+	Reason types.String `tfsdk:"reason"`
+}
+
 // ProjectDomain reflects the state terraform stores internally for a project domain.
 type ProjectDomain struct {
-	Domain              types.String `tfsdk:"domain"`
-	GitBranch           types.String `tfsdk:"git_branch"`
-	CustomEnvironmentID types.String `tfsdk:"custom_environment_id"`
-	ID                  types.String `tfsdk:"id"`
-	ProjectID           types.String `tfsdk:"project_id"`
-	Redirect            types.String `tfsdk:"redirect"`
-	RedirectStatusCode  types.Int64  `tfsdk:"redirect_status_code"`
-	TeamID              types.String `tfsdk:"team_id"`
+	Domain              types.String                `tfsdk:"domain"`
+	GitBranch           types.String                `tfsdk:"git_branch"`
+	CustomEnvironmentID types.String                `tfsdk:"custom_environment_id"`
+	ID                  types.String                `tfsdk:"id"`
+	ProjectID           types.String                `tfsdk:"project_id"`
+	Redirect            types.String                `tfsdk:"redirect"`
+	RedirectStatusCode  types.Int64                 `tfsdk:"redirect_status_code"`
+	TeamID              types.String                `tfsdk:"team_id"`
+	Verified            types.Bool                  `tfsdk:"verified"`
+	Verification        []ProjectDomainVerification `tfsdk:"verification"`
 }
 
 func convertResponseToProjectDomain(response client.ProjectDomainResponse) ProjectDomain {
+	verification := make([]ProjectDomainVerification, 0, len(response.Verification))
+	for _, v := range response.Verification {
+		verification = append(verification, ProjectDomainVerification{
+			Type:   types.StringValue(v.Type),
+			Domain: types.StringValue(v.Domain),
+			Value:  types.StringValue(v.Value),
+			Reason: types.StringValue(v.Reason),
+		})
+	}
+
 	return ProjectDomain{
 		Domain:              types.StringValue(response.Name),
 		GitBranch:           types.StringPointerValue(response.GitBranch),
@@ -139,6 +187,8 @@ func convertResponseToProjectDomain(response client.ProjectDomainResponse) Proje
 		Redirect:            types.StringPointerValue(response.Redirect),
 		RedirectStatusCode:  types.Int64PointerValue(response.RedirectStatusCode),
 		TeamID:              toTeamID(response.TeamID),
+		Verified:            types.BoolValue(response.Verified),
+		Verification:        verification,
 	}
 }
 

--- a/vercel/resource_project_domain_test.go
+++ b/vercel/resource_project_domain_test.go
@@ -40,6 +40,8 @@ func TestAcc_ProjectDomain(t *testing.T) {
 					testAccProjectDomainExists(testClient(t), "vercel_project.test", testTeam(t), "2"+domain),
 					testTeamID,
 					resource.TestCheckResourceAttr("vercel_project_domain.test", "domain", "2"+domain),
+					resource.TestCheckResourceAttrSet("vercel_project_domain.test", "verified"),
+					resource.TestCheckResourceAttrSet("vercel_project_domain.test", "verification.#"),
 				),
 			},
 			// Update testing


### PR DESCRIPTION
## Summary

- Adds computed `verified` and `verification` attributes to the `vercel_project_domain` resource, so users whose domains are hosted with an external DNS provider can also provision the challenge records.
- Bumps the GET/PATCH/DELETE client calls from `v8` to `v9`; `v9` is the version that reliably returns `verified` / `verification`.

Example usage, paired w/ AWS provider to satisfy the TXT challenge:

```hcl
resource "vercel_project_domain" "example" {
  project_id = vercel_project.example.id
  domain     = "example.com"
}

resource "aws_route53_record" "vercel_verification" {
  for_each = {
    for v in vercel_project_domain.example.verification : "${v.domain}:${v.type}" => v
  }
  zone_id = aws_route53_zone.example.zone_id
  name    = each.value.domain
  type    = each.value.type
  records = [each.value.value]
  ttl     = 60
}
```

Refs #199.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `staticcheck ./client/ ./vercel/`
- [x] `gofmt -s -l` clean
- [x] Added assertions on `verified` / `verification.#` to the existing `TestAcc_ProjectDomain` step
- [x] Full acceptance test run (`task test`)