### PR TITLE
chore: keep edge config token stable across deprecated plaintext-field removal

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -39,6 +39,11 @@ func (c *Client) WithTeam(team Team) *Client {
 	return c
 }
 
+func (c *Client) WithBaseURL(baseURL string) *Client {
+	c.baseURL = baseURL
+	return c
+}
+
 func (c *Client) Team(ctx context.Context, teamID string) (Team, error) {
 	if teamID != "" {
 		return c.GetTeam(ctx, teamID)

--- a/client/edge_config_token.go
+++ b/client/edge_config_token.go
@@ -97,6 +97,14 @@ func (c *Client) GetEdgeConfigToken(ctx context.Context, request EdgeConfigToken
 		method: "GET",
 		url:    url,
 	}, &e)
+	// The plaintext `token` and `edgeConfigId` are no longer guaranteed to be
+	// present on the GET response — the Vercel API is moving toward only
+	// returning the plaintext token once, at creation time. Both values are
+	// already known to the caller (they're part of the request path), so we
+	// repopulate them here to keep the returned struct stable regardless of
+	// which response shape the API currently emits.
+	e.Token = request.Token
+	e.EdgeConfigID = request.EdgeConfigID
 	e.TeamID = request.TeamID
 	return e, err
 }

--- a/client/edge_config_token.go
+++ b/client/edge_config_token.go
@@ -97,14 +97,14 @@ func (c *Client) GetEdgeConfigToken(ctx context.Context, request EdgeConfigToken
 		method: "GET",
 		url:    url,
 	}, &e)
-	// The plaintext `token` and `edgeConfigId` are no longer guaranteed to be
-	// present on the GET response — the Vercel API is moving toward only
-	// returning the plaintext token once, at creation time. Both values are
-	// already known to the caller (they're part of the request path), so we
-	// repopulate them here to keep the returned struct stable regardless of
-	// which response shape the API currently emits.
+	// The Vercel API has marked the plaintext `token` field on this endpoint's
+	// response as deprecated and intends to remove it in a future rollout
+	// (FLA-2777 / FLA-2803). The plaintext is already part of the request path,
+	// so we repopulate it from the request to keep the returned struct — and
+	// the computed `connection_string` that depends on it — stable across that
+	// future response-shape change. Getting this patch adopted in-wild is an
+	// explicit prerequisite for the server-side removal.
 	e.Token = request.Token
-	e.EdgeConfigID = request.EdgeConfigID
 	e.TeamID = request.TeamID
 	return e, err
 }

--- a/client/edge_config_token.go
+++ b/client/edge_config_token.go
@@ -97,13 +97,11 @@ func (c *Client) GetEdgeConfigToken(ctx context.Context, request EdgeConfigToken
 		method: "GET",
 		url:    url,
 	}, &e)
-	// The Vercel API has marked the plaintext `token` field on this endpoint's
-	// response as deprecated and intends to remove it in a future rollout
-	// (FLA-2777 / FLA-2803). The plaintext is already part of the request path,
-	// so we repopulate it from the request to keep the returned struct — and
-	// the computed `connection_string` that depends on it — stable across that
-	// future response-shape change. Getting this patch adopted in-wild is an
-	// explicit prerequisite for the server-side removal.
+	// The plaintext `token` on this endpoint's response is deprecated and will
+	// be removed in a future API rollout. It's already part of the request
+	// path, so we repopulate it from the request to keep the returned struct —
+	// and the computed `connection_string` that depends on it — stable across
+	// that response-shape change.
 	e.Token = request.Token
 	e.TeamID = request.TeamID
 	return e, err

--- a/client/edge_config_token_test.go
+++ b/client/edge_config_token_test.go
@@ -1,0 +1,72 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetEdgeConfigToken(t *testing.T) {
+	type TestCase struct {
+		Name         string
+		ResponseJSON string
+	}
+
+	// Both shapes must round-trip to a struct where Token and EdgeConfigID
+	// match the values passed in the request. The "WithToken" shape is what
+	// the API emits today; "WithoutToken" is the forthcoming shape after the
+	// plaintext token is removed from GET /v1/edge-config/:id/token/:token.
+	for _, tc := range []TestCase{
+		{
+			Name:         "WithToken",
+			ResponseJSON: `{"token":"tkn_xxx","id":"a","label":"my token","edgeConfigId":"ecfg_xxx","createdAt":1,"partialToken":"tkn_********"}`,
+		},
+		{
+			Name:         "WithoutToken",
+			ResponseJSON: `{"id":"a","label":"my token","edgeConfigId":"ecfg_xxx","createdAt":1,"partialToken":"tkn_********"}`,
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			h := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				fmt.Fprintln(w, tc.ResponseJSON)
+			}))
+			t.Cleanup(h.Close)
+
+			cl := New("INVALID")
+			cl.baseURL = fmt.Sprintf("http://%s", h.Listener.Addr().String())
+
+			req := EdgeConfigTokenRequest{
+				Token:        "tkn_xxx",
+				TeamID:       "team_123",
+				EdgeConfigID: "ecfg_xxx",
+			}
+			got, err := cl.GetEdgeConfigToken(context.Background(), req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got.Token != req.Token {
+				t.Errorf("Token = %q, want %q", got.Token, req.Token)
+			}
+			if got.EdgeConfigID != req.EdgeConfigID {
+				t.Errorf("EdgeConfigID = %q, want %q", got.EdgeConfigID, req.EdgeConfigID)
+			}
+			if got.TeamID != req.TeamID {
+				t.Errorf("TeamID = %q, want %q", got.TeamID, req.TeamID)
+			}
+			if got.ID != "a" {
+				t.Errorf("ID = %q, want %q", got.ID, "a")
+			}
+			if got.Label != "my token" {
+				t.Errorf("Label = %q, want %q", got.Label, "my token")
+			}
+
+			wantCS := "https://edge-config.vercel.com/ecfg_xxx?token=tkn_xxx"
+			if cs := got.ConnectionString(); cs != wantCS {
+				t.Errorf("ConnectionString() = %q, want %q", cs, wantCS)
+			}
+		})
+	}
+}

--- a/client/edge_config_token_test.go
+++ b/client/edge_config_token_test.go
@@ -14,10 +14,12 @@ func TestGetEdgeConfigToken(t *testing.T) {
 		ResponseJSON string
 	}
 
-	// Both shapes must round-trip to a struct where Token and EdgeConfigID
-	// match the values passed in the request. The "WithToken" shape is what
-	// the API emits today; "WithoutToken" is the forthcoming shape after the
-	// plaintext token is removed from GET /v1/edge-config/:id/token/:token.
+	// Both shapes must round-trip to a struct where Token matches the value
+	// passed in the request. "WithToken" is what GET /v1/edge-config/:id/token/:token
+	// emits today (the field is currently deprecated — see FLA-2777);
+	// "WithoutToken" is the forthcoming shape once the deprecated field is
+	// removed (FLA-2803). `edgeConfigId` is retained on the response in both
+	// cases — its removal is explicitly not in scope.
 	for _, tc := range []TestCase{
 		{
 			Name:         "WithToken",

--- a/client/edge_config_token_test.go
+++ b/client/edge_config_token_test.go
@@ -16,10 +16,8 @@ func TestGetEdgeConfigToken(t *testing.T) {
 
 	// Both shapes must round-trip to a struct where Token matches the value
 	// passed in the request. "WithToken" is what GET /v1/edge-config/:id/token/:token
-	// emits today (the field is currently deprecated — see FLA-2777);
-	// "WithoutToken" is the forthcoming shape once the deprecated field is
-	// removed (FLA-2803). `edgeConfigId` is retained on the response in both
-	// cases — its removal is explicitly not in scope.
+	// emits today (the `token` field is currently deprecated); "WithoutToken"
+	// is the forthcoming shape once the deprecated field is removed.
 	for _, tc := range []TestCase{
 		{
 			Name:         "WithToken",

--- a/client/edge_config_token_test.go
+++ b/client/edge_config_token_test.go
@@ -1,4 +1,4 @@
-package client
+package client_test
 
 import (
 	"context"
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func TestGetEdgeConfigToken(t *testing.T) {
@@ -34,10 +36,8 @@ func TestGetEdgeConfigToken(t *testing.T) {
 			}))
 			t.Cleanup(h.Close)
 
-			cl := New("INVALID")
-			cl.baseURL = fmt.Sprintf("http://%s", h.Listener.Addr().String())
-
-			req := EdgeConfigTokenRequest{
+			cl := client.New("INVALID").WithBaseURL(fmt.Sprintf("http://%s", h.Listener.Addr().String()))
+			req := client.EdgeConfigTokenRequest{
 				Token:        "tkn_xxx",
 				TeamID:       "team_123",
 				EdgeConfigID: "ecfg_xxx",

--- a/client/feature_flag_test.go
+++ b/client/feature_flag_test.go
@@ -1,4 +1,4 @@
-package client
+package client_test
 
 import (
 	"context"
@@ -8,31 +8,33 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	vercelclient "github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func TestCreateFeatureFlag(t *testing.T) {
 	t.Parallel()
 
-	request := CreateFeatureFlagRequest{
+	request := vercelclient.CreateFeatureFlagRequest{
 		ProjectID:   "prj_123",
 		TeamID:      "team_123",
 		Slug:        "checkout-banner",
 		Kind:        "string",
 		Description: "Controls the checkout banner copy",
 		State:       "active",
-		Variants: []FeatureFlagVariant{
+		Variants: []vercelclient.FeatureFlagVariant{
 			{ID: "control", Value: "control"},
 			{ID: "variant-a", Label: "Variant A", Value: "variant-a"},
 		},
-		Environments: map[string]FeatureFlagEnvironment{
+		Environments: map[string]vercelclient.FeatureFlagEnvironment{
 			"production": {
 				Active: true,
 				Rules:  []json.RawMessage{},
-				Fallthrough: FeatureFlagOutcome{
+				Fallthrough: vercelclient.FeatureFlagOutcome{
 					Type:      "variant",
 					VariantID: "variant-a",
 				},
-				PausedOutcome: FeatureFlagOutcome{
+				PausedOutcome: vercelclient.FeatureFlagOutcome{
 					Type:      "variant",
 					VariantID: "control",
 				},
@@ -88,14 +90,14 @@ func TestCreateFeatureFlag(t *testing.T) {
 func TestCreateFeatureFlagOmitsEnvironmentsWhenUnset(t *testing.T) {
 	t.Parallel()
 
-	request := CreateFeatureFlagRequest{
+	request := vercelclient.CreateFeatureFlagRequest{
 		ProjectID:   "prj_123",
 		TeamID:      "team_123",
 		Slug:        "checkout-banner",
 		Kind:        "string",
 		Description: "Controls the checkout banner copy",
 		State:       "active",
-		Variants: []FeatureFlagVariant{
+		Variants: []vercelclient.FeatureFlagVariant{
 			{ID: "control", Value: "control"},
 			{ID: "variant-a", Value: "variant-a"},
 		},
@@ -168,9 +170,9 @@ func TestGetFeatureFlagUsesConfiguredTeam(t *testing.T) {
 				}
 			}
 		}`))
-	}).WithTeam(Team{ID: "team_default"})
+	}).WithTeam(vercelclient.Team{ID: "team_default"})
 
-	flag, err := client.GetFeatureFlag(context.Background(), GetFeatureFlagRequest{
+	flag, err := client.GetFeatureFlag(context.Background(), vercelclient.GetFeatureFlagRequest{
 		ProjectID:    "prj_123",
 		FlagIDOrSlug: "flag_123",
 	})
@@ -190,24 +192,24 @@ func TestGetFeatureFlagUsesConfiguredTeam(t *testing.T) {
 func TestCreateFeatureFlagSupportsLegacyKeyField(t *testing.T) {
 	t.Parallel()
 
-	request := CreateFeatureFlagRequest{
+	request := vercelclient.CreateFeatureFlagRequest{
 		ProjectID: "prj_123",
 		TeamID:    "team_123",
 		Key:       "legacy-key",
 		Kind:      "boolean",
-		Variants: []FeatureFlagVariant{
+		Variants: []vercelclient.FeatureFlagVariant{
 			{ID: "off", Value: false},
 			{ID: "on", Value: true},
 		},
-		Environments: map[string]FeatureFlagEnvironment{
+		Environments: map[string]vercelclient.FeatureFlagEnvironment{
 			"production": {
 				Active: true,
 				Rules:  []json.RawMessage{},
-				Fallthrough: FeatureFlagOutcome{
+				Fallthrough: vercelclient.FeatureFlagOutcome{
 					Type:      "variant",
 					VariantID: "on",
 				},
-				PausedOutcome: FeatureFlagOutcome{
+				PausedOutcome: vercelclient.FeatureFlagOutcome{
 					Type:      "variant",
 					VariantID: "off",
 				},
@@ -278,21 +280,21 @@ func TestCreateFeatureFlagSupportsLegacyKeyField(t *testing.T) {
 func TestUpdateFeatureFlag(t *testing.T) {
 	t.Parallel()
 
-	request := UpdateFeatureFlagRequest{
+	request := vercelclient.UpdateFeatureFlagRequest{
 		ProjectID:    "prj_123",
 		FlagIDOrSlug: "flag_123",
 		TeamID:       "team_123",
 		Message:      "pause rollout",
 		State:        "archived",
-		Environments: map[string]FeatureFlagEnvironment{
+		Environments: map[string]vercelclient.FeatureFlagEnvironment{
 			"production": {
 				Active: false,
 				Rules:  []json.RawMessage{},
-				Fallthrough: FeatureFlagOutcome{
+				Fallthrough: vercelclient.FeatureFlagOutcome{
 					Type:      "variant",
 					VariantID: "control",
 				},
-				PausedOutcome: FeatureFlagOutcome{
+				PausedOutcome: vercelclient.FeatureFlagOutcome{
 					Type:      "variant",
 					VariantID: "control",
 				},
@@ -347,7 +349,7 @@ func TestDeleteFeatureFlag(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := client.DeleteFeatureFlag(context.Background(), DeleteFeatureFlagRequest{
+	err := client.DeleteFeatureFlag(context.Background(), vercelclient.DeleteFeatureFlagRequest{
 		ProjectID:    "prj_123",
 		FlagIDOrSlug: "flag_123",
 		TeamID:       "team_123",
@@ -381,7 +383,7 @@ func TestFeatureFlagRequestAliasesUseLegacyFlagID(t *testing.T) {
 			}`))
 		})
 
-		_, err := client.GetFeatureFlag(context.Background(), GetFeatureFlagRequest{
+		_, err := client.GetFeatureFlag(context.Background(), vercelclient.GetFeatureFlagRequest{
 			ProjectID: "prj_123",
 			TeamID:    "team_123",
 			FlagID:    "flag_legacy",
@@ -415,7 +417,7 @@ func TestFeatureFlagRequestAliasesUseLegacyFlagID(t *testing.T) {
 			}`))
 		})
 
-		_, err := client.UpdateFeatureFlag(context.Background(), UpdateFeatureFlagRequest{
+		_, err := client.UpdateFeatureFlag(context.Background(), vercelclient.UpdateFeatureFlagRequest{
 			ProjectID: "prj_123",
 			TeamID:    "team_123",
 			FlagID:    "flag_legacy",
@@ -435,7 +437,7 @@ func TestFeatureFlagRequestAliasesUseLegacyFlagID(t *testing.T) {
 			w.WriteHeader(http.StatusNoContent)
 		})
 
-		err := client.DeleteFeatureFlag(context.Background(), DeleteFeatureFlagRequest{
+		err := client.DeleteFeatureFlag(context.Background(), vercelclient.DeleteFeatureFlagRequest{
 			ProjectID: "prj_123",
 			TeamID:    "team_123",
 			FlagID:    "flag_legacy",
@@ -449,27 +451,27 @@ func TestFeatureFlagRequestAliasesUseLegacyFlagID(t *testing.T) {
 func TestCreateFeatureFlagSegment(t *testing.T) {
 	t.Parallel()
 
-	request := CreateFeatureFlagSegmentRequest{
+	request := vercelclient.CreateFeatureFlagSegmentRequest{
 		ProjectID:   "prj_123",
 		TeamID:      "team_123",
 		Slug:        "internal-users",
 		Label:       "Internal Users",
 		Description: "Matches employees",
 		Hint:        "user-email",
-		Data: FeatureFlagSegmentData{
-			Include: map[string]map[string][]FeatureFlagSegmentValue{
+		Data: vercelclient.FeatureFlagSegmentData{
+			Include: map[string]map[string][]vercelclient.FeatureFlagSegmentValue{
 				"user": {
 					"email": {
 						{Value: "alice@example.com"},
 					},
 				},
 			},
-			Rules: []FeatureFlagSegmentRule{
+			Rules: []vercelclient.FeatureFlagSegmentRule{
 				{
 					ID: "rule-1",
-					Conditions: []FeatureFlagSegmentCondition{
+					Conditions: []vercelclient.FeatureFlagSegmentCondition{
 						{
-							LHS: FeatureFlagSegmentConditionLHS{
+							LHS: vercelclient.FeatureFlagSegmentConditionLHS{
 								Type:      "entity",
 								Kind:      "user",
 								Attribute: "email",
@@ -478,7 +480,7 @@ func TestCreateFeatureFlagSegment(t *testing.T) {
 							RHS: "@example.com",
 						},
 					},
-					Outcome: FeatureFlagSegmentOutcome{Type: "all"},
+					Outcome: vercelclient.FeatureFlagSegmentOutcome{Type: "all"},
 				},
 			},
 		},
@@ -551,7 +553,7 @@ func TestGetFeatureFlagSegment(t *testing.T) {
 		}`))
 	})
 
-	segment, err := client.GetFeatureFlagSegment(context.Background(), GetFeatureFlagSegmentRequest{
+	segment, err := client.GetFeatureFlagSegment(context.Background(), vercelclient.GetFeatureFlagSegmentRequest{
 		ProjectID:       "prj_123",
 		SegmentIDOrSlug: "segment_123",
 		TeamID:          "team_123",
@@ -568,19 +570,19 @@ func TestGetFeatureFlagSegment(t *testing.T) {
 func TestUpdateFeatureFlagSegment(t *testing.T) {
 	t.Parallel()
 
-	request := UpdateFeatureFlagSegmentRequest{
+	request := vercelclient.UpdateFeatureFlagSegmentRequest{
 		ProjectID:       "prj_123",
 		SegmentIDOrSlug: "segment_123",
 		TeamID:          "team_123",
 		Label:           "Beta Users",
 		Hint:            "user-id",
-		Data: FeatureFlagSegmentData{
-			Rules: []FeatureFlagSegmentRule{
+		Data: vercelclient.FeatureFlagSegmentData{
+			Rules: []vercelclient.FeatureFlagSegmentRule{
 				{
 					ID: "rule-1",
-					Conditions: []FeatureFlagSegmentCondition{
+					Conditions: []vercelclient.FeatureFlagSegmentCondition{
 						{
-							LHS: FeatureFlagSegmentConditionLHS{
+							LHS: vercelclient.FeatureFlagSegmentConditionLHS{
 								Type:      "entity",
 								Kind:      "user",
 								Attribute: "plan",
@@ -589,9 +591,9 @@ func TestUpdateFeatureFlagSegment(t *testing.T) {
 							RHS: "beta",
 						},
 					},
-					Outcome: FeatureFlagSegmentOutcome{
+					Outcome: vercelclient.FeatureFlagSegmentOutcome{
 						Type: "split",
-						Base: &FeatureFlagSegmentConditionLHS{
+						Base: &vercelclient.FeatureFlagSegmentConditionLHS{
 							Type:      "entity",
 							Kind:      "user",
 							Attribute: "id",
@@ -656,7 +658,7 @@ func TestDeleteFeatureFlagSegment(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := client.DeleteFeatureFlagSegment(context.Background(), DeleteFeatureFlagSegmentRequest{
+	err := client.DeleteFeatureFlagSegment(context.Background(), vercelclient.DeleteFeatureFlagSegmentRequest{
 		ProjectID:       "prj_123",
 		SegmentIDOrSlug: "segment_123",
 		TeamID:          "team_123",
@@ -687,7 +689,7 @@ func TestFeatureFlagSegmentRequestAliasesUseLegacySegmentID(t *testing.T) {
 			}`))
 		})
 
-		_, err := client.GetFeatureFlagSegment(context.Background(), GetFeatureFlagSegmentRequest{
+		_, err := client.GetFeatureFlagSegment(context.Background(), vercelclient.GetFeatureFlagSegmentRequest{
 			ProjectID: "prj_123",
 			TeamID:    "team_123",
 			SegmentID: "segment_legacy",
@@ -723,16 +725,16 @@ func TestFeatureFlagSegmentRequestAliasesUseLegacySegmentID(t *testing.T) {
 			}`))
 		})
 
-		_, err := client.UpdateFeatureFlagSegment(context.Background(), UpdateFeatureFlagSegmentRequest{
+		_, err := client.UpdateFeatureFlagSegment(context.Background(), vercelclient.UpdateFeatureFlagSegmentRequest{
 			ProjectID: "prj_123",
 			TeamID:    "team_123",
 			SegmentID: "segment_legacy",
 			Label:     "Legacy Segment",
 			Hint:      "user-id",
-			Data: FeatureFlagSegmentData{
-				Rules:   []FeatureFlagSegmentRule{},
-				Include: map[string]map[string][]FeatureFlagSegmentValue{},
-				Exclude: map[string]map[string][]FeatureFlagSegmentValue{},
+			Data: vercelclient.FeatureFlagSegmentData{
+				Rules:   []vercelclient.FeatureFlagSegmentRule{},
+				Include: map[string]map[string][]vercelclient.FeatureFlagSegmentValue{},
+				Exclude: map[string]map[string][]vercelclient.FeatureFlagSegmentValue{},
 			},
 		})
 		if err != nil {
@@ -748,7 +750,7 @@ func TestFeatureFlagSegmentRequestAliasesUseLegacySegmentID(t *testing.T) {
 			w.WriteHeader(http.StatusNoContent)
 		})
 
-		err := client.DeleteFeatureFlagSegment(context.Background(), DeleteFeatureFlagSegmentRequest{
+		err := client.DeleteFeatureFlagSegment(context.Background(), vercelclient.DeleteFeatureFlagSegmentRequest{
 			ProjectID: "prj_123",
 			TeamID:    "team_123",
 			SegmentID: "segment_legacy",
@@ -762,7 +764,7 @@ func TestFeatureFlagSegmentRequestAliasesUseLegacySegmentID(t *testing.T) {
 func TestCreateFeatureFlagSDKKey(t *testing.T) {
 	t.Parallel()
 
-	request := CreateFeatureFlagSDKKeyRequest{
+	request := vercelclient.CreateFeatureFlagSDKKeyRequest{
 		ProjectID:   "prj_123",
 		TeamID:      "team_123",
 		Type:        "server",
@@ -831,7 +833,7 @@ func TestListFeatureFlagSDKKeys(t *testing.T) {
 		}`))
 	})
 
-	keys, err := client.ListFeatureFlagSDKKeys(context.Background(), ListFeatureFlagSDKKeysRequest{
+	keys, err := client.ListFeatureFlagSDKKeys(context.Background(), vercelclient.ListFeatureFlagSDKKeysRequest{
 		ProjectID: "prj_123",
 		TeamID:    "team_123",
 	})
@@ -855,7 +857,7 @@ func TestDeleteFeatureFlagSDKKey(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := client.DeleteFeatureFlagSDKKey(context.Background(), DeleteFeatureFlagSDKKeyRequest{
+	err := client.DeleteFeatureFlagSDKKey(context.Background(), vercelclient.DeleteFeatureFlagSDKKeyRequest{
 		ProjectID: "prj_123",
 		HashKey:   "sdk_123",
 		TeamID:    "team_123",
@@ -865,14 +867,14 @@ func TestDeleteFeatureFlagSDKKey(t *testing.T) {
 	}
 }
 
-func newFeatureFlagTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+func newFeatureFlagTestClient(t *testing.T, handler http.HandlerFunc) *vercelclient.Client {
 	t.Helper()
 
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	client := New("test-token")
-	client.baseURL = server.URL
+	client := vercelclient.New("test-token")
+	client.WithBaseURL(server.URL)
 	return client
 }
 
@@ -917,8 +919,13 @@ func assertJSONEqual(t *testing.T, expected any, body io.Reader) {
 		t.Fatalf("unmarshaling request body: %v", err)
 	}
 
+	wantJSON, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatalf("marshaling expected body: %v", err)
+	}
+
 	var want any
-	if err := json.Unmarshal(mustMarshal(expected), &want); err != nil {
+	if err := json.Unmarshal(wantJSON, &want); err != nil {
 		t.Fatalf("unmarshaling expected body: %v", err)
 	}
 

--- a/client/firewall_config_test.go
+++ b/client/firewall_config_test.go
@@ -1,15 +1,17 @@
-package client
+package client_test
 
 import (
 	"context"
 	"net/http"
 	"testing"
+
+	vercelclient "github.com/vercel/terraform-provider-vercel/v4/client"
 )
 
 func TestUpdateFirewallConfig(t *testing.T) {
 	t.Parallel()
 
-	request := UpdateFirewallConfigRequest{
+	request := vercelclient.UpdateFirewallConfigRequest{
 		ProjectID: "prj_123",
 		TeamID:    "team_123",
 		Action:    "rules.update",
@@ -41,9 +43,9 @@ func TestUpdateFirewallConfigUsesConfiguredTeam(t *testing.T) {
 			"value":  nil,
 		})
 		_, _ = w.Write([]byte(`{}`))
-	}).WithTeam(Team{ID: "team_default"})
+	}).WithTeam(vercelclient.Team{ID: "team_default"})
 
-	err := client.UpdateFirewallConfig(context.Background(), UpdateFirewallConfigRequest{
+	err := client.UpdateFirewallConfig(context.Background(), vercelclient.UpdateFirewallConfigRequest{
 		ProjectID: "prj_123",
 		Action:    "rules.remove",
 		ID:        "rule_123",


### PR DESCRIPTION
## Why

The Vercel REST API is hardening how Edge Config tokens are exposed. 

- `GET /v1/edge-config/:id/token/:token` (detail) — continues to return `token`, but the field will be marked `@deprecated` in the public TS types and OpenAPI spec. Actual removal from this endpoint is deferred to a follow-up, intentionally gated on in-wild adoption of a client-side patch in `terraform-provider-vercel`.

This PR is that client-side patch. It is not fixing a user-visible bug today — it's getting the change into a release so an adoption window can start, ahead of the follow-up that eventually removes the deprecated field from the detail response.

Without this patch released, flipping the detail endpoint later would cause:

- Permanent non-convergent drift on `vercel_edge_config_token.token` / `connection_string` (both `Computed` + `Sensitive`, no plan modifier retains state — every `plan` would re-show the diff).
- `connection_string` silently rewritten to `https://edge-config.vercel.com/<id>?token=` on the next `apply`, cascading into `EDGE_CONFIG` env vars on dependent projects and producing runtime `401`s.
- New `terraform import` into broken state (`token = ""`).

## What

`GetEdgeConfigToken` already accepts the plaintext token as part of the request (it's the last URL path segment), so we repopulate `Token` from the request after the HTTP call — same pattern `CreateEdgeConfigToken` already uses for `Label` / `TeamID` / `EdgeConfigID`. This makes the client resilient to both the current and the forthcoming response shape.

Scope is intentionally narrow: `edgeConfigId` is not being removed from any endpoint, so we do not re-populate it.

Adds a client-level unit test that runs the call against a stub server emitting each shape and asserts the returned struct — including `ConnectionString()` — is identical in both cases.

## Validation

- `go test ./client/ -run TestGetEdgeConfigToken -v` passes for both `WithToken` and `WithoutToken` shapes
- `go vet ./...` / `gofmt` clean
- No schema or state changes for users; existing `Read` callers get the same struct they got before, independent of API shape