### PR TITLE
fix: bypass secret rotation via computed input (e.g. random_password.keepers)

### DIFF
--- a/vercel/plan_modifier_automation_bypass_secret.go
+++ b/vercel/plan_modifier_automation_bypass_secret.go
@@ -14,6 +14,15 @@ import (
 // this, the attribute is recomputed to Unknown on every plan which produces a
 // spurious diff and, during apply, causes the Update path to issue a
 // revoke-only request to the API (see issue #473).
+//
+// When the config value is Unknown (e.g. because the user wired
+// `random_password.result` — or any other computed attribute — into
+// protection_bypass_for_automation_secret and that upstream resource is being
+// replaced), we must NOT freeze the old state value into the plan. Doing so
+// causes Terraform core to report "inconsistent values for sensitive
+// attribute" once the upstream value becomes known during apply and differs
+// from the preserved state value. In that case we explicitly plan Unknown so
+// the newly learned value flows through normally.
 func useStateForAutomationBypassSecret() planmodifier.String {
 	return automationBypassSecretPlanModifier{}
 }
@@ -32,7 +41,13 @@ func (m automationBypassSecretPlanModifier) PlanModifyString(ctx context.Context
 	if req.StateValue.IsNull() {
 		return
 	}
-	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() {
+
+	if req.ConfigValue.IsUnknown() {
+		resp.PlanValue = types.StringUnknown()
+		return
+	}
+
+	if !req.ConfigValue.IsNull() {
 		return
 	}
 

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -627,6 +627,75 @@ resource "vercel_project" "idempotent" {
 	})
 }
 
+// TestAcc_ProjectAutomationBypassRotateViaComputedInput verifies that rotating
+// protection_bypass_for_automation_secret via a computed/unknown input (e.g.
+// random_password.result with keepers) applies cleanly. Previously this
+// triggered "Provider produced inconsistent final plan ... inconsistent values
+// for sensitive attribute" because the plan modifier preserved the stale
+// state value when the config was unknown.
+func TestAcc_ProjectAutomationBypassRotateViaComputedInput(t *testing.T) {
+	projectSuffix := acctest.RandString(16)
+	configTemplate := `
+terraform {
+  required_providers {
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+}
+
+resource "random_password" "rotating_secret" {
+  length  = 32
+  special = false
+
+  keepers = {
+    seed = "%s"
+  }
+}
+
+resource "vercel_project" "rotate_via_computed" {
+  name                                    = "test-acc-bypass-rotate-%s"
+  protection_bypass_for_automation        = true
+  protection_bypass_for_automation_secret = random_password.rotating_secret.result
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source: "hashicorp/random",
+			},
+		},
+		CheckDestroy: testAccProjectDestroy(testClient(t), "vercel_project.rotate_via_computed", testTeam(t)),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(fmt.Sprintf(configTemplate, "seed-1", projectSuffix)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectExists(testClient(t), "vercel_project.rotate_via_computed", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_project.rotate_via_computed", "protection_bypass_for_automation", "true"),
+					resource.TestCheckResourceAttrSet("vercel_project.rotate_via_computed", "protection_bypass_for_automation_secret"),
+				),
+			},
+			{
+				Config: cfg(fmt.Sprintf(configTemplate, "seed-2", projectSuffix)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("vercel_project.rotate_via_computed", "protection_bypass_for_automation", "true"),
+					resource.TestCheckResourceAttrSet("vercel_project.rotate_via_computed", "protection_bypass_for_automation_secret"),
+				),
+			},
+			{
+				Config: cfg(fmt.Sprintf(configTemplate, "seed-2", projectSuffix)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func getProjectImportID(n string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[n]


### PR DESCRIPTION
## Why

Follow-up to #477. When `protection_bypass_for_automation_secret` is wired to a computed input (e.g. `random_password.result` with `keepers` for rotation), the config value is **Unknown** at plan time — not Null. The plan modifier from #477 treats Unknown the same as Null and freezes the old state secret into the plan. Once the upstream value becomes known during apply and differs, terraform core surfaces it as:

```
Error: Provider produced inconsistent final plan

When expanding the plan for module.X.vercel_project.main to include new values
learned so far during apply, provider produced an invalid new value for
.protection_bypass_for_automation_secret: inconsistent values for sensitive
attribute.
```

This currently blocks the ongoing Vercel secrets-rotation incident (INC-6014) for projects that rotate their bypass tokens through Terraform — reproducible on `vercel/vercel v4.8.1`.

## Fix

Distinguish Unknown config from Null config in the plan modifier:
- **Unknown config** (pending rotation from a computed upstream) → plan Unknown so the new value flows through normally.
- **Null config** (omitted) → preserve state (keeps #477's fix for #473 intact).
- **Known config** → pass through as before.

## Validation

- `go build ./...`, `go vet ./...`, `gofmt` all clean.
- Added `TestAcc_ProjectAutomationBypassRotateViaComputedInput` covering the `random_password.keepers` rotation path with a 3-step apply (create → rotate → idempotent).
- Existing `TestAcc_ProjectAutomationBypassIdempotent` still guards the #473 scenario.

## Real-world blocker

- Production run hitting this: https://app.terraform.io/app/Vercel/workspaces/api-vercel/runs/run-uRBxFw6NHA8ALfRk
- Slack thread: https://vercel.slack.com/archives/C06UAH4DQ12/p1776778565468859

/cc @kit @jarneson