### PR TITLE
Stop project update after env var upsert failure

### DIFF
--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -2412,6 +2412,7 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 					err,
 				),
 			)
+			return
 		}
 		tflog.Info(ctx, "upserted environment variables", map[string]any{
 			"team_id":    plan.TeamID.ValueString(),


### PR DESCRIPTION
Fixes project updates so env var upsert failures stop the apply immediately.

Previously we added a diagnostic but kept going into the project update, git repo changes, deploy hook changes, and final state write. This could leave a partially-applied project update after the first API step had already failed.