### PR TITLE
fix microfrontend membership state handling

### DIFF
--- a/client/microfrontend_group_membership.go
+++ b/client/microfrontend_group_membership.go
@@ -46,7 +46,15 @@ func (c *Client) GetMicrofrontendGroupMembership(ctx context.Context, TeamID str
 		"project_id": ProjectID,
 		"group":      group,
 	})
-	return group.Projects[ProjectID], nil
+	membership, ok := group.Projects[ProjectID]
+	if !ok {
+		return r, APIError{
+			Code:       "not_found",
+			Message:    "Microfrontend group membership not found",
+			StatusCode: 404,
+		}
+	}
+	return membership, nil
 }
 
 func (c *Client) AddOrUpdateMicrofrontendGroupMembership(ctx context.Context, request MicrofrontendGroupMembership) (r MicrofrontendGroupMembership, err error) {

--- a/client/microfrontend_group_membership_unit_test.go
+++ b/client/microfrontend_group_membership_unit_test.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetMicrofrontendGroupMembershipReturnsNotFoundWhenProjectMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		fmt.Fprintln(w, `{"groups":[{"group":{"id":"group_123","name":"Group","slug":"group","team_id":"team_123","projects":{}},"projects":[{"id":"prj_other","microfrontends":{"groupIds":["group_123"],"enabled":true,"isDefaultApp":false,"routeObservabilityToThisProject":false}}]}]}`)
+	}))
+	t.Cleanup(server.Close)
+
+	cl := New("INVALID")
+	cl.baseURL = server.URL
+	_, err := cl.GetMicrofrontendGroupMembership(context.Background(), "team_123", "group_123", "prj_123")
+	if !NotFound(err) {
+		t.Fatalf("GetMicrofrontendGroupMembership() error = %v, want NotFound", err)
+	}
+}

--- a/vercel/data_source_microfrontend_group_membership.go
+++ b/vercel/data_source_microfrontend_group_membership.go
@@ -97,7 +97,13 @@ func (d *microfrontendGroupMembershipDataSource) Read(ctx context.Context, req d
 		config.ProjectID.ValueString(),
 	)
 	if client.NotFound(err) {
-		resp.State.RemoveResource(ctx)
+		resp.Diagnostics.AddError(
+			"Microfrontend group membership not found",
+			fmt.Sprintf("Could not find microfrontend group membership for project %s in group %s",
+				config.ProjectID.ValueString(),
+				config.MicrofrontendGroupID.ValueString(),
+			),
+		)
 		return
 	}
 	if err != nil {

--- a/vercel/data_source_microfrontend_group_test.go
+++ b/vercel/data_source_microfrontend_group_test.go
@@ -35,6 +35,8 @@ func TestAcc_MicrofrontendGroupDataSource(t *testing.T) {
 						id = vercel_microfrontend_group.test_group.id
 					}
 					data "vercel_microfrontend_group_membership" "test_child" {
+						depends_on = [vercel_microfrontend_group_membership.test_child]
+
 						microfrontend_group_id = vercel_microfrontend_group.test_group.id
 						project_id = vercel_project.test_project_2.id
 					}


### PR DESCRIPTION
Fixes microfrontend membership reads so a missing project membership is treated as not found instead of returning an empty state object.