### PR TITLE
fix: filter automation-bypass scope when parsing update response

### DIFF
--- a/client/project_protection_bypass_for_automation_update.go
+++ b/client/project_protection_bypass_for_automation_update.go
@@ -98,14 +98,29 @@ func (c *Client) UpdateProtectionBypassForAutomation(ctx context.Context, reques
 		return
 	}
 
-	if len(response.ProtectionBypass) != 1 {
-		return s, fmt.Errorf("error adding protection bypass for automation: the response contained an unexpected number of items (%d)", len(response.ProtectionBypass))
+	// When the caller supplied an explicit new secret we already know what was
+	// set — no need to inspect the response, which can contain entries for
+	// other bypass scopes (e.g. shareable-link) or both the old and new
+	// automation-bypass during a rotation.
+	if request.NewSecret != "" {
+		return request.NewSecret, nil
 	}
 
-	// return the first key from the map
-	for key := range response.ProtectionBypass {
-		return key, err
+	// The API generated a secret for us. Filter to the automation-bypass scope
+	// since the project may have other bypass scopes (e.g. shareable-link) in
+	// the same response map.
+	var automationKey string
+	var automationCount int
+	for key, bypass := range response.ProtectionBypass {
+		if bypass.Scope == "automation-bypass" {
+			automationKey = key
+			automationCount++
+		}
 	}
 
-	return s, err
+	if automationCount != 1 {
+		return s, fmt.Errorf("error adding protection bypass for automation: the response contained an unexpected number of automation-bypass items (%d)", automationCount)
+	}
+
+	return automationKey, nil
 }

--- a/client/project_protection_bypass_for_automation_update_test.go
+++ b/client/project_protection_bypass_for_automation_update_test.go
@@ -1,0 +1,133 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newProtectionBypassTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client := New("test-token")
+	client.baseURL = server.URL
+	return client
+}
+
+// When the project has another bypass scope (e.g. shareable-link) the response
+// includes that entry alongside the automation-bypass entry. The client must
+// filter by scope rather than erroring on the total count.
+func TestUpdateProtectionBypassForAutomation_FiltersNonAutomationScopes(t *testing.T) {
+	t.Parallel()
+
+	client := newProtectionBypassTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, "PATCH", "/v10/projects/prj_123/protection-bypass", "team_123", map[string]any{})
+		_, _ = w.Write([]byte(`{
+			"protectionBypass": {
+				"generated-automation-secret": {"scope": "automation-bypass"},
+				"shareable-link-secret": {"scope": "shareable-link"}
+			}
+		}`))
+	})
+
+	secret, err := client.UpdateProtectionBypassForAutomation(context.Background(), UpdateProtectionBypassForAutomationRequest{
+		TeamID:    "team_123",
+		ProjectID: "prj_123",
+		NewValue:  true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if secret != "generated-automation-secret" {
+		t.Fatalf("expected generated-automation-secret, got %q", secret)
+	}
+}
+
+// During a rotation we send generate+revoke and the API can transiently return
+// both old and new automation-bypass entries. When the caller provided the new
+// secret we should return it directly without inspecting the response map.
+func TestUpdateProtectionBypassForAutomation_RotationReturnsCallerSecret(t *testing.T) {
+	t.Parallel()
+
+	client := newProtectionBypassTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"protectionBypass": {
+				"old-automation-secret": {"scope": "automation-bypass"},
+				"new-automation-secret": {"scope": "automation-bypass"}
+			}
+		}`))
+	})
+
+	secret, err := client.UpdateProtectionBypassForAutomation(context.Background(), UpdateProtectionBypassForAutomationRequest{
+		TeamID:    "team_123",
+		ProjectID: "prj_123",
+		NewValue:  true,
+		NewSecret: "new-automation-secret",
+		OldSecret: "old-automation-secret",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if secret != "new-automation-secret" {
+		t.Fatalf("expected new-automation-secret, got %q", secret)
+	}
+}
+
+// If the response has no automation-bypass entry at all the client should
+// surface a clear error rather than silently returning an empty secret.
+func TestUpdateProtectionBypassForAutomation_NoAutomationEntryErrors(t *testing.T) {
+	t.Parallel()
+
+	client := newProtectionBypassTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"protectionBypass": {
+				"shareable-link-secret": {"scope": "shareable-link"}
+			}
+		}`))
+	})
+
+	_, err := client.UpdateProtectionBypassForAutomation(context.Background(), UpdateProtectionBypassForAutomationRequest{
+		TeamID:    "team_123",
+		ProjectID: "prj_123",
+		NewValue:  true,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unexpected number of automation-bypass items (0)") {
+		t.Fatalf("error did not mention automation-bypass count: %v", err)
+	}
+}
+
+// Disabling (NewValue=false) should never inspect the response map, so even a
+// response with multiple entries must not produce an error.
+func TestUpdateProtectionBypassForAutomation_DisableIgnoresResponseShape(t *testing.T) {
+	t.Parallel()
+
+	client := newProtectionBypassTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"protectionBypass": {
+				"shareable-link-a": {"scope": "shareable-link"},
+				"shareable-link-b": {"scope": "shareable-link"}
+			}
+		}`))
+	})
+
+	secret, err := client.UpdateProtectionBypassForAutomation(context.Background(), UpdateProtectionBypassForAutomationRequest{
+		TeamID:    "team_123",
+		ProjectID: "prj_123",
+		NewValue:  false,
+		OldSecret: "old-automation-secret",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if secret != "" {
+		t.Fatalf("expected empty secret on disable, got %q", secret)
+	}
+}


### PR DESCRIPTION
## Summary

`UpdateProtectionBypassForAutomation` errored with `the response contained an unexpected number of items (N)` whenever the project had any other bypass entry (e.g. a shareable-link bypass) in its `protectionBypass` map, because the client asserted `len(response.ProtectionBypass) == 1`.

A project's `protectionBypass` is keyed by secret and each entry has a `scope` — the automation-bypass flow only owns entries where `scope == "automation-bypass"`. The Read path already filters this way at `vercel/resource_project.go:1737`. This PR applies the same filter in the update client.

## Changes

- `client/project_protection_bypass_for_automation_update.go`
  - Short-circuit to the caller-supplied `NewSecret` when it's set. We know what we wrote, so we don't need to inspect the response — this also handles the rotation path (generate+revoke) where the API may transiently return both old and new automation-bypass entries.
  - Otherwise filter the response by `scope == "automation-bypass"` and return the single matching key. Error only if the filtered count isn't 1.
- `client/project_protection_bypass_for_automation_update_test.go` (new)
  - Multi-scope response returns the automation-bypass key.
  - Rotation with caller-supplied `NewSecret` returns that secret directly even when the response has two automation-bypass entries.
  - Missing automation-bypass entry produces a clear error.
  - `NewValue=false` (disable) ignores the response map entirely.

## Repro

Reported by a user whose plan produced:
```
Error: Error updating protection bypass for automation
...
unexpected error updating Protection Bypass For Automation: error adding
protection bypass for automation: the response contained an unexpected
number of items (2)
```
The project had an additional non-automation-bypass entry in the `protectionBypass` map, so the strict count check rejected an otherwise-successful API response.

## Test plan

- [x] `go test ./client/...` passes including the 4 new cases.
- [x] `go vet ./...` clean.
- [ ] Verify against the reporter's project (apply with a real secret rotation / fresh generate on a project that already has a shareable-link bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)