### PR TITLE
ignore missing env vars on delete

### DIFF
--- a/vercel/resource_project_environment_variables.go
+++ b/vercel/resource_project_environment_variables.go
@@ -794,6 +794,9 @@ func (r *projectEnvironmentVariablesResource) Delete(ctx context.Context, req re
 	}
 	for _, v := range envs {
 		err := r.client.DeleteEnvironmentVariable(ctx, state.ProjectID.ValueString(), state.TeamID.ValueString(), v.ID.ValueString())
+		if client.NotFound(err) {
+			continue
+		}
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error updating Project Environment Variables",


### PR DESCRIPTION
Fixes vercel_project_environment_variables deletion when one of the managed env vars has already been removed outside Terraform.

The aggregate resource now treats a not-found response the same way as vercel_project_environment_variable: the item is already gone, so delete can continue.