### PR TITLE
fix project update payload bools

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -360,19 +360,19 @@ type UpdateProjectRequest struct {
 	TrustedIps                           *TrustedIps                     `json:"trustedIps"`
 	OIDCTokenConfig                      *OIDCTokenConfig                `json:"oidcTokenConfig"`
 	OptionsAllowlist                     *OptionsAllowlist               `json:"optionsAllowlist"`
-	AutoExposeSystemEnvVars              bool                            `json:"autoExposeSystemEnvs"`
+	AutoExposeSystemEnvVars              *bool                           `json:"autoExposeSystemEnvs,omitempty"`
 	EnablePreviewFeedback                *bool                           `json:"enablePreviewFeedback"`
 	EnableProductionFeedback             *bool                           `json:"enableProductionFeedback"`
 	EnableAffectedProjectsDeployments    *bool                           `json:"enableAffectedProjectsDeployments,omitempty"`
-	PreviewDeploymentsDisabled           bool                            `json:"previewDeploymentsDisabled"`
-	AutoAssignCustomDomains              bool                            `json:"autoAssignCustomDomains"`
-	GitLFS                               bool                            `json:"gitLFS"`
-	ServerlessFunctionZeroConfigFailover bool                            `json:"serverlessFunctionZeroConfigFailover"`
-	CustomerSupportCodeVisibility        bool                            `json:"customerSupportCodeVisibility"`
-	GitForkProtection                    bool                            `json:"gitForkProtection"`
-	ProductionDeploymentsFastLane        bool                            `json:"productionDeploymentsFastLane"`
-	DirectoryListing                     bool                            `json:"directoryListing"`
-	SkewProtectionMaxAge                 int                             `json:"skewProtectionMaxAge"`
+	PreviewDeploymentsDisabled           *bool                           `json:"previewDeploymentsDisabled,omitempty"`
+	AutoAssignCustomDomains              *bool                           `json:"autoAssignCustomDomains,omitempty"`
+	GitLFS                               *bool                           `json:"gitLFS,omitempty"`
+	ServerlessFunctionZeroConfigFailover *bool                           `json:"serverlessFunctionZeroConfigFailover,omitempty"`
+	CustomerSupportCodeVisibility        *bool                           `json:"customerSupportCodeVisibility,omitempty"`
+	GitForkProtection                    *bool                           `json:"gitForkProtection,omitempty"`
+	ProductionDeploymentsFastLane        *bool                           `json:"productionDeploymentsFastLane,omitempty"`
+	DirectoryListing                     *bool                           `json:"directoryListing,omitempty"`
+	SkewProtectionMaxAge                 *int                            `json:"skewProtectionMaxAge,omitempty"`
 	GitComments                          *GitComments                    `json:"gitComments"`
 	GitProviderOptions                   *GitProviderOptions             `json:"gitProviderOptions,omitempty"`
 	ResourceConfig                       *ResourceConfig                 `json:"resourceConfig,omitempty"`

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -955,6 +955,14 @@ func toSkewProtectionAge(sp types.String) int {
 	return v
 }
 
+func toSkewProtectionAgePointer(sp types.String) *int {
+	if sp.IsNull() || sp.IsUnknown() {
+		return nil
+	}
+	v := toSkewProtectionAge(sp)
+	return &v
+}
+
 func oneBoolPointer(a, b types.Bool) *bool {
 	if !a.IsNull() && !a.IsUnknown() {
 		return a.ValueBoolPointer()
@@ -967,6 +975,13 @@ func oneBoolPointer(a, b types.Bool) *bool {
 
 func knownBool(v types.Bool) bool {
 	return !v.IsNull() && !v.IsUnknown()
+}
+
+func knownBoolPointer(v types.Bool) *bool {
+	if !knownBool(v) {
+		return nil
+	}
+	return v.ValueBoolPointer()
 }
 
 func knownString(v types.String) bool {
@@ -1028,19 +1043,19 @@ func (p *Project) toUpdateProjectRequest(ctx context.Context, oldName string) (r
 		TrustedIps:                           ti.toUpdateProjectRequest(),
 		OIDCTokenConfig:                      oidc.toUpdateProjectRequest(),
 		OptionsAllowlist:                     oal.toUpdateProjectRequest(),
-		AutoExposeSystemEnvVars:              p.AutoExposeSystemEnvVars.ValueBool(),
+		AutoExposeSystemEnvVars:              knownBoolPointer(p.AutoExposeSystemEnvVars),
 		EnablePreviewFeedback:                oneBoolPointer(p.EnablePreviewFeedback, p.PreviewComments),
 		EnableProductionFeedback:             p.EnableProductionFeedback.ValueBoolPointer(),
 		EnableAffectedProjectsDeployments:    p.EnableAffectedProjectsDeployments.ValueBoolPointer(),
-		PreviewDeploymentsDisabled:           p.PreviewDeploymentsDisabled.ValueBool(),
-		AutoAssignCustomDomains:              p.AutoAssignCustomDomains.ValueBool(),
-		GitLFS:                               p.GitLFS.ValueBool(),
-		ServerlessFunctionZeroConfigFailover: p.FunctionFailover.ValueBool(),
-		CustomerSupportCodeVisibility:        p.CustomerSuccessCodeVisibility.ValueBool(),
-		GitForkProtection:                    p.GitForkProtection.ValueBool(),
-		ProductionDeploymentsFastLane:        p.PrioritiseProductionBuilds.ValueBool(),
-		DirectoryListing:                     p.DirectoryListing.ValueBool(),
-		SkewProtectionMaxAge:                 toSkewProtectionAge(p.SkewProtection),
+		PreviewDeploymentsDisabled:           knownBoolPointer(p.PreviewDeploymentsDisabled),
+		AutoAssignCustomDomains:              knownBoolPointer(p.AutoAssignCustomDomains),
+		GitLFS:                               knownBoolPointer(p.GitLFS),
+		ServerlessFunctionZeroConfigFailover: knownBoolPointer(p.FunctionFailover),
+		CustomerSupportCodeVisibility:        knownBoolPointer(p.CustomerSuccessCodeVisibility),
+		GitForkProtection:                    knownBoolPointer(p.GitForkProtection),
+		ProductionDeploymentsFastLane:        knownBoolPointer(p.PrioritiseProductionBuilds),
+		DirectoryListing:                     knownBoolPointer(p.DirectoryListing),
+		SkewProtectionMaxAge:                 toSkewProtectionAgePointer(p.SkewProtection),
 		GitComments:                          gc.toUpdateProjectRequest(),
 		GitProviderOptions:                   gpoReq,
 		ResourceConfig:                       resourceConfig.toClientResourceConfig(ctx, p.OnDemandConcurrentBuilds, p.BuildMachineType, p.ServerlessFunctionRegion),

--- a/vercel/resource_project_unit_test.go
+++ b/vercel/resource_project_unit_test.go
@@ -1,6 +1,8 @@
 package vercel
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -19,6 +21,66 @@ func TestProjectRequiresUpdateAfterCreationOnlyForConfiguredFields(t *testing.T)
 	})
 	if !project.RequiresUpdateAfterCreation() {
 		t.Fatal("RequiresUpdateAfterCreation() = false, want true for configured git_comments")
+	}
+}
+
+func TestProjectUpdateRequestOmitsUnknownPostCreateFields(t *testing.T) {
+	project := projectForUpdateRequestTests()
+
+	req, diags := project.toUpdateProjectRequest(context.Background(), project.Name.ValueString())
+	if diags.HasError() {
+		t.Fatalf("toUpdateProjectRequest() returned diagnostics: %v", diags)
+	}
+
+	payload := map[string]any{}
+	b, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if err := json.Unmarshal(b, &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	for _, field := range []string{
+		"autoExposeSystemEnvs",
+		"previewDeploymentsDisabled",
+		"gitLFS",
+		"serverlessFunctionZeroConfigFailover",
+		"customerSupportCodeVisibility",
+		"productionDeploymentsFastLane",
+		"directoryListing",
+		"skewProtectionMaxAge",
+	} {
+		if _, ok := payload[field]; ok {
+			t.Fatalf("field %q was included for an unknown/unset value: %s", field, b)
+		}
+	}
+}
+
+func TestProjectUpdateRequestSendsKnownFalsePostCreateFields(t *testing.T) {
+	project := projectForUpdateRequestTests()
+	project.GitLFS = types.BoolValue(false)
+
+	req, diags := project.toUpdateProjectRequest(context.Background(), project.Name.ValueString())
+	if diags.HasError() {
+		t.Fatalf("toUpdateProjectRequest() returned diagnostics: %v", diags)
+	}
+
+	payload := map[string]any{}
+	b, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if err := json.Unmarshal(b, &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	got, ok := payload["gitLFS"].(bool)
+	if !ok {
+		t.Fatalf("gitLFS was not included as a bool: %s", b)
+	}
+	if got {
+		t.Fatalf("gitLFS = true, want false")
 	}
 }
 


### PR DESCRIPTION
Fixes project updates so unknown Optional + Computed values are omitted from the PATCH payload instead of being sent as false.

Explicit false values still get sent, which means configured fields continue to work while post-create updates no longer clobber defaults for unrelated project settings.