### PR TITLE
fix microfrontend route observability updates

### DIFF
--- a/client/microfrontend_group_membership.go
+++ b/client/microfrontend_group_membership.go
@@ -11,7 +11,7 @@ type MicrofrontendGroupMembership struct {
 	MicrofrontendGroupID            string `json:"microfrontendsGroupId"`
 	IsDefaultApp                    bool   `json:"isDefaultApp,omitempty"`
 	DefaultRoute                    string `json:"defaultRoute,omitempty"`
-	RouteObservabilityToThisProject bool   `json:"routeObservabilityToThisProject,omitempty"`
+	RouteObservabilityToThisProject bool   `json:"routeObservabilityToThisProject"`
 	ProjectID                       string `json:"projectId"`
 	Enabled                         bool   `json:"enabled"`
 	TeamID                          string `json:"team_id"`

--- a/client/microfrontend_group_membership_unit_test.go
+++ b/client/microfrontend_group_membership_unit_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -22,5 +23,39 @@ func TestGetMicrofrontendGroupMembershipReturnsNotFoundWhenProjectMissing(t *tes
 	_, err := cl.GetMicrofrontendGroupMembership(context.Background(), "team_123", "group_123", "prj_123")
 	if !NotFound(err) {
 		t.Fatalf("GetMicrofrontendGroupMembership() error = %v, want NotFound", err)
+	}
+}
+
+func TestPatchMicrofrontendGroupMembershipSendsFalseRouteObservability(t *testing.T) {
+	var payload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method = %s, want PATCH", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		fmt.Fprintln(w, `{"microfrontends":{"enabled":true,"isDefaultApp":false,"routeObservabilityToThisProject":false}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	cl := New("INVALID")
+	cl.baseURL = server.URL
+	_, err := cl.PatchMicrofrontendGroupMembership(context.Background(), MicrofrontendGroupMembership{
+		ProjectID:                       "prj_123",
+		MicrofrontendGroupID:            "mfe_123",
+		Enabled:                         true,
+		RouteObservabilityToThisProject: false,
+	})
+	if err != nil {
+		t.Fatalf("PatchMicrofrontendGroupMembership() error = %v", err)
+	}
+
+	got, ok := payload["routeObservabilityToThisProject"].(bool)
+	if !ok {
+		t.Fatalf("routeObservabilityToThisProject was not included as a bool: %#v", payload)
+	}
+	if got {
+		t.Fatalf("routeObservabilityToThisProject = true, want false")
 	}
 }


### PR DESCRIPTION
Fixes microfrontend group membership updates so route_observability_to_this_project = false is sent to the API.

The client request used omitempty on the API bool, which meant false looked the same as unset in the PATCH payload.