### PR TITLE
stop logging secret payloads

### DIFF
--- a/client/deployment.go
+++ b/client/deployment.go
@@ -221,8 +221,7 @@ func (c *Client) CreateDeployment(ctx context.Context, request CreateDeploymentR
 	payload := string(mustMarshal(request))
 
 	tflog.Info(ctx, "creating deployment", map[string]any{
-		"url":     url,
-		"payload": payload,
+		"url": url,
 	})
 	err = c.doRequest(clientRequest{
 		ctx:    ctx,

--- a/client/environment_variable.go
+++ b/client/environment_variable.go
@@ -37,8 +37,7 @@ func (c *Client) CreateEnvironmentVariable(ctx context.Context, request CreateEn
 	payload := string(mustMarshal(request.EnvironmentVariable))
 
 	tflog.Info(ctx, "creating environment variable", map[string]any{
-		"url":     url,
-		"payload": payload,
+		"url": url,
 	})
 	var response CreateEnvironmentVariableResponse
 	err = c.doRequest(clientRequest{
@@ -98,7 +97,7 @@ func (c *Client) CreateEnvironmentVariable(ctx context.Context, request CreateEn
 				return e, fmt.Errorf("failed to create environment variable, %s", msg)
 			}
 		}
-		return e, fmt.Errorf("%w - %s", err, payload)
+		return e, err
 	}
 	response.Created.Value = request.EnvironmentVariable.Value
 	response.Created.TeamID = c.TeamID(request.TeamID)
@@ -258,7 +257,7 @@ func (c *Client) CreateEnvironmentVariables(ctx context.Context, request CreateE
 				return nil, fmt.Errorf("failed to create environment variables, %s", strings.Join(uniq, "; "))
 			}
 		}
-		return nil, fmt.Errorf("%w - %s", err, payload)
+		return nil, err
 	}
 
 	decrypted := false
@@ -327,8 +326,7 @@ func (c *Client) UpdateEnvironmentVariable(ctx context.Context, request UpdateEn
 	}
 	payload := string(mustMarshal(request))
 	tflog.Info(ctx, "updating environment variable", map[string]any{
-		"url":     url,
-		"payload": payload,
+		"url": url,
 	})
 	err = c.doRequest(clientRequest{
 		ctx:    ctx,

--- a/client/project.go
+++ b/client/project.go
@@ -74,8 +74,7 @@ func (c *Client) CreateProject(ctx context.Context, teamID string, request Creat
 
 	payload := string(mustMarshal(request))
 	tflog.Info(ctx, "creating project", map[string]any{
-		"url":     url,
-		"payload": payload,
+		"url": url,
 	})
 	err = c.doRequest(clientRequest{
 		ctx:    ctx,
@@ -388,8 +387,7 @@ func (c *Client) UpdateProject(ctx context.Context, projectID, teamID string, re
 	}
 	payload := string(mustMarshal(request))
 	tflog.Info(ctx, "updating project", map[string]any{
-		"url":     url,
-		"payload": payload,
+		"url": url,
 	})
 	err = c.doRequest(clientRequest{
 		ctx:    ctx,

--- a/client/shared_environment_variable.go
+++ b/client/shared_environment_variable.go
@@ -68,8 +68,7 @@ func (c *Client) CreateSharedEnvironmentVariable(ctx context.Context, request Cr
 	}
 	payload := string(mustMarshal(request.EnvironmentVariable))
 	tflog.Info(ctx, "creating shared environment variable", map[string]any{
-		"url":     url,
-		"payload": payload,
+		"url": url,
 	})
 	var response struct {
 		Created []SharedEnvironmentVariableResponse `json:"created"`
@@ -196,8 +195,7 @@ func (c *Client) UpdateSharedEnvironmentVariable(ctx context.Context, request Up
 	}))
 
 	tflog.Info(ctx, "updating shared environment variable", map[string]any{
-		"url":     url,
-		"payload": payload,
+		"url": url,
 	})
 	var response struct {
 		Updated []SharedEnvironmentVariableResponse `json:"updated"`


### PR DESCRIPTION
Stops logging secret request payloads and avoids echoing secret values back through client errors.