### PR TITLE
Canonicalize project function regions

### DIFF
--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -1691,28 +1691,7 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 		})
 	}
 
-	resourceConfig := types.ObjectNull(resourceConfigAttrType.AttrTypes)
-	if response.ResourceConfig != nil {
-		var functionDefaultRegions attr.Value
-		regions := make([]attr.Value, 0, len(response.ResourceConfig.FunctionDefaultRegions))
-		for _, region := range response.ResourceConfig.FunctionDefaultRegions {
-			regions = append(regions, types.StringValue(region))
-		}
-		functionDefaultRegions = types.SetValueMust(types.StringType, regions)
-
-		resourceConfig = types.ObjectValueMust(resourceConfigAttrType.AttrTypes, map[string]attr.Value{
-			"function_default_cpu_type": types.StringPointerValue(response.ResourceConfig.FunctionDefaultMemoryType),
-			"function_default_timeout":  types.Int64PointerValue(response.ResourceConfig.FunctionDefaultTimeout),
-			"function_default_regions":  functionDefaultRegions,
-			"fluid":                     types.BoolValue(response.ResourceConfig.Fluid),
-		})
-	}
-	onDemandConcurrentBuilds := types.BoolNull()
-	buildMachineType := types.StringNull()
-	if response.ResourceConfig != nil {
-		onDemandConcurrentBuilds = types.BoolValue(response.ResourceConfig.ElasticConcurrencyEnabled)
-		buildMachineType = types.StringValue(response.ResourceConfig.BuildMachineType)
-	}
+	resourceConfig := projectResourceConfigFromResponse(response)
 
 	// Options allowlist
 	oalObj := types.ObjectNull(optionsAllowlistAttrType.AttrTypes)
@@ -1831,6 +1810,18 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 		})
 	}
 
+	serverlessFunctionRegion := types.StringNull()
+	if !plan.ServerlessFunctionRegion.IsNull() && !plan.ServerlessFunctionRegion.IsUnknown() {
+		serverlessFunctionRegion = types.StringPointerValue(response.ServerlessFunctionRegion)
+	}
+
+	onDemandConcurrentBuilds := types.BoolNull()
+	buildMachineType := types.StringNull()
+	if response.ResourceConfig != nil {
+		onDemandConcurrentBuilds = types.BoolValue(response.ResourceConfig.ElasticConcurrencyEnabled)
+		buildMachineType = types.StringValue(response.ResourceConfig.BuildMachineType)
+	}
+
 	return Project{
 		BuildCommand:                      uncoerceString(fields.BuildCommand, types.StringPointerValue(response.BuildCommand)),
 		DevCommand:                        uncoerceString(fields.DevCommand, types.StringPointerValue(response.DevCommand)),
@@ -1845,7 +1836,7 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 		PreviewDeploymentSuffix:           types.StringPointerValue(response.PreviewDeploymentSuffix),
 		PublicSource:                      uncoerceBool(fields.PublicSource, types.BoolPointerValue(response.PublicSource)),
 		RootDirectory:                     types.StringPointerValue(response.RootDirectory),
-		ServerlessFunctionRegion:          types.StringPointerValue(response.ServerlessFunctionRegion),
+		ServerlessFunctionRegion:          serverlessFunctionRegion,
 		TeamID:                            toTeamID(response.TeamID),
 		PasswordProtection:                passwordObj,
 		VercelAuthentication:              va,
@@ -1873,6 +1864,44 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 		OnDemandConcurrentBuilds:          onDemandConcurrentBuilds,
 		BuildMachineType:                  buildMachineType,
 	}, nil
+}
+
+func projectResourceConfigFromResponse(response client.ProjectResponse) types.Object {
+	regions := responseFunctionDefaultRegions(response)
+	if response.ResourceConfig == nil && len(regions) == 0 {
+		return types.ObjectNull(resourceConfigAttrType.AttrTypes)
+	}
+
+	regionValues := make([]attr.Value, 0, len(regions))
+	for _, region := range regions {
+		regionValues = append(regionValues, types.StringValue(region))
+	}
+
+	functionDefaultCPUType := types.StringNull()
+	functionDefaultTimeout := types.Int64Null()
+	fluid := types.BoolNull()
+	if response.ResourceConfig != nil {
+		functionDefaultCPUType = types.StringPointerValue(response.ResourceConfig.FunctionDefaultMemoryType)
+		functionDefaultTimeout = types.Int64PointerValue(response.ResourceConfig.FunctionDefaultTimeout)
+		fluid = types.BoolValue(response.ResourceConfig.Fluid)
+	}
+
+	return types.ObjectValueMust(resourceConfigAttrType.AttrTypes, map[string]attr.Value{
+		"function_default_cpu_type": functionDefaultCPUType,
+		"function_default_timeout":  functionDefaultTimeout,
+		"function_default_regions":  types.SetValueMust(types.StringType, regionValues),
+		"fluid":                     fluid,
+	})
+}
+
+func responseFunctionDefaultRegions(response client.ProjectResponse) []string {
+	if response.ResourceConfig != nil && len(response.ResourceConfig.FunctionDefaultRegions) > 0 {
+		return response.ResourceConfig.FunctionDefaultRegions
+	}
+	if response.ServerlessFunctionRegion != nil && *response.ServerlessFunctionRegion != "" {
+		return []string{*response.ServerlessFunctionRegion}
+	}
+	return nil
 }
 
 func (r *projectResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {

--- a/vercel/resource_project_regions_unit_test.go
+++ b/vercel/resource_project_regions_unit_test.go
@@ -1,0 +1,94 @@
+package vercel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
+)
+
+func TestConvertResponseToProjectCanonicalizesLegacyServerlessRegion(t *testing.T) {
+	region := "sfo1"
+	result, err := convertResponseToProject(context.Background(), client.ProjectResponse{
+		ID:                       "prj_123",
+		Name:                     "example",
+		ServerlessFunctionRegion: &region,
+	}, nullProject, nil)
+	if err != nil {
+		t.Fatalf("convertResponseToProject() returned error: %v", err)
+	}
+
+	if !result.ServerlessFunctionRegion.IsNull() {
+		t.Fatalf("ServerlessFunctionRegion = %v, want null for unconfigured deprecated field", result.ServerlessFunctionRegion)
+	}
+
+	assertProjectFunctionDefaultRegions(t, result, []string{"sfo1"})
+}
+
+func TestConvertResponseToProjectPrefersResourceConfigRegions(t *testing.T) {
+	region := "sfo1"
+	result, err := convertResponseToProject(context.Background(), client.ProjectResponse{
+		ID:                       "prj_123",
+		Name:                     "example",
+		ServerlessFunctionRegion: &region,
+		ResourceConfig: &client.ResourceConfigResponse{
+			FunctionDefaultRegions: []string{"iad1", "fra1"},
+		},
+	}, nullProject, nil)
+	if err != nil {
+		t.Fatalf("convertResponseToProject() returned error: %v", err)
+	}
+
+	assertProjectFunctionDefaultRegions(t, result, []string{"iad1", "fra1"})
+}
+
+func TestConvertResponseToProjectPreservesConfiguredDeprecatedRegion(t *testing.T) {
+	region := "sfo1"
+	plan := nullProject
+	plan.ServerlessFunctionRegion = types.StringValue(region)
+
+	result, err := convertResponseToProject(context.Background(), client.ProjectResponse{
+		ID:                       "prj_123",
+		Name:                     "example",
+		ServerlessFunctionRegion: &region,
+	}, plan, nil)
+	if err != nil {
+		t.Fatalf("convertResponseToProject() returned error: %v", err)
+	}
+
+	if got := result.ServerlessFunctionRegion.ValueString(); got != region {
+		t.Fatalf("ServerlessFunctionRegion = %q, want %q", got, region)
+	}
+	assertProjectFunctionDefaultRegions(t, result, []string{"sfo1"})
+}
+
+func assertProjectFunctionDefaultRegions(t *testing.T, project Project, want []string) {
+	t.Helper()
+
+	resourceConfig, diags := project.resourceConfig(context.Background())
+	if diags.HasError() {
+		t.Fatalf("resourceConfig() returned diagnostics: %v", diags)
+	}
+	if resourceConfig == nil {
+		t.Fatal("resourceConfig() = nil, want populated resource config")
+	}
+
+	var got []string
+	diags = resourceConfig.FunctionDefaultRegions.ElementsAs(context.Background(), &got, false)
+	if diags.HasError() {
+		t.Fatalf("FunctionDefaultRegions.ElementsAs() returned diagnostics: %v", diags)
+	}
+	gotByRegion := make(map[string]struct{}, len(got))
+	for _, region := range got {
+		gotByRegion[region] = struct{}{}
+	}
+	if len(gotByRegion) != len(want) {
+		t.Fatalf("function_default_regions = %v, want %v", got, want)
+	}
+	for _, region := range want {
+		if _, ok := gotByRegion[region]; !ok {
+			t.Fatalf("function_default_regions = %v, want %v", got, want)
+		}
+	}
+}

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -58,7 +58,8 @@ func TestAcc_Project(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_project.test", "public_source", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "root_directory", "ui/src"),
 					resource.TestCheckResourceAttr("vercel_project.test", "ignore_command", "echo 'wat'"),
-					resource.TestCheckResourceAttr("vercel_project.test", "serverless_function_region", "syd1"),
+					resource.TestCheckResourceAttr("vercel_project.test", "resource_config.function_default_regions.#", "1"),
+					resource.TestCheckTypeSetElemAttr("vercel_project.test", "resource_config.function_default_regions.*", "syd1"),
 					resource.TestCheckResourceAttr("vercel_project.test", "automatically_expose_system_environment_variables", "true"),
 					resource.TestCheckTypeSetElemNestedAttrs("vercel_project.test", "environment.*", map[string]string{
 						"key":       "foo",
@@ -297,7 +298,6 @@ func TestAcc_ProjectFunctionDefaultRegions(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("vercel_project.test", "name", fmt.Sprintf("test-acc-regions-%s", projectSuffix)),
 					resource.TestCheckResourceAttr("vercel_project.test", "resource_config.function_default_regions.#", "2"),
-					resource.TestCheckResourceAttr("vercel_project.test", "serverless_function_region", "hkg1"),
 					resource.TestCheckTypeSetElemAttr("vercel_project.test", "resource_config.function_default_regions.*", "hkg1"),
 					resource.TestCheckTypeSetElemAttr("vercel_project.test", "resource_config.function_default_regions.*", "sin1"),
 					resource.TestCheckResourceAttr("vercel_project.test", "resource_config.function_default_cpu_type", "performance"),


### PR DESCRIPTION
Fixes project import/read for legacy function region state by canonicalizing API regions into resource_config.function_default_regions instead of repopulating the deprecated field.