### PR TITLE
Fix dev envs when sensitive policy is set

### DIFF
--- a/vercel/environment_variable_sensitivity.go
+++ b/vercel/environment_variable_sensitivity.go
@@ -26,7 +26,7 @@ func setIsUnset(ctx context.Context, set types.Set) (bool, diag.Diagnostics) {
 		return true, nil
 	}
 	if set.IsUnknown() {
-		return false, nil
+		return true, nil
 	}
 
 	var values []string

--- a/vercel/environment_variable_sensitivity_unit_test.go
+++ b/vercel/environment_variable_sensitivity_unit_test.go
@@ -45,9 +45,9 @@ func TestShouldValidateSensitiveEnvironmentVariablePolicy(t *testing.T) {
 			want:                         true,
 		},
 		{
-			name:                         "development only skips validation",
+			name:                         "development only with unknown custom environments skips validation",
 			target:                       stringSet("development"),
-			customEnvironmentIDs:         types.SetNull(types.StringType),
+			customEnvironmentIDs:         types.SetUnknown(types.StringType),
 			targetsAllCustomEnvironments: false,
 			explicitlyNonSensitive:       true,
 			id:                           types.StringNull(),


### PR DESCRIPTION
Sensitive policy means all env vars (except development only) must be
sensitive.

However, custom_environment_ids being Optional + Computed means they are
unknown at plan time, and thus the validatio thinks there could be env
vars that target non-dev environments that aren't sensitive... so it
falsely rejects valid plans.

Fix this by skipping validaiton on computed custom_environment_ids.
This means we could have invalid things pass the plan stage (e.g. if
custom_environment_ids is read from a different resource and thus
unknown). But this will just fail at apply time so it's okay.
