### PR TITLE
Stop team member reads after errors

### DIFF
--- a/vercel/data_source_team_member.go
+++ b/vercel/data_source_team_member.go
@@ -148,6 +148,7 @@ func (d *teamMemberDataSource) Read(ctx context.Context, req datasource.ReadRequ
 			"Error reading Team Member",
 			"Could not read Team Member, unexpected error: "+err.Error(),
 		)
+		return
 	}
 	teamMember := convertResponseToTeamMember(response, TeamMember{
 		UserID:       config.UserID,

--- a/vercel/resource_team_member.go
+++ b/vercel/resource_team_member.go
@@ -487,6 +487,7 @@ func (r *teamMemberResource) Read(ctx context.Context, req resource.ReadRequest,
 			"Error reading Team Member",
 			"Could not read Team Member, unexpected error: "+err.Error(),
 		)
+		return
 	}
 	teamMember := convertResponseToTeamMember(response, state)
 	diags = resp.State.Set(ctx, teamMember)
@@ -575,6 +576,7 @@ func (r *teamMemberResource) Update(ctx context.Context, req resource.UpdateRequ
 			"Error reading Team Member",
 			"Could not read Team Member, unexpected error: "+err.Error(),
 		)
+		return
 	}
 	tflog.Info(ctx, "updated Team member", map[string]any{
 		"team_id": request.TeamID,
@@ -643,6 +645,7 @@ func (r *teamMemberResource) ImportState(ctx context.Context, req resource.Impor
 			"Error reading Team Member",
 			"Could not read Team Member, unexpected error: "+err.Error(),
 		)
+		return
 	}
 	teamMember := convertResponseToTeamMember(response, TeamMember{
 		TeamID: types.StringValue(teamID),


### PR DESCRIPTION
Fixes team member reads so failed reads do not continue into state conversion.

The resource read, update read-back, import, and data source read paths all added diagnostics but then kept going. This could write zero or stale team member state after reporting an API read error.