### PR TITLE
fix shared env update payloads

### DIFF
--- a/client/shared_environment_variable.go
+++ b/client/shared_environment_variable.go
@@ -170,13 +170,13 @@ type UpdateSharedEnvironmentVariableRequestProjectIDUpdates struct {
 }
 
 type UpdateSharedEnvironmentVariableRequest struct {
-	Value                        string                                                 `json:"value,omitempty"`
-	Type                         string                                                 `json:"type,omitempty"`
-	ProjectIDs                   []string                                               `json:"projectId,omitempty"`
+	Value                        string                                                 `json:"value"`
+	Type                         string                                                 `json:"type"`
+	ProjectIDs                   []string                                               `json:"projectId"`
 	ProjectIDUpdates             UpdateSharedEnvironmentVariableRequestProjectIDUpdates `json:"projectIdUpdates,omitempty"`
-	ApplyToAllCustomEnvironments bool                                                   `json:"applyToAllCustomEnvironments,omitempty"`
-	Target                       []string                                               `json:"target,omitempty"`
-	Comment                      string                                                 `json:"comment,omitempty"`
+	ApplyToAllCustomEnvironments bool                                                   `json:"applyToAllCustomEnvironments"`
+	Target                       []string                                               `json:"target"`
+	Comment                      string                                                 `json:"comment"`
 	TeamID                       string                                                 `json:"-"`
 	EnvID                        string                                                 `json:"-"`
 }

--- a/client/shared_environment_variable_test.go
+++ b/client/shared_environment_variable_test.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestUpdateSharedEnvironmentVariableRequestIncludesEmptyValues(t *testing.T) {
+	payload := string(mustMarshal(struct {
+		Updates map[string]UpdateSharedEnvironmentVariableRequest `json:"updates"`
+	}{
+		Updates: map[string]UpdateSharedEnvironmentVariableRequest{
+			"env_123": {
+				Value:                        "",
+				Type:                         "encrypted",
+				ProjectIDs:                   []string{},
+				ApplyToAllCustomEnvironments: false,
+				Target:                       []string{},
+				Comment:                      "",
+			},
+		},
+	}))
+
+	var out struct {
+		Updates map[string]map[string]any `json:"updates"`
+	}
+	if err := json.Unmarshal([]byte(payload), &out); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	update := out.Updates["env_123"]
+	for _, field := range []string{"value", "projectId", "applyToAllCustomEnvironments", "target", "comment"} {
+		if _, ok := update[field]; !ok {
+			t.Fatalf("field %q was omitted from payload %s", field, payload)
+		}
+	}
+}


### PR DESCRIPTION
Fixes shared environment variable updates so false and empty values are still included in the PATCH payload.

This lets updates clear comments, clear targets, send an empty value, and set apply_to_all_custom_environments back to false.