### PR TITLE
fix: make protection_bypass_for_automation idempotent on re-apply

### DIFF
--- a/vercel/plan_modifier_automation_bypass_secret.go
+++ b/vercel/plan_modifier_automation_bypass_secret.go
@@ -1,0 +1,51 @@
+package vercel
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// useStateForAutomationBypassSecret preserves the previously generated/stored
+// protection_bypass_for_automation_secret across plans when the user has not
+// supplied a new secret in config and bypass is not being disabled. Without
+// this, the attribute is recomputed to Unknown on every plan which produces a
+// spurious diff and, during apply, causes the Update path to issue a
+// revoke-only request to the API (see issue #473).
+func useStateForAutomationBypassSecret() planmodifier.String {
+	return automationBypassSecretPlanModifier{}
+}
+
+type automationBypassSecretPlanModifier struct{}
+
+func (m automationBypassSecretPlanModifier) Description(_ context.Context) string {
+	return "Preserve the stored protection_bypass_for_automation_secret when it isn't being rotated or revoked."
+}
+
+func (m automationBypassSecretPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m automationBypassSecretPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.StateValue.IsNull() {
+		return
+	}
+	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	planBypass := types.Bool{}
+	diags := req.Plan.GetAttribute(ctx, path.Root("protection_bypass_for_automation"), &planBypass)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !planBypass.ValueBool() {
+		resp.PlanValue = types.StringUnknown()
+		return
+	}
+
+	resp.PlanValue = req.StateValue
+}

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -426,10 +426,11 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				Description: "Allow automation services to bypass Deployment Protection on this project when using an HTTP header named `x-vercel-protection-bypass` with a value of the `protection_bypass_for_automation_secret` field.",
 			},
 			"protection_bypass_for_automation_secret": schema.StringAttribute{
-				Computed:    true,
-				Optional:    true,
-				Sensitive:   true,
-				Description: "If `protection_bypass_for_automation` is enabled, optionally set this value to specify a 32 character secret, otherwise a secret will be generated.",
+				Computed:      true,
+				Optional:      true,
+				Sensitive:     true,
+				Description:   "If `protection_bypass_for_automation` is enabled, optionally set this value to specify a 32 character secret, otherwise a secret will be generated.",
+				PlanModifiers: []planmodifier.String{useStateForAutomationBypassSecret()},
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(`^[a-zA-Z0-9]{32}$`),

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -594,6 +594,39 @@ func TestAcc_ProjectWithAutomationBypass(t *testing.T) {
 	})
 }
 
+func TestAcc_ProjectAutomationBypassIdempotent(t *testing.T) {
+	projectSuffix := acctest.RandString(16)
+	config := fmt.Sprintf(`
+resource "vercel_project" "idempotent" {
+    name = "test-acc-bypass-idem-%s"
+    protection_bypass_for_automation = true
+}
+`, projectSuffix)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccProjectDestroy(testClient(t), "vercel_project.idempotent", testTeam(t)),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(config),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectExists(testClient(t), "vercel_project.idempotent", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_project.idempotent", "protection_bypass_for_automation", "true"),
+					resource.TestCheckResourceAttrSet("vercel_project.idempotent", "protection_bypass_for_automation_secret"),
+				),
+			},
+			{
+				Config: cfg(config),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func getProjectImportID(n string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[n]


### PR DESCRIPTION
## Summary

Fixes #473 — a regression introduced in #463 (commit 8647a94) where a project with `protection_bypass_for_automation = true` and no secret supplied in config would fail on every subsequent `terraform apply` with:

```
Error: Error updating protection bypass for automation
... unexpected error updating Protection Bypass For Automation: error adding
protection bypass for automation: the response contained an unexpected number of items (0)
```

### Root cause

#463 removed the state-preserving plan modifier from `protection_bypass_for_automation_secret`. Because the attribute is `Computed: true, Optional: true`, leaving it unset in config then causes the plan to mark it Unknown on every refresh. In `Update()`, `plannedSecret` is empty (from Unknown) and `currentSecret` holds the stored generated value, so the `else if currentSecret != plannedSecret` branch fires and calls the API with a revoke-only body (no `generate` clause). The response has 0 items and the provider errors out.

### Fix

Reintroduce a plan modifier — but only for the case that needs it. `useStateForAutomationBypassSecret` copies state to plan when:

- state has a secret, and
- the user did not set a secret in config, and
- bypass is not being disabled in this plan

This preserves idempotency for the generated-secret case without reviving the post-apply inconsistency that motivated removing `UseStateForUnknown` in #463 (where bypass being disabled or the secret being rotated would cause the planned value to drift from the apply result). In those scenarios the modifier returns early and leaves the plan as Unknown, which is compatible with any post-apply value.

### Test

Added `TestAcc_ProjectAutomationBypassIdempotent` which creates a project with `protection_bypass_for_automation = true` (generated secret) and then re-applies the same config with `plancheck.ExpectEmptyPlan()` — the exact scenario from #473.

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass
- [ ] `TestAcc_ProjectAutomationBypassIdempotent` passes against a real Vercel team
- [ ] Existing `TestAcc_ProjectWithAutomationBypass` still passes (covers rotate / disable paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)