### PR TITLE
fix project update payload strictness

### DIFF
--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -706,17 +706,17 @@ func (p Project) RequiresUpdateAfterCreation() bool {
 		(!p.OIDCTokenConfig.IsNull() && !p.OIDCTokenConfig.IsUnknown()) ||
 		(!p.OptionsAllowlist.IsNull() && !p.OptionsAllowlist.IsUnknown()) ||
 		(!p.GitProviderOptions.IsNull() && !p.GitProviderOptions.IsUnknown()) ||
-		!p.AutoExposeSystemEnvVars.IsNull() ||
-		p.GitComments.IsNull() ||
-		(!p.AutoAssignCustomDomains.IsNull() && !p.AutoAssignCustomDomains.ValueBool()) ||
-		!p.GitLFS.IsNull() ||
-		!p.FunctionFailover.IsNull() ||
-		!p.CustomerSuccessCodeVisibility.IsNull() ||
-		(!p.GitForkProtection.IsNull() && !p.GitForkProtection.ValueBool()) ||
-		!p.PrioritiseProductionBuilds.IsNull() ||
-		!p.DirectoryListing.IsNull() ||
-		!p.SkewProtection.IsNull() ||
-		!p.NodeVersion.IsNull()
+		knownBool(p.AutoExposeSystemEnvVars) ||
+		(!p.GitComments.IsNull() && !p.GitComments.IsUnknown()) ||
+		(knownBool(p.AutoAssignCustomDomains) && !p.AutoAssignCustomDomains.ValueBool()) ||
+		knownBool(p.GitLFS) ||
+		knownBool(p.FunctionFailover) ||
+		knownBool(p.CustomerSuccessCodeVisibility) ||
+		(knownBool(p.GitForkProtection) && !p.GitForkProtection.ValueBool()) ||
+		knownBool(p.PrioritiseProductionBuilds) ||
+		knownBool(p.DirectoryListing) ||
+		knownString(p.SkewProtection) ||
+		knownString(p.NodeVersion)
 }
 
 var nullProject = Project{
@@ -965,6 +965,14 @@ func oneBoolPointer(a, b types.Bool) *bool {
 	return nil
 }
 
+func knownBool(v types.Bool) bool {
+	return !v.IsNull() && !v.IsUnknown()
+}
+
+func knownString(v types.String) bool {
+	return !v.IsNull() && !v.IsUnknown()
+}
+
 func (p *Project) toUpdateProjectRequest(ctx context.Context, oldName string) (req client.UpdateProjectRequest, diags diag.Diagnostics) {
 	var name *string = nil
 	if oldName != p.Name.ValueString() {
@@ -972,12 +980,14 @@ func (p *Project) toUpdateProjectRequest(ctx context.Context, oldName string) (r
 		name = &n
 	}
 	var gc *GitComments
-	diags = p.GitComments.As(ctx, &gc, basetypes.ObjectAsOptions{
-		UnhandledNullAsEmpty:    true,
-		UnhandledUnknownAsEmpty: true,
-	})
-	if diags.HasError() {
-		return req, diags
+	if !p.GitComments.IsNull() && !p.GitComments.IsUnknown() {
+		diags = p.GitComments.As(ctx, &gc, basetypes.ObjectAsOptions{
+			UnhandledNullAsEmpty:    true,
+			UnhandledUnknownAsEmpty: true,
+		})
+		if diags.HasError() {
+			return req, diags
+		}
 	}
 	resourceConfig, diags := p.resourceConfig(ctx)
 	if diags.HasError() {
@@ -1414,10 +1424,10 @@ func (r *ResourceConfig) toClientResourceConfig(ctx context.Context, onDemandCon
 	if r != nil {
 		resourceConfig = &client.ResourceConfig{}
 	}
-	if r != nil && !r.FunctionDefaultCPUType.IsUnknown() {
+	if r != nil && !r.FunctionDefaultCPUType.IsUnknown() && !r.FunctionDefaultCPUType.IsNull() {
 		resourceConfig.FunctionDefaultMemoryType = r.FunctionDefaultCPUType.ValueStringPointer()
 	}
-	if r != nil && !r.FunctionDefaultTimeout.IsUnknown() {
+	if r != nil && !r.FunctionDefaultTimeout.IsUnknown() && !r.FunctionDefaultTimeout.IsNull() {
 		resourceConfig.FunctionDefaultTimeout = r.FunctionDefaultTimeout.ValueInt64Pointer()
 	}
 	if r != nil && !r.FunctionDefaultRegions.IsUnknown() && !r.FunctionDefaultRegions.IsNull() {
@@ -1430,10 +1440,10 @@ func (r *ResourceConfig) toClientResourceConfig(ctx context.Context, onDemandCon
 		}
 		resourceConfig.FunctionDefaultRegions = []string{serverlessFunctionRegion.ValueString()}
 	}
-	if r != nil && !r.Fluid.IsUnknown() {
+	if r != nil && !r.Fluid.IsUnknown() && !r.Fluid.IsNull() {
 		resourceConfig.Fluid = r.Fluid.ValueBoolPointer()
 	}
-	if !onDemandConcurrentBuilds.IsUnknown() {
+	if !onDemandConcurrentBuilds.IsUnknown() && !onDemandConcurrentBuilds.IsNull() {
 		if resourceConfig == nil {
 			resourceConfig = &client.ResourceConfig{}
 		}

--- a/vercel/resource_project_unit_test.go
+++ b/vercel/resource_project_unit_test.go
@@ -1,0 +1,65 @@
+package vercel
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestProjectRequiresUpdateAfterCreationOnlyForConfiguredFields(t *testing.T) {
+	project := projectForUpdateRequestTests()
+	if project.RequiresUpdateAfterCreation() {
+		t.Fatal("RequiresUpdateAfterCreation() = true, want false for unset fields")
+	}
+
+	project.GitComments = types.ObjectValueMust(gitCommentsAttrTypes, map[string]attr.Value{
+		"on_pull_request": types.BoolValue(true),
+		"on_commit":       types.BoolValue(false),
+	})
+	if !project.RequiresUpdateAfterCreation() {
+		t.Fatal("RequiresUpdateAfterCreation() = false, want true for configured git_comments")
+	}
+}
+
+func projectForUpdateRequestTests() Project {
+	return Project{
+		Name:                              types.StringValue("example"),
+		BuildCommand:                      types.StringNull(),
+		IgnoreCommand:                     types.StringNull(),
+		DevCommand:                        types.StringNull(),
+		Framework:                         types.StringNull(),
+		InstallCommand:                    types.StringNull(),
+		OutputDirectory:                   types.StringNull(),
+		PreviewDeploymentSuffix:           types.StringNull(),
+		PublicSource:                      types.BoolNull(),
+		RootDirectory:                     types.StringNull(),
+		GitRepository:                     types.ObjectNull(gitRepositoryAttrType.AttrTypes),
+		VercelAuthentication:              types.ObjectNull(vercelAuthenticationAttrType.AttrTypes),
+		PasswordProtection:                types.ObjectNull(passwordProtectionWithPasswordAttrType.AttrTypes),
+		TrustedIps:                        types.ObjectNull(trustedIpsAttrType.AttrTypes),
+		OIDCTokenConfig:                   types.ObjectNull(oidcTokenConfigAttrType.AttrTypes),
+		OptionsAllowlist:                  types.ObjectNull(optionsAllowlistAttrType.AttrTypes),
+		AutoExposeSystemEnvVars:           types.BoolUnknown(),
+		PreviewComments:                   types.BoolNull(),
+		EnablePreviewFeedback:             types.BoolNull(),
+		EnableProductionFeedback:          types.BoolNull(),
+		EnableAffectedProjectsDeployments: types.BoolNull(),
+		PreviewDeploymentsDisabled:        types.BoolUnknown(),
+		AutoAssignCustomDomains:           types.BoolValue(true),
+		GitLFS:                            types.BoolUnknown(),
+		FunctionFailover:                  types.BoolUnknown(),
+		CustomerSuccessCodeVisibility:     types.BoolUnknown(),
+		GitForkProtection:                 types.BoolValue(true),
+		PrioritiseProductionBuilds:        types.BoolUnknown(),
+		DirectoryListing:                  types.BoolUnknown(),
+		SkewProtection:                    types.StringNull(),
+		GitComments:                       types.ObjectNull(gitCommentsAttrTypes),
+		GitProviderOptions:                types.ObjectNull(gitProviderOptionsAttrType.AttrTypes),
+		ResourceConfig:                    types.ObjectNull(resourceConfigAttrType.AttrTypes),
+		NodeVersion:                       types.StringUnknown(),
+		OnDemandConcurrentBuilds:          types.BoolUnknown(),
+		BuildMachineType:                  types.StringUnknown(),
+		Environment:                       types.SetNull(envVariableElemType),
+	}
+}


### PR DESCRIPTION
Fixes project post-create update detection so git_comments only triggers when it is actually configured, and avoids treating unknown/null project resource config values as update payload values.