### PR TITLE
fix: skip empty build_machine_type so adopted projects can update

### DIFF
--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -1439,7 +1439,11 @@ func (r *ResourceConfig) toClientResourceConfig(ctx context.Context, onDemandCon
 		}
 		resourceConfig.ElasticConcurrencyEnabled = onDemandConcurrentBuilds.ValueBoolPointer()
 	}
-	if !buildMachineType.IsUnknown() {
+	// The API rejects an explicit `buildMachineType: ""` (allowed values are
+	// null, "enhanced", "turbo", "standard", "elastic"). Adopted projects can
+	// land in state with an empty string when the API returned no value, so
+	// only forward concrete, non-empty values.
+	if !buildMachineType.IsUnknown() && !buildMachineType.IsNull() && buildMachineType.ValueString() != "" {
 		if resourceConfig == nil {
 			resourceConfig = &client.ResourceConfig{}
 		}

--- a/vercel/resource_project_unit_test.go
+++ b/vercel/resource_project_unit_test.go
@@ -1,0 +1,85 @@
+package vercel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestToClientResourceConfig_BuildMachineType(t *testing.T) {
+	tests := []struct {
+		name              string
+		buildMachineType  types.String
+		wantBuildMachine  *string
+		wantSelection     *string
+	}{
+		{
+			name:             "null is omitted",
+			buildMachineType: types.StringNull(),
+		},
+		// Regression: an adopted project whose API response had no
+		// buildMachineType previously landed in state as
+		// types.StringValue("") and was forwarded back to the API on
+		// update, which rejects an explicit empty string.
+		{
+			name:             "empty string is omitted",
+			buildMachineType: types.StringValue(""),
+		},
+		{
+			name:             "unknown is omitted",
+			buildMachineType: types.StringUnknown(),
+		},
+		{
+			name:             "enhanced is sent as buildMachineType",
+			buildMachineType: types.StringValue("enhanced"),
+			wantBuildMachine: stringPtr("enhanced"),
+		},
+		{
+			name:             "elastic is sent as buildMachineSelection",
+			buildMachineType: types.StringValue("elastic"),
+			wantSelection:    stringPtr("elastic"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var rc *ResourceConfig
+			got := rc.toClientResourceConfig(
+				context.Background(),
+				types.BoolNull(),
+				tc.buildMachineType,
+				types.StringNull(),
+			)
+
+			if got == nil {
+				if tc.wantBuildMachine != nil || tc.wantSelection != nil {
+					t.Fatalf("expected resource config, got nil")
+				}
+				return
+			}
+			if !stringPtrEq(got.BuildMachineType, tc.wantBuildMachine) {
+				t.Errorf("BuildMachineType: got %v, want %v", deref(got.BuildMachineType), deref(tc.wantBuildMachine))
+			}
+			if !stringPtrEq(got.BuildMachineSelection, tc.wantSelection) {
+				t.Errorf("BuildMachineSelection: got %v, want %v", deref(got.BuildMachineSelection), deref(tc.wantSelection))
+			}
+		})
+	}
+}
+
+func stringPtr(v string) *string { return &v }
+
+func stringPtrEq(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func deref(p *string) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}


### PR DESCRIPTION
## Summary

When a project's API response had no `buildMachineType` value, the provider's Read path stored it in state as `types.StringValue("")` — a known empty string rather than null. On subsequent updates, that planned value was forwarded to the API as `buildMachineType: ""`, which the API rejects (allowed values are `null`, `enhanced`, `turbo`, `standard`, `elastic`):

```
unexpected error: bad_request - Invalid request:
`resourceConfig.buildMachineType` should be equal to one of the
allowed values ", enhanced, turbo, standard, elastic".
```

This affected projects adopted with no build machine type set, even when `build_machine_type` was in `lifecycle.ignore_changes` — `ignore_changes` substitutes the state value into the plan, and the state value was `""` rather than null.

`toClientResourceConfig` now skips `BuildMachineType`/`BuildMachineSelection` when the value is null or empty, so the empty-string case maps to the API's "omit the field" behavior.

## Test plan

- [x] New unit test `TestToClientResourceConfig_BuildMachineType` covers null, empty, unknown, `enhanced`, and `elastic` inputs and fails on the unfixed code in the empty-string case
- [ ] Re-run the failing terraform plan against an adopted project to confirm it now succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)