### PR TITLE
return after project lookup errors

### DIFF
--- a/vercel/resource_attack_challenge_mode.go
+++ b/vercel/resource_attack_challenge_mode.go
@@ -127,6 +127,13 @@ func (r *attackChallengeModeResource) Create(ctx context.Context, req resource.C
 		)
 		return
 	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating Attack Challenge Mode",
+			"Error reading project information, unexpected error: "+err.Error(),
+		)
+		return
+	}
 	out, err := r.client.UpdateAttackChallengeMode(ctx, client.AttackChallengeMode{
 		TeamID:                plan.TeamID.ValueString(),
 		ProjectID:             plan.ProjectID.ValueString(),

--- a/vercel/resource_project_environment_variable.go
+++ b/vercel/resource_project_environment_variable.go
@@ -414,6 +414,13 @@ func (r *projectEnvironmentVariableResource) Create(ctx context.Context, req res
 		)
 		return
 	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating project environment variable",
+			"Error reading project information, unexpected error: "+err.Error(),
+		)
+		return
+	}
 
 	request, diags := plan.toCreateEnvironmentVariableRequest(ctx, config.ValueWO)
 	if diags.HasError() {

--- a/vercel/resource_project_environment_variables.go
+++ b/vercel/resource_project_environment_variables.go
@@ -438,6 +438,13 @@ func (r *projectEnvironmentVariablesResource) Create(ctx context.Context, req re
 		)
 		return
 	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating project environment variables",
+			"Error reading project information, unexpected error: "+err.Error(),
+		)
+		return
+	}
 
 	envs, diags := plan.environment(ctx)
 	if diags.HasError() {


### PR DESCRIPTION
Fixes create paths that validated project existence but only stopped for not-found errors.

Unexpected GetProject errors now return a diagnostic instead of continuing into the resource-specific create call.