### PR TITLE
fix not found state removal

### DIFF
--- a/vercel/resource_custom_environment.go
+++ b/vercel/resource_custom_environment.go
@@ -268,6 +268,7 @@ func (r *customEnvironmentResource) Read(ctx context.Context, req resource.ReadR
 	})
 	if client.NotFound(err) {
 		resp.State.RemoveResource(ctx)
+		return
 	}
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -334,6 +335,7 @@ func (r *customEnvironmentResource) Delete(ctx context.Context, req resource.Del
 	})
 	if client.NotFound(err) {
 		resp.State.RemoveResource(ctx)
+		return
 	}
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/vercel/resource_project_members.go
+++ b/vercel/resource_project_members.go
@@ -220,6 +220,7 @@ func (r *projectMembersResource) Create(ctx context.Context, req resource.Create
 	})
 	if client.NotFound(err) {
 		resp.State.RemoveResource(ctx)
+		return
 	}
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -317,6 +318,7 @@ func (r *projectMembersResource) Read(ctx context.Context, req resource.ReadRequ
 	})
 	if client.NotFound(err) {
 		resp.State.RemoveResource(ctx)
+		return
 	}
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -530,6 +532,7 @@ func (r *projectMembersResource) Delete(ctx context.Context, req resource.Delete
 	})
 	if client.NotFound(err) {
 		resp.State.RemoveResource(ctx)
+		return
 	}
 	if err != nil {
 		resp.Diagnostics.AddError(


### PR DESCRIPTION
Fixes resources that removed state on 404 but then kept going into the generic error path.

Custom environments and project members now return immediately after treating a missing remote object as gone.