### PR TITLE
Add git_commit_status and consolidated_git_commit_status to git_provider_options

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -229,15 +229,24 @@ type GitComments struct {
 }
 
 type GitProviderOptions struct {
-	RequireVerifiedCommits          *bool   `json:"requireVerifiedCommits,omitempty"`
-	CreateDeployments               *string `json:"createDeployments,omitempty"`
-	DisableRepositoryDispatchEvents *bool   `json:"disableRepositoryDispatchEvents,omitempty"`
+	RequireVerifiedCommits          *bool                        `json:"requireVerifiedCommits,omitempty"`
+	CreateDeployments               *string                      `json:"createDeployments,omitempty"`
+	DisableRepositoryDispatchEvents *bool                        `json:"disableRepositoryDispatchEvents,omitempty"`
+	GitCommitStatus                 *bool                        `json:"gitCommitStatus,omitempty"`
+	ConsolidatedGitCommitStatus     *ConsolidatedGitCommitStatus `json:"consolidatedGitCommitStatus,omitempty"`
 }
 
 type GitProviderOptionsResponse struct {
-	RequireVerifiedCommits          *bool   `json:"requireVerifiedCommits"`
-	CreateDeployments               *string `json:"createDeployments"`
-	DisableRepositoryDispatchEvents *bool   `json:"disableRepositoryDispatchEvents"`
+	RequireVerifiedCommits          *bool                        `json:"requireVerifiedCommits"`
+	CreateDeployments               *string                      `json:"createDeployments"`
+	DisableRepositoryDispatchEvents *bool                        `json:"disableRepositoryDispatchEvents"`
+	GitCommitStatus                 *bool                        `json:"gitCommitStatus"`
+	ConsolidatedGitCommitStatus     *ConsolidatedGitCommitStatus `json:"consolidatedGitCommitStatus"`
+}
+
+type ConsolidatedGitCommitStatus struct {
+	Enabled           bool `json:"enabled"`
+	PropagateFailures bool `json:"propagateFailures"`
 }
 
 type Security struct {

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -107,7 +107,7 @@ Required:
 
 Read-Only:
 
-- `consolidated_git_commit_status` (Attributes) Configuration for consolidated git commit status reporting. (see [below for nested schema](#nestedatt--git_provider_options--consolidated_git_commit_status))
+- `consolidated_git_commit_status` (Attributes) **Beta:** Configuration for consolidated git commit status reporting. This feature is in beta and may change in backwards-incompatible ways. (see [below for nested schema](#nestedatt--git_provider_options--consolidated_git_commit_status))
 - `create_deployments` (Boolean) Whether to create deployments.
 - `git_commit_status` (Boolean) Whether Vercel posts git commit statuses for this project.
 - `repository_dispatch_events` (Boolean) Whether repository dispatch events are enabled.
@@ -118,8 +118,8 @@ Read-Only:
 
 Read-Only:
 
-- `enabled` (Boolean) Whether consolidated commit status is enabled.
-- `propagate_failures` (Boolean) Whether to propagate individual deployment failures to the consolidated status.
+- `enabled` (Boolean) **Beta:** Whether consolidated commit status is enabled.
+- `propagate_failures` (Boolean) **Beta:** Whether to propagate individual deployment failures to the consolidated status.
 
 
 

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -107,9 +107,20 @@ Required:
 
 Read-Only:
 
+- `consolidated_git_commit_status` (Attributes) Configuration for consolidated git commit status reporting. (see [below for nested schema](#nestedatt--git_provider_options--consolidated_git_commit_status))
 - `create_deployments` (Boolean) Whether to create deployments.
+- `git_commit_status` (Boolean) Whether Vercel posts git commit statuses for this project.
 - `repository_dispatch_events` (Boolean) Whether repository dispatch events are enabled.
 - `require_verified_commits` (Boolean) Whether to require verified commits.
+
+<a id="nestedatt--git_provider_options--consolidated_git_commit_status"></a>
+### Nested Schema for `git_provider_options.consolidated_git_commit_status`
+
+Read-Only:
+
+- `enabled` (Boolean) Whether consolidated commit status is enabled.
+- `propagate_failures` (Boolean) Whether to propagate individual deployment failures to the consolidated status.
+
 
 
 <a id="nestedatt--git_repository"></a>

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -136,7 +136,7 @@ Required:
 
 Optional:
 
-- `consolidated_git_commit_status` (Attributes) Configuration for consolidated git commit status reporting. When enabled, Vercel posts a single consolidated commit status instead of one per deployment. (see [below for nested schema](#nestedatt--git_provider_options--consolidated_git_commit_status))
+- `consolidated_git_commit_status` (Attributes) **Beta:** Configuration for consolidated git commit status reporting. When enabled, Vercel posts a single consolidated commit status instead of one per deployment. This feature is in beta and may change in backwards-incompatible ways. (see [below for nested schema](#nestedatt--git_provider_options--consolidated_git_commit_status))
 - `create_deployments` (Boolean) Whether to create deployments
 - `git_commit_status` (Boolean) Whether Vercel should post git commit statuses for this project. Defaults to `true` when unset.
 - `repository_dispatch_events` (Boolean) Whether to enable repository dispatch events
@@ -147,8 +147,8 @@ Optional:
 
 Required:
 
-- `enabled` (Boolean) Whether consolidated commit status is enabled.
-- `propagate_failures` (Boolean) Whether to propagate individual deployment failures to the consolidated status.
+- `enabled` (Boolean) **Beta:** Whether consolidated commit status is enabled.
+- `propagate_failures` (Boolean) **Beta:** Whether to propagate individual deployment failures to the consolidated status.
 
 
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -136,9 +136,20 @@ Required:
 
 Optional:
 
+- `consolidated_git_commit_status` (Attributes) Configuration for consolidated git commit status reporting. When enabled, Vercel posts a single consolidated commit status instead of one per deployment. (see [below for nested schema](#nestedatt--git_provider_options--consolidated_git_commit_status))
 - `create_deployments` (Boolean) Whether to create deployments
+- `git_commit_status` (Boolean) Whether Vercel should post git commit statuses for this project. Defaults to `true` when unset.
 - `repository_dispatch_events` (Boolean) Whether to enable repository dispatch events
 - `require_verified_commits` (Boolean) Whether to require verified commits
+
+<a id="nestedatt--git_provider_options--consolidated_git_commit_status"></a>
+### Nested Schema for `git_provider_options.consolidated_git_commit_status`
+
+Required:
+
+- `enabled` (Boolean) Whether consolidated commit status is enabled.
+- `propagate_failures` (Boolean) Whether to propagate individual deployment failures to the consolidated status.
+
 
 
 <a id="nestedatt--git_repository"></a>

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -337,6 +337,24 @@ For more detailed information, please see the [Vercel documentation](https://ver
 						MarkdownDescription: "Whether repository dispatch events are enabled.",
 						Computed:            true,
 					},
+					"git_commit_status": schema.BoolAttribute{
+						MarkdownDescription: "Whether Vercel posts git commit statuses for this project.",
+						Computed:            true,
+					},
+					"consolidated_git_commit_status": schema.SingleNestedAttribute{
+						MarkdownDescription: "Configuration for consolidated git commit status reporting.",
+						Computed:            true,
+						Attributes: map[string]schema.Attribute{
+							"enabled": schema.BoolAttribute{
+								MarkdownDescription: "Whether consolidated commit status is enabled.",
+								Computed:            true,
+							},
+							"propagate_failures": schema.BoolAttribute{
+								MarkdownDescription: "Whether to propagate individual deployment failures to the consolidated status.",
+								Computed:            true,
+							},
+						},
+					},
 				},
 			},
 			"preview_comments": schema.BoolAttribute{
@@ -494,10 +512,19 @@ func convertResponseToProjectDataSource(ctx context.Context, response client.Pro
 		if response.GitProviderOptions.DisableRepositoryDispatchEvents != nil {
 			repositoryDispatchEvents = types.BoolValue(!*response.GitProviderOptions.DisableRepositoryDispatchEvents)
 		}
+		consolidated := types.ObjectNull(consolidatedGitCommitStatusAttrType.AttrTypes)
+		if response.GitProviderOptions.ConsolidatedGitCommitStatus != nil {
+			consolidated = types.ObjectValueMust(consolidatedGitCommitStatusAttrType.AttrTypes, map[string]attr.Value{
+				"enabled":            types.BoolValue(response.GitProviderOptions.ConsolidatedGitCommitStatus.Enabled),
+				"propagate_failures": types.BoolValue(response.GitProviderOptions.ConsolidatedGitCommitStatus.PropagateFailures),
+			})
+		}
 		plan.GitProviderOptions = types.ObjectValueMust(gitProviderOptionsAttrType.AttrTypes, map[string]attr.Value{
-			"require_verified_commits":   types.BoolPointerValue(response.GitProviderOptions.RequireVerifiedCommits),
-			"create_deployments":         createDeployments,
-			"repository_dispatch_events": repositoryDispatchEvents,
+			"require_verified_commits":       types.BoolPointerValue(response.GitProviderOptions.RequireVerifiedCommits),
+			"create_deployments":             createDeployments,
+			"repository_dispatch_events":     repositoryDispatchEvents,
+			"git_commit_status":              types.BoolPointerValue(response.GitProviderOptions.GitCommitStatus),
+			"consolidated_git_commit_status": consolidated,
 		})
 	}
 

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -342,15 +342,15 @@ For more detailed information, please see the [Vercel documentation](https://ver
 						Computed:            true,
 					},
 					"consolidated_git_commit_status": schema.SingleNestedAttribute{
-						MarkdownDescription: "Configuration for consolidated git commit status reporting.",
+						MarkdownDescription: "**Beta:** Configuration for consolidated git commit status reporting. This feature is in beta and may change in backwards-incompatible ways.",
 						Computed:            true,
 						Attributes: map[string]schema.Attribute{
 							"enabled": schema.BoolAttribute{
-								MarkdownDescription: "Whether consolidated commit status is enabled.",
+								MarkdownDescription: "**Beta:** Whether consolidated commit status is enabled.",
 								Computed:            true,
 							},
 							"propagate_failures": schema.BoolAttribute{
-								MarkdownDescription: "Whether to propagate individual deployment failures to the consolidated status.",
+								MarkdownDescription: "**Beta:** Whether to propagate individual deployment failures to the consolidated status.",
 								Computed:            true,
 							},
 						},

--- a/vercel/data_source_project_test.go
+++ b/vercel/data_source_project_test.go
@@ -248,6 +248,8 @@ func TestAcc_ProjectDataSourceGitProviderOptions(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vercel_project.test", "name", "test-acc-gpo-ds-"+name),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "git_provider_options.create_deployments", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "git_provider_options.repository_dispatch_events", "false"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "git_provider_options.consolidated_git_commit_status.enabled", "true"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "git_provider_options.consolidated_git_commit_status.propagate_failures", "true"),
 				),
 			},
 		},
@@ -265,6 +267,10 @@ resource "vercel_project" "test" {
   git_provider_options = {
     create_deployments = true
     repository_dispatch_events = false
+    consolidated_git_commit_status = {
+      enabled = true
+      propagate_failures = true
+    }
   }
 }
 

--- a/vercel/data_source_project_test.go
+++ b/vercel/data_source_project_test.go
@@ -248,6 +248,7 @@ func TestAcc_ProjectDataSourceGitProviderOptions(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vercel_project.test", "name", "test-acc-gpo-ds-"+name),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "git_provider_options.create_deployments", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "git_provider_options.repository_dispatch_events", "false"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "git_provider_options.git_commit_status", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "git_provider_options.consolidated_git_commit_status.enabled", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "git_provider_options.consolidated_git_commit_status.propagate_failures", "true"),
 				),
@@ -267,6 +268,7 @@ resource "vercel_project" "test" {
   git_provider_options = {
     create_deployments = true
     repository_dispatch_events = false
+    git_commit_status = true
     consolidated_git_commit_status = {
       enabled = true
       propagate_failures = true

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -705,6 +705,7 @@ func (p Project) RequiresUpdateAfterCreation() bool {
 		(!p.TrustedIps.IsNull() && !p.TrustedIps.IsUnknown()) ||
 		(!p.OIDCTokenConfig.IsNull() && !p.OIDCTokenConfig.IsUnknown()) ||
 		(!p.OptionsAllowlist.IsNull() && !p.OptionsAllowlist.IsUnknown()) ||
+		(!p.GitProviderOptions.IsNull() && !p.GitProviderOptions.IsUnknown()) ||
 		!p.AutoExposeSystemEnvVars.IsNull() ||
 		p.GitComments.IsNull() ||
 		(!p.AutoAssignCustomDomains.IsNull() && !p.AutoAssignCustomDomains.ValueBool()) ||

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -467,6 +467,26 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 						Optional:            true,
 						Computed:            true,
 					},
+					"git_commit_status": schema.BoolAttribute{
+						MarkdownDescription: "Whether Vercel should post git commit statuses for this project. Defaults to `true` when unset.",
+						Optional:            true,
+						Computed:            true,
+					},
+					"consolidated_git_commit_status": schema.SingleNestedAttribute{
+						MarkdownDescription: "Configuration for consolidated git commit status reporting. When enabled, Vercel posts a single consolidated commit status instead of one per deployment.",
+						Optional:            true,
+						Computed:            true,
+						Attributes: map[string]schema.Attribute{
+							"enabled": schema.BoolAttribute{
+								MarkdownDescription: "Whether consolidated commit status is enabled.",
+								Required:            true,
+							},
+							"propagate_failures": schema.BoolAttribute{
+								MarkdownDescription: "Whether to propagate individual deployment failures to the consolidated status.",
+								Required:            true,
+							},
+						},
+					},
 				},
 			},
 			"preview_comments": schema.BoolAttribute{
@@ -830,9 +850,9 @@ func (p *Project) gitProviderOptionsObj(ctx context.Context) (*GitProviderOption
 	return &gpo, nil
 }
 
-func (g *GitProviderOptions) toUpdateProjectRequest() *client.GitProviderOptions {
+func (g *GitProviderOptions) toUpdateProjectRequest(ctx context.Context) (*client.GitProviderOptions, diag.Diagnostics) {
 	if g == nil {
-		return nil
+		return nil, nil
 	}
 	var createDeployments *string
 	if !g.CreateDeployments.IsNull() && !g.CreateDeployments.IsUnknown() {
@@ -847,11 +867,25 @@ func (g *GitProviderOptions) toUpdateProjectRequest() *client.GitProviderOptions
 		val := !g.RepositoryDispatchEvents.ValueBool()
 		disableRepositoryDispatchEvents = &val
 	}
+	var consolidated *client.ConsolidatedGitCommitStatus
+	if !g.ConsolidatedGitCommitStatus.IsNull() && !g.ConsolidatedGitCommitStatus.IsUnknown() {
+		var c ConsolidatedGitCommitStatus
+		diags := g.ConsolidatedGitCommitStatus.As(ctx, &c, basetypes.ObjectAsOptions{UnhandledNullAsEmpty: true, UnhandledUnknownAsEmpty: true})
+		if diags.HasError() {
+			return nil, diags
+		}
+		consolidated = &client.ConsolidatedGitCommitStatus{
+			Enabled:           c.Enabled.ValueBool(),
+			PropagateFailures: c.PropagateFailures.ValueBool(),
+		}
+	}
 	return &client.GitProviderOptions{
 		RequireVerifiedCommits:          g.RequireVerifiedCommits.ValueBoolPointer(),
 		CreateDeployments:               createDeployments,
 		DisableRepositoryDispatchEvents: disableRepositoryDispatchEvents,
-	}
+		GitCommitStatus:                 g.GitCommitStatus.ValueBoolPointer(),
+		ConsolidatedGitCommitStatus:     consolidated,
+	}, nil
 }
 
 func (p *Project) toCreateProjectRequest(ctx context.Context, envs []EnvironmentItem) (req client.CreateProjectRequest, diags diag.Diagnostics) {
@@ -962,6 +996,8 @@ func (p *Project) toUpdateProjectRequest(ctx context.Context, oldName string) (r
 	diags.Append(d4...)
 	gpo, d5 := p.gitProviderOptionsObj(ctx)
 	diags.Append(d5...)
+	gpoReq, d6 := gpo.toUpdateProjectRequest(ctx)
+	diags.Append(d6...)
 	if diags.HasError() {
 		return req, diags
 	}
@@ -995,7 +1031,7 @@ func (p *Project) toUpdateProjectRequest(ctx context.Context, oldName string) (r
 		DirectoryListing:                     p.DirectoryListing.ValueBool(),
 		SkewProtectionMaxAge:                 toSkewProtectionAge(p.SkewProtection),
 		GitComments:                          gc.toUpdateProjectRequest(),
-		GitProviderOptions:                   gpo.toUpdateProjectRequest(),
+		GitProviderOptions:                   gpoReq,
 		ResourceConfig:                       resourceConfig.toClientResourceConfig(ctx, p.OnDemandConcurrentBuilds, p.BuildMachineType, p.ServerlessFunctionRegion),
 		NodeVersion:                          p.NodeVersion.ValueString(),
 	}, nil
@@ -1307,18 +1343,34 @@ var optionsAllowlistAttrType = types.ObjectType{
 	},
 }
 
+var consolidatedGitCommitStatusAttrType = types.ObjectType{
+	AttrTypes: map[string]attr.Type{
+		"enabled":            types.BoolType,
+		"propagate_failures": types.BoolType,
+	},
+}
+
 var gitProviderOptionsAttrType = types.ObjectType{
 	AttrTypes: map[string]attr.Type{
-		"require_verified_commits":   types.BoolType,
-		"create_deployments":         types.BoolType,
-		"repository_dispatch_events": types.BoolType,
+		"require_verified_commits":       types.BoolType,
+		"create_deployments":             types.BoolType,
+		"repository_dispatch_events":     types.BoolType,
+		"git_commit_status":              types.BoolType,
+		"consolidated_git_commit_status": consolidatedGitCommitStatusAttrType,
 	},
 }
 
 type GitProviderOptions struct {
-	RequireVerifiedCommits   types.Bool `tfsdk:"require_verified_commits"`
-	CreateDeployments        types.Bool `tfsdk:"create_deployments"`
-	RepositoryDispatchEvents types.Bool `tfsdk:"repository_dispatch_events"`
+	RequireVerifiedCommits      types.Bool   `tfsdk:"require_verified_commits"`
+	CreateDeployments           types.Bool   `tfsdk:"create_deployments"`
+	RepositoryDispatchEvents    types.Bool   `tfsdk:"repository_dispatch_events"`
+	GitCommitStatus             types.Bool   `tfsdk:"git_commit_status"`
+	ConsolidatedGitCommitStatus types.Object `tfsdk:"consolidated_git_commit_status"`
+}
+
+type ConsolidatedGitCommitStatus struct {
+	Enabled           types.Bool `tfsdk:"enabled"`
+	PropagateFailures types.Bool `tfsdk:"propagate_failures"`
 }
 
 type ResourceConfig struct {
@@ -1743,10 +1795,19 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 		if response.GitProviderOptions.DisableRepositoryDispatchEvents != nil {
 			repositoryDispatchEvents = types.BoolValue(!*response.GitProviderOptions.DisableRepositoryDispatchEvents)
 		}
+		consolidated := types.ObjectNull(consolidatedGitCommitStatusAttrType.AttrTypes)
+		if response.GitProviderOptions.ConsolidatedGitCommitStatus != nil {
+			consolidated = types.ObjectValueMust(consolidatedGitCommitStatusAttrType.AttrTypes, map[string]attr.Value{
+				"enabled":            types.BoolValue(response.GitProviderOptions.ConsolidatedGitCommitStatus.Enabled),
+				"propagate_failures": types.BoolValue(response.GitProviderOptions.ConsolidatedGitCommitStatus.PropagateFailures),
+			})
+		}
 		gitProviderOptions = types.ObjectValueMust(gitProviderOptionsAttrType.AttrTypes, map[string]attr.Value{
-			"require_verified_commits":   types.BoolPointerValue(response.GitProviderOptions.RequireVerifiedCommits),
-			"create_deployments":         createDeployments,
-			"repository_dispatch_events": repositoryDispatchEvents,
+			"require_verified_commits":       types.BoolPointerValue(response.GitProviderOptions.RequireVerifiedCommits),
+			"create_deployments":             createDeployments,
+			"repository_dispatch_events":     repositoryDispatchEvents,
+			"git_commit_status":              types.BoolPointerValue(response.GitProviderOptions.GitCommitStatus),
+			"consolidated_git_commit_status": consolidated,
 		})
 	}
 

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -473,16 +473,16 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 						Computed:            true,
 					},
 					"consolidated_git_commit_status": schema.SingleNestedAttribute{
-						MarkdownDescription: "Configuration for consolidated git commit status reporting. When enabled, Vercel posts a single consolidated commit status instead of one per deployment.",
+						MarkdownDescription: "**Beta:** Configuration for consolidated git commit status reporting. When enabled, Vercel posts a single consolidated commit status instead of one per deployment. This feature is in beta and may change in backwards-incompatible ways.",
 						Optional:            true,
 						Computed:            true,
 						Attributes: map[string]schema.Attribute{
 							"enabled": schema.BoolAttribute{
-								MarkdownDescription: "Whether consolidated commit status is enabled.",
+								MarkdownDescription: "**Beta:** Whether consolidated commit status is enabled.",
 								Required:            true,
 							},
 							"propagate_failures": schema.BoolAttribute{
-								MarkdownDescription: "Whether to propagate individual deployment failures to the consolidated status.",
+								MarkdownDescription: "**Beta:** Whether to propagate individual deployment failures to the consolidated status.",
 								Required:            true,
 							},
 						},

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -1244,21 +1244,23 @@ func TestAcc_ProjectGitProviderOptions(t *testing.T) {
 		CheckDestroy:             testAccProjectDestroy(testClient(t), "vercel_project.test", testTeam(t)),
 		Steps: []resource.TestStep{
 			{
-				// Create project with git_provider_options
 				Config: cfg(testAccProjectConfigWithGitProviderOptions(projectSuffix, testGithubRepo(t))),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccProjectExists(testClient(t), "vercel_project.test", testTeam(t)),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.create_deployments", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.repository_dispatch_events", "false"),
+					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.consolidated_git_commit_status.enabled", "true"),
+					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.consolidated_git_commit_status.propagate_failures", "true"),
 				),
 			},
 			{
-				// Update git_provider_options
 				Config: cfg(testAccProjectConfigWithGitProviderOptionsUpdated(projectSuffix, testGithubRepo(t))),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccProjectExists(testClient(t), "vercel_project.test", testTeam(t)),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.create_deployments", "false"),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.repository_dispatch_events", "true"),
+					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.consolidated_git_commit_status.enabled", "false"),
+					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.consolidated_git_commit_status.propagate_failures", "false"),
 				),
 			},
 		},
@@ -1276,6 +1278,10 @@ resource "vercel_project" "test" {
   git_provider_options = {
     create_deployments = true
     repository_dispatch_events = false
+    consolidated_git_commit_status = {
+      enabled = true
+      propagate_failures = true
+    }
   }
 }
 `, projectSuffix, githubRepo)
@@ -1292,6 +1298,10 @@ resource "vercel_project" "test" {
   git_provider_options = {
     create_deployments = false
     repository_dispatch_events = true
+    consolidated_git_commit_status = {
+      enabled = false
+      propagate_failures = false
+    }
   }
 }
 `, projectSuffix, githubRepo)

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -1249,6 +1249,7 @@ func TestAcc_ProjectGitProviderOptions(t *testing.T) {
 					testAccProjectExists(testClient(t), "vercel_project.test", testTeam(t)),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.create_deployments", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.repository_dispatch_events", "false"),
+					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.git_commit_status", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.consolidated_git_commit_status.enabled", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.consolidated_git_commit_status.propagate_failures", "true"),
 				),
@@ -1259,6 +1260,7 @@ func TestAcc_ProjectGitProviderOptions(t *testing.T) {
 					testAccProjectExists(testClient(t), "vercel_project.test", testTeam(t)),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.create_deployments", "false"),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.repository_dispatch_events", "true"),
+					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.git_commit_status", "false"),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.consolidated_git_commit_status.enabled", "false"),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_provider_options.consolidated_git_commit_status.propagate_failures", "false"),
 				),
@@ -1278,6 +1280,7 @@ resource "vercel_project" "test" {
   git_provider_options = {
     create_deployments = true
     repository_dispatch_events = false
+    git_commit_status = true
     consolidated_git_commit_status = {
       enabled = true
       propagate_failures = true
@@ -1298,6 +1301,7 @@ resource "vercel_project" "test" {
   git_provider_options = {
     create_deployments = false
     repository_dispatch_events = true
+    git_commit_status = false
     consolidated_git_commit_status = {
       enabled = false
       propagate_failures = false


### PR DESCRIPTION
## Summary

- Adds two new optional fields under `git_provider_options` on `vercel_project`: `git_commit_status` (bool) and `consolidated_git_commit_status` (object with `enabled`/`propagate_failures`).
- Mirrors the same fields as read-only on the project data source.
- Wires them through to the `api-projects` PATCH payload alongside the existing `requireVerifiedCommits`, `createDeployments`, and repository-dispatch options.

These map to the API fields added in vercel/api#65962 and vercel/api#66970.

## Test plan

- [ ] \`go build ./...\`
- [ ] \`gofmt -s -l .\` clean
- [ ] \`go vet ./...\` clean
- [ ] \`tfproviderlint\` clean
- [ ] \`task docs\` produces no further diff
- [ ] Acceptance test with a project setting both new fields end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)