### PR TITLE
fix(project): allow coexistence of serverless_function_region and resource_config.function_default_regions

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -57,7 +57,6 @@ type CreateProjectRequest struct {
 	PreviewDeploymentSuffix           *string               `json:"previewDeploymentSuffix"`
 	PublicSource                      *bool                 `json:"publicSource"`
 	RootDirectory                     *string               `json:"rootDirectory"`
-	ServerlessFunctionRegion          string                `json:"serverlessFunctionRegion,omitempty"`
 	ResourceConfig                    *ResourceConfig       `json:"resourceConfig,omitempty"`
 	EnablePreviewFeedback             *bool                 `json:"enablePreviewFeedback,omitempty"`
 	EnableProductionFeedback          *bool                 `json:"enableProductionFeedback,omitempty"`
@@ -327,7 +326,6 @@ type UpdateProjectRequest struct {
 	PreviewDeploymentSuffix              *string                         `json:"previewDeploymentSuffix"`
 	PublicSource                         *bool                           `json:"publicSource"`
 	RootDirectory                        *string                         `json:"rootDirectory"`
-	ServerlessFunctionRegion             string                          `json:"serverlessFunctionRegion,omitempty"`
 	VercelAuthentication                 *VercelAuthentication           `json:"ssoProtection"`
 	PasswordProtection                   *PasswordProtectionWithPassword `json:"passwordProtection"`
 	TrustedIps                           *TrustedIps                     `json:"trustedIps"`

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -120,10 +120,6 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				Description:        "The region on Vercel's network to which your Serverless Functions are deployed. It should be close to any data source your Serverless Function might depend on. A new Deployment is required for your changes to take effect. Please see [Vercel's documentation](https://vercel.com/docs/concepts/edge-network/regions) for a full list of regions.",
 				Validators: []validator.String{
 					validateServerlessFunctionRegion(),
-					stringvalidator.ConflictsWith(
-						path.MatchRoot("serverless_function_region"),
-						path.MatchRoot("resource_config").AtName("function_default_regions"),
-					),
 				},
 			},
 			"node_version": schema.StringAttribute{
@@ -582,10 +578,6 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 						Validators: []validator.Set{
 							setvalidator.ValueStringsAre(
 								validateServerlessFunctionRegion(),
-							),
-							setvalidator.ConflictsWith(
-								path.MatchRoot("serverless_function_region"),
-								path.MatchRoot("resource_config").AtName("function_default_regions"),
 							),
 						},
 					},
@@ -1799,6 +1791,30 @@ func (r *projectResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	// Warn when both region fields are set in user config. The Vercel API returns
+	// serverless_function_region as a derived alias of resource_config.function_default_regions[0],
+	// so the provider prefers the modern field and ignores the legacy one. Read from req.Config
+	// so this only fires for user-authored dual-declaration, not for state round-trips on import.
+	if !req.Config.Raw.IsNull() {
+		var cfg Project
+		if cd := req.Config.Get(ctx, &cfg); !cd.HasError() {
+			legacySet := !cfg.ServerlessFunctionRegion.IsNull() && !cfg.ServerlessFunctionRegion.IsUnknown()
+			modernSet := false
+			if !cfg.ResourceConfig.IsNull() && !cfg.ResourceConfig.IsUnknown() {
+				if rc, rcDiags := cfg.resourceConfig(ctx); !rcDiags.HasError() && rc != nil {
+					modernSet = !rc.FunctionDefaultRegions.IsNull() && !rc.FunctionDefaultRegions.IsUnknown()
+				}
+			}
+			if legacySet && modernSet {
+				resp.Diagnostics.AddAttributeWarning(
+					path.Root("serverless_function_region"),
+					"Deprecated attribute ignored",
+					"`serverless_function_region` is deprecated and is ignored when `resource_config.function_default_regions` is also set. `resource_config.function_default_regions` is the source of truth; remove `serverless_function_region` from your configuration to silence this warning.",
+				)
+			}
+		}
 	}
 
 	environment, err := plan.environment(ctx)

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -226,6 +226,72 @@ func TestAcc_ProjectFluidCompute(t *testing.T) {
 	})
 }
 
+// TestAcc_ProjectImportDualRegion is a regression test for issue #475.
+//
+// The Vercel API returns serverless_function_region as a derived alias of
+// resource_config.function_default_regions[0], so any project created with the
+// modern field also has the legacy field populated in its stored state. Before
+// the fix, the provider's ConflictsWith validators rejected that coexistence on
+// import, making projects unimportable once the API started auto-mirroring.
+//
+// This test creates a project via resource_config.function_default_regions
+// (producing the dual-populated state), imports it, and asserts that a follow-up
+// plan is empty — proving the provider now ingests the live state cleanly.
+func TestAcc_ProjectImportDualRegion(t *testing.T) {
+	projectSuffix := acctest.RandString(16)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccProjectDestroy(testClient(t), "vercel_project.test", testTeam(t)),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(fmt.Sprintf(`
+                resource "vercel_project" "test" {
+                    name = "test-acc-import-dual-region-%[1]s"
+                    resource_config = {
+                        function_default_regions = ["sfo1"]
+                    }
+                }
+                `, projectSuffix)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectExists(testClient(t), "vercel_project.test", testTeam(t)),
+					// Vercel mirrors the modern value into the legacy field on the
+					// server side; both should now be present in state without
+					// tripping ConflictsWith.
+					resource.TestCheckResourceAttr("vercel_project.test", "serverless_function_region", "sfo1"),
+					resource.TestCheckResourceAttr("vercel_project.test", "resource_config.function_default_regions.#", "1"),
+					resource.TestCheckResourceAttr("vercel_project.test", "resource_config.function_default_regions.0", "sfo1"),
+				),
+			},
+			{
+				// Import the dual-populated project and verify state parity.
+				ResourceName:      "vercel_project.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: getProjectImportID("vercel_project.test"),
+			},
+			{
+				// Re-apply with the same config and assert an empty plan. This is
+				// the reduction of the Pulumi-bridge failure to plain Terraform:
+				// after import, a no-op plan must succeed.
+				Config: cfg(fmt.Sprintf(`
+                resource "vercel_project" "test" {
+                    name = "test-acc-import-dual-region-%[1]s"
+                    resource_config = {
+                        function_default_regions = ["sfo1"]
+                    }
+                }
+                `, projectSuffix)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAcc_ProjectFunctionDefaultRegions(t *testing.T) {
 	projectSuffix := acctest.RandString(16)
 
@@ -234,17 +300,26 @@ func TestAcc_ProjectFunctionDefaultRegions(t *testing.T) {
 		CheckDestroy:             testAccProjectDestroy(testClient(t), "vercel_project.test", testTeam(t)),
 		Steps: []resource.TestStep{
 			{
-				// check if legacy setting serverless_function_region conflicts with resource_config.function_default_regions
+				// Declaring both the legacy and modern region fields is tolerated:
+				// resource_config.function_default_regions is the source of truth,
+				// and the legacy field is surfaced as a deprecation warning. This
+				// matches the Vercel API, which returns serverless_function_region
+				// as a derived alias of resource_config.function_default_regions[0]
+				// even when only the modern field is written.
 				Config: cfg(fmt.Sprintf(`
                 resource "vercel_project" "test" {
-                    name = "test-acc-regions-conflict-%[1]s"
+                    name = "test-acc-regions-both-%[1]s"
                     serverless_function_region = "sfo1"
                     resource_config = {
                         function_default_regions = ["iad1", "fra1"]
                     }
                 }
                 `, projectSuffix)),
-				ExpectError: regexp.MustCompile(strings.ReplaceAll("Attribute \"serverless_function_region\" cannot be specified when \"resource_config.function_default_regions\" is specified", " ", `\s*`)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("vercel_project.test", "resource_config.function_default_regions.#", "2"),
+					resource.TestCheckTypeSetElemAttr("vercel_project.test", "resource_config.function_default_regions.*", "iad1"),
+					resource.TestCheckTypeSetElemAttr("vercel_project.test", "resource_config.function_default_regions.*", "fra1"),
+				),
 			},
 			{
 				// check invalid region value


### PR DESCRIPTION
Fixes #475.

## Root cause

The Vercel API returns `serverlessFunctionRegion` as a **derived, backwards-compatibility alias** for `resourceConfig.functionDefaultRegions[0]` — confirmed by Vercel Support on the support ticket referenced in #475:

> `serverlessFunctionRegion` is not behaving like an independently stored field that can be cleared directly. Instead, it is returned by the API as a backwards-compatibility alias derived from `resourceConfig.functionDefaultRegions[0]`. […] we do not have a programmatic way to permanently clear `serverlessFunctionRegion` while `resourceConfig.functionDefaultRegions` is set.

The provider's reciprocal `ConflictsWith` validators modeled the API's *write* semantics (where you can set one field or the other, not both) but not its *read* semantics (where both coexist on any project created or touched via the modern path). The result: projects that the API itself produces fail the provider's own import-time validation.

## Why this reproduced through Pulumi but not plain Terraform

`ConflictsWith` from `terraform-plugin-framework-validators` checks `req.ConfigValue` — config, not state. In pure Terraform, `import { … }` brings state in without populating config, so the config slot for both attributes is null and the validator does not fire. Pulumi's Terraform bridge, however, reifies imported state back into Pulumi inputs, and those inputs become the effective config for the next validation pass. Both fields land in config with non-null values, and both reciprocal errors fire — which is exactly what @haseebrj17 hit.

## Change

- **Drop both `ConflictsWith` validators** on `serverless_function_region` and `resource_config.function_default_regions`. The write path in `toClientResourceConfig` already collapses the two into a single `functionDefaultRegions` array and prefers the modern value, so removing the config-level conflict is safe on `Create`/`Update`.
- **Add a `ModifyPlan` warning** (not an error) when a user authors both fields in config. The warning reads from `req.Config`, not `req.Plan`, so it only fires for user-authored dual-declaration and *not* for state round-trips during import.
- **Remove the unused `ServerlessFunctionRegion` field** from `CreateProjectRequest` and `UpdateProjectRequest` in `client/project.go`. The provider never populated these — `toClientResourceConfig` always folded the legacy value into `functionDefaultRegions`. This is strictly cleanup to keep future contributors from assuming the legacy field is writable over the v9 PATCH endpoint (the API rejects it anyway).

## Tests

- New: `TestAcc_ProjectImportDualRegion` — creates a project via `resource_config.function_default_regions = [\"sfo1\"]`, imports the resulting dual-populated state, and asserts an empty follow-up plan. This is the regression guard for #475: the Pulumi-bridge failure reduced to plain Terraform.
- Updated: step 1 of `TestAcc_ProjectFunctionDefaultRegions`, which previously asserted `ConflictsWith` fired. It now asserts the dual-field config succeeds and the modern field wins in state.

## Behavior change to call out for reviewers

Previously, declaring both fields in config was a hard error at plan time. It is now **permitted**, with the modern field winning silently plus a plan-time deprecation warning. This matches Vercel's own API semantics (where the legacy field is a derived alias and setting both in one PATCH is rejected by the API itself).

## No-ops

- No client-side clearing of `serverlessFunctionRegion` is possible — Vercel Support confirmed the field cannot be cleared server-side while `functionDefaultRegions` is set. This PR does not attempt any workaround; it simply stops rejecting the state the API returns.
- `data_source_project.go` already declares `serverless_function_region` as `Computed` with no `ConflictsWith`, so data sources were never affected.
- `docs/resources/project.md` is unchanged — `tfplugindocs` does not render `ConflictsWith` in markdown, only Description + `Deprecated` marker, and both are unchanged.

## Test plan

- [ ] Run `task test -- -run 'TestAcc_ProjectImportDualRegion'` against a Vercel test team — expect green.
- [ ] Run `task test -- -run 'TestAcc_ProjectFunctionDefaultRegions'` — expect green (updated step 1).
- [ ] Spot-check a fresh `terraform import` against a pre-migration project with both fields populated — expect clean state + empty follow-up plan.
- [ ] Manually verify the deprecation warning renders on `terraform plan` when both fields are in config.