### PR TITLE
fix api token validation

### DIFF
--- a/vercel/provider.go
+++ b/vercel/provider.go
@@ -146,7 +146,7 @@ type providerData struct {
 
 // apiTokenRe is a regex for an API access token. We use this to validate that the
 // token provided matches the expected format.
-var apiTokenRe = regexp.MustCompile("[0-9a-zA-Z]{24}")
+var apiTokenRe = regexp.MustCompile("^[0-9a-zA-Z]{24}$")
 
 // Configure takes a provider and applies any configuration. In the context of Vercel
 // this allows us to set up an API token.
@@ -185,7 +185,7 @@ func (p *vercelProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	if !apiTokenRe.MatchString(apiToken) {
 		resp.Diagnostics.AddError(
 			"Invalid api_token",
-			"api_token (VERCEL_API_TOKEN) must be 24 characters and only contain characters 0-9 and a-f (all lowercased)",
+			"api_token (VERCEL_API_TOKEN) must be 24 alphanumeric characters",
 		)
 		return
 	}

--- a/vercel/provider_unit_test.go
+++ b/vercel/provider_unit_test.go
@@ -1,0 +1,33 @@
+package vercel
+
+import "testing"
+
+func TestAPITokenRegexMatchesWholeToken(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		token string
+		want  bool
+	}{
+		{
+			name:  "valid token",
+			token: "abcDEF123456abcDEF123456",
+			want:  true,
+		},
+		{
+			name:  "too long with valid substring",
+			token: "abcDEF123456abcDEF123456!",
+			want:  false,
+		},
+		{
+			name:  "invalid character",
+			token: "abcDEF123456abcDEF12345!",
+			want:  false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := apiTokenRe.MatchString(tt.token); got != tt.want {
+				t.Fatalf("apiTokenRe.MatchString(%q) = %t, want %t", tt.token, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes provider API token validation so the regex has to match the whole token.

The validation message now matches the accepted format, and longer strings with a valid 24-character substring no longer pass.