### PR TITLE
fix: return "elastic" for build_machine_type when selection is elastic

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,7 +30,7 @@ tasks:
     cmds:
       - go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.25.0
     status:
-      - which tfplugindocs
+      - go version -m "$(command -v tfplugindocs)" | grep -Eq '^\s*mod\s+github.com/hashicorp/terraform-plugin-docs\s+v0\.25\.0\s'
 
   install-goreleaser:
     desc: "Install goreleaser"
@@ -44,7 +44,7 @@ tasks:
     deps:
       - install-tfplugindocs
     cmds:
-      - tfplugindocs generate --provider-name terraform-provider-vercel
+      - tfplugindocs generate --provider-name terraform-provider-vercel --tf-version 1.14.9
       - sed -i.bak 's/vercel Provider/Vercel Provider/g' docs/index.md
       - rm docs/index.md.bak
     sources:

--- a/client/project.go
+++ b/client/project.go
@@ -262,6 +262,7 @@ type ResourceConfig struct {
 	Fluid                     *bool    `json:"fluid,omitempty"`
 	ElasticConcurrencyEnabled *bool    `json:"elasticConcurrencyEnabled,omitempty"`
 	BuildMachineType          *string  `json:"buildMachineType,omitempty"`
+	BuildMachineSelection     *string  `json:"buildMachineSelection,omitempty"`
 }
 
 // normalizeBuildMachineType collapses the API's (buildMachineType, buildMachineSelection)

--- a/client/project.go
+++ b/client/project.go
@@ -87,6 +87,7 @@ func (c *Client) CreateProject(ctx context.Context, teamID string, request Creat
 		return r, err
 	}
 	r.TeamID = c.TeamID(teamID)
+	r.normalizeBuildMachineType()
 	return r, err
 }
 
@@ -251,6 +252,7 @@ type ResourceConfigResponse struct {
 	Fluid                     bool     `json:"fluid"`
 	ElasticConcurrencyEnabled bool     `json:"elasticConcurrencyEnabled"`
 	BuildMachineType          string   `json:"buildMachineType"`
+	BuildMachineSelection     string   `json:"buildMachineSelection"`
 }
 
 type ResourceConfig struct {
@@ -260,6 +262,20 @@ type ResourceConfig struct {
 	Fluid                     *bool    `json:"fluid,omitempty"`
 	ElasticConcurrencyEnabled *bool    `json:"elasticConcurrencyEnabled,omitempty"`
 	BuildMachineType          *string  `json:"buildMachineType,omitempty"`
+}
+
+// normalizeBuildMachineType collapses the API's (buildMachineType, buildMachineSelection)
+// pair into a single value for the provider: when selection is "elastic", the effective
+// type is "elastic" regardless of the concrete buildMachineType returned by the API (which
+// can auto-adjust between standard/enhanced/turbo). This mirrors the value the user sets
+// in their Terraform config via `build_machine_type = "elastic"`.
+func (r *ProjectResponse) normalizeBuildMachineType() {
+	if r.ResourceConfig == nil {
+		return
+	}
+	if r.ResourceConfig.BuildMachineSelection == "elastic" {
+		r.ResourceConfig.BuildMachineType = "elastic"
+	}
 }
 
 // GetProject retrieves information about an existing project from Vercel.
@@ -282,6 +298,7 @@ func (c *Client) GetProject(ctx context.Context, projectID, teamID string) (r Pr
 	}
 
 	r.TeamID = c.TeamID(teamID)
+	r.normalizeBuildMachineType()
 	return r, err
 }
 
@@ -306,6 +323,7 @@ func (c *Client) ListProjects(ctx context.Context, teamID string) (r []ProjectRe
 	}, &pr)
 	for i := range pr.Projects {
 		pr.Projects[i].TeamID = c.TeamID(teamID)
+		pr.Projects[i].normalizeBuildMachineType()
 	}
 	return pr.Projects, err
 }
@@ -374,6 +392,7 @@ func (c *Client) UpdateProject(ctx context.Context, projectID, teamID string, re
 	}
 
 	r.TeamID = c.TeamID(teamID)
+	r.normalizeBuildMachineType()
 	return r, err
 }
 
@@ -403,6 +422,7 @@ func (c *Client) UpdateProductionBranch(ctx context.Context, request UpdateProdu
 		return r, err
 	}
 	r.TeamID = c.TeamID(c.TeamID(request.TeamID))
+	r.normalizeBuildMachineType()
 	return r, err
 }
 
@@ -423,6 +443,7 @@ func (c *Client) UnlinkGitRepoFromProject(ctx context.Context, projectID, teamID
 		return r, fmt.Errorf("error unlinking git repo: %w", err)
 	}
 	r.TeamID = c.TeamID(teamID)
+	r.normalizeBuildMachineType()
 	return r, err
 }
 
@@ -452,5 +473,6 @@ func (c *Client) LinkGitRepoToProject(ctx context.Context, request LinkGitRepoTo
 		return r, fmt.Errorf("error linking git repo: %w", err)
 	}
 	r.TeamID = c.TeamID(c.TeamID(request.TeamID))
+	r.normalizeBuildMachineType()
 	return r, err
 }

--- a/client/project_test.go
+++ b/client/project_test.go
@@ -1,0 +1,146 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNormalizeBuildMachineType(t *testing.T) {
+	type testCase struct {
+		name              string
+		resourceConfig    *ResourceConfigResponse
+		expectedType      string
+		expectedSelection string
+	}
+
+	for _, tc := range []testCase{
+		{
+			name:           "nil resource config is a no-op",
+			resourceConfig: nil,
+		},
+		{
+			name: "selection=elastic overrides concrete type to elastic",
+			resourceConfig: &ResourceConfigResponse{
+				BuildMachineType:      "enhanced",
+				BuildMachineSelection: "elastic",
+			},
+			expectedType:      "elastic",
+			expectedSelection: "elastic",
+		},
+		{
+			name: "selection=elastic overrides standard to elastic",
+			resourceConfig: &ResourceConfigResponse{
+				BuildMachineType:      "standard",
+				BuildMachineSelection: "elastic",
+			},
+			expectedType:      "elastic",
+			expectedSelection: "elastic",
+		},
+		{
+			name: "selection=fixed leaves buildMachineType untouched",
+			resourceConfig: &ResourceConfigResponse{
+				BuildMachineType:      "enhanced",
+				BuildMachineSelection: "fixed",
+			},
+			expectedType:      "enhanced",
+			expectedSelection: "fixed",
+		},
+		{
+			name: "empty selection leaves buildMachineType untouched",
+			resourceConfig: &ResourceConfigResponse{
+				BuildMachineType:      "turbo",
+				BuildMachineSelection: "",
+			},
+			expectedType:      "turbo",
+			expectedSelection: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &ProjectResponse{ResourceConfig: tc.resourceConfig}
+			r.normalizeBuildMachineType()
+
+			if tc.resourceConfig == nil {
+				if r.ResourceConfig != nil {
+					t.Fatalf("expected nil resource config to remain nil")
+				}
+				return
+			}
+			if got := r.ResourceConfig.BuildMachineType; got != tc.expectedType {
+				t.Errorf("BuildMachineType: got %q, want %q", got, tc.expectedType)
+			}
+			if got := r.ResourceConfig.BuildMachineSelection; got != tc.expectedSelection {
+				t.Errorf("BuildMachineSelection: got %q, want %q", got, tc.expectedSelection)
+			}
+		})
+	}
+}
+
+func TestGetProjectNormalizesElasticBuildMachine(t *testing.T) {
+	type testCase struct {
+		name         string
+		responseJSON string
+		expectedType string
+	}
+
+	for _, tc := range []testCase{
+		{
+			name: "API returns selection=elastic with concrete type -> provider returns elastic",
+			responseJSON: `{
+				"id": "proj_1",
+				"name": "test",
+				"resourceConfig": {
+					"buildMachineType": "enhanced",
+					"buildMachineSelection": "elastic"
+				}
+			}`,
+			expectedType: "elastic",
+		},
+		{
+			name: "API returns selection=fixed -> provider returns concrete type",
+			responseJSON: `{
+				"id": "proj_1",
+				"name": "test",
+				"resourceConfig": {
+					"buildMachineType": "turbo",
+					"buildMachineSelection": "fixed"
+				}
+			}`,
+			expectedType: "turbo",
+		},
+		{
+			name: "API omits selection -> provider returns concrete type",
+			responseJSON: `{
+				"id": "proj_1",
+				"name": "test",
+				"resourceConfig": {
+					"buildMachineType": "enhanced"
+				}
+			}`,
+			expectedType: "enhanced",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				fmt.Fprintln(w, tc.responseJSON)
+			}))
+			defer h.Close()
+
+			cl := New("INVALID")
+			cl.baseURL = fmt.Sprintf("http://%s", h.Listener.Addr().String())
+
+			r, err := cl.GetProject(context.Background(), "proj_1", "")
+			if err != nil {
+				t.Fatalf("GetProject: %v", err)
+			}
+			if r.ResourceConfig == nil {
+				t.Fatalf("expected resourceConfig to be set")
+			}
+			if got := r.ResourceConfig.BuildMachineType; got != tc.expectedType {
+				t.Errorf("BuildMachineType: got %q, want %q", got, tc.expectedType)
+			}
+		})
+	}
+}

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -61,7 +61,7 @@ resource "vercel_project" "example" {
 - `auto_assign_custom_domains` (Boolean) Automatically assign custom production domains after each Production deployment via merge to the production branch or Vercel CLI deploy with --prod. Defaults to `true`
 - `automatically_expose_system_environment_variables` (Boolean) Vercel provides a set of Environment Variables that are automatically populated by the System, such as the URL of the Deployment or the name of the Git branch deployed. To expose them to your Deployments, enable this field
 - `build_command` (String) The build command for this project. If omitted, this value will be automatically detected.
-- `build_machine_type` (String) The build machine type to use for this project. Must be one of "enhanced" or "turbo".
+- `build_machine_type` (String) The build machine type to use for this project. Must be one of "enhanced", "turbo", or "elastic". When set to "elastic", Vercel automatically adjusts the underlying machine type based on build duration.
 - `customer_success_code_visibility` (Boolean) Allows Vercel Customer Support to inspect all Deployments' source code in this project to assist with debugging.
 - `dev_command` (String) The dev command for this project. If omitted, this value will be automatically detected.
 - `directory_listing` (Boolean) If no index file is present within a directory, the directory contents will be displayed.

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -604,11 +604,11 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"build_machine_type": schema.StringAttribute{
-				Description: "The build machine type to use for this project. Must be one of \"enhanced\" or \"turbo\".",
+				Description: "The build machine type to use for this project. Must be one of \"enhanced\", \"turbo\", or \"elastic\". When set to \"elastic\", Vercel automatically adjusts the underlying machine type based on build duration.",
 				Optional:    true,
 				Computed:    true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("enhanced", "turbo"),
+					stringvalidator.OneOf("enhanced", "turbo", "elastic"),
 				},
 			},
 		},

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -1390,7 +1390,11 @@ func (r *ResourceConfig) toClientResourceConfig(ctx context.Context, onDemandCon
 		if resourceConfig == nil {
 			resourceConfig = &client.ResourceConfig{}
 		}
-		resourceConfig.BuildMachineType = buildMachineType.ValueStringPointer()
+		if buildMachineType.ValueString() == "elastic" {
+			resourceConfig.BuildMachineSelection = buildMachineType.ValueStringPointer()
+		} else {
+			resourceConfig.BuildMachineType = buildMachineType.ValueStringPointer()
+		}
 	}
 	return resourceConfig
 }

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -412,6 +412,31 @@ func TestAcc_ProjectUpdateResourceConfig(t *testing.T) {
 	})
 }
 
+func TestAcc_ProjectBuildMachineTypeElastic(t *testing.T) {
+	projectSuffix := acctest.RandString(16)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccProjectDestroy(testClient(t), "vercel_project.test", testTeam(t)),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(testAccProjectConfigWithElasticBuildMachine(projectSuffix)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectExists(testClient(t), "vercel_project.test", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_project.test", "build_machine_type", "elastic"),
+				),
+			},
+			{
+				Config: cfg(testAccProjectConfigWithElasticBuildMachine(projectSuffix)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAcc_ProjectWithGitRepository(t *testing.T) {
 	projectSuffix := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{
@@ -662,6 +687,15 @@ resource "vercel_project" "test" {
     function_default_timeout = 30
     fluid = false
   }
+}
+`, projectSuffix)
+}
+
+func testAccProjectConfigWithElasticBuildMachine(projectSuffix string) string {
+	return fmt.Sprintf(`
+resource "vercel_project" "test" {
+  name = "test-acc-elastic-build-machine-%s"
+  build_machine_type = "elastic"
 }
 `, projectSuffix)
 }


### PR DESCRIPTION
## Summary

Fixes a bug where `build_machine_type` drifts on every refresh when a user configures `build_machine_type = "elastic"`.

The Vercel API returns two fields in `resourceConfig`:
- `buildMachineType`: concrete current machine (`standard` | `enhanced` | `turbo`)
- `buildMachineSelection`: user's selection mode (`elastic` | `fixed`)

When a user sends `buildMachineType: "elastic"` in a PATCH, the API accepts it as a virtual input, sets `buildMachineSelection: "elastic"` and stores a concrete `buildMachineType` that Vercel auto-adjusts based on build duration. On reads, the API returns the concrete type — which the provider was then writing to state, causing permanent drift against the user's `elastic` config.

## Changes

- Add `BuildMachineSelection` field to `ResourceConfigResponse`
- Add `normalizeBuildMachineType()` helper on `*ProjectResponse` that overrides `BuildMachineType` to `"elastic"` whenever `BuildMachineSelection == "elastic"`
- Call it from every client method that returns a `ProjectResponse`: `CreateProject`, `GetProject`, `ListProjects`, `UpdateProject`, `UpdateProductionBranch`, `UnlinkGitRepoFromProject`, `LinkGitRepoToProject`
- Update the `build_machine_type` schema validator and description to accept `"elastic"` as a valid input

## Test plan

- [ ] `go build ./...` (passes locally)
- [ ] `go vet ./...` (passes locally)
- [ ] `go test ./client/...` (passes locally)
- [ ] Acceptance test: set `build_machine_type = "elastic"`, apply, refresh, confirm no drift
- [ ] Acceptance test: set `build_machine_type = "enhanced"`, apply, refresh, confirm unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)