### PR TITLE
Fix team member delete state handling

### DIFF
--- a/vercel/resource_team_member.go
+++ b/vercel/resource_team_member.go
@@ -607,6 +607,7 @@ func (r *teamMemberResource) Delete(ctx context.Context, req resource.DeleteRequ
 			"Error removing Team Member",
 			"Could not remove Team Member, unexpected error: "+err.Error(),
 		)
+		return
 	}
 
 	resp.State.RemoveResource(ctx)


### PR DESCRIPTION
Fixes team member deletion so state is only removed after Vercel confirms the member was removed, or says it is already gone.

Previously we added a diagnostic for unexpected RemoveTeamMember errors, then still removed the resource from state. That could leave a team member managed in Vercel but forgotten by Terraform.