### PR TITLE
fix rate limit retry default

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -155,7 +155,7 @@ func (c *Client) _doRequest(req *http.Request, v any, errorOnNoContent bool) err
 		}
 		errorResponse.StatusCode = resp.StatusCode
 		errorResponse.RawMessage = responseBody
-		errorResponse.retryAfter = 1000 // set a sensible default for retrying. This is in milliseconds.
+		errorResponse.retryAfter = 1 // set a sensible default for retrying. This is in seconds.
 		if resp.StatusCode == 429 {
 			retryAfterRaw := resp.Header.Get("Retry-After")
 			if retryAfterRaw != "" {

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDoRequestDefaultsRetryAfterToSeconds(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		fmt.Fprintln(w, `{"error":{"code":"rate_limited","message":"slow down"}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+
+	err = New("INVALID")._doRequest(req, nil, false)
+	var apiErr APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("_doRequest() error = %v, want APIError", err)
+	}
+	if apiErr.retryAfter != 1 {
+		t.Fatalf("retryAfter = %d, want 1", apiErr.retryAfter)
+	}
+}


### PR DESCRIPTION
Fixes the default Retry-After value for 429 responses without a header.

The retry loop treats retryAfter as seconds, so the default is now one second instead of 1000, which was larger than the five-minute retry guard.