### PR TITLE
Add "4 hours" to skew_protection allowed values

### DIFF
--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -566,7 +566,7 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				Optional:    true,
 				Description: "Ensures that outdated clients always fetch the correct version for a given deployment. This value defines how long Vercel keeps Skew Protection active.",
 				Validators: []validator.String{
-					stringvalidator.OneOf("30 minutes", "12 hours", "1 day", "7 days"),
+					stringvalidator.OneOf("30 minutes", "4 hours", "12 hours", "1 day", "7 days"),
 				},
 			},
 			"resource_config": schema.SingleNestedAttribute{
@@ -943,6 +943,7 @@ func toSkewProtectionAge(sp types.String) int {
 	}
 	var ages = map[string]int{
 		"30 minutes": 1800,
+		"4 hours":    14400,
 		"12 hours":   43200,
 		"1 day":      86400,
 		"7 days":     604800,
@@ -1586,6 +1587,7 @@ func fromSkewProtectionMaxAge(sp int) types.String {
 	}
 	var ages = map[int]string{
 		1800:   "30 minutes",
+		14400:  "4 hours",
 		43200:  "12 hours",
 		86400:  "1 day",
 		604800: "7 days",


### PR DESCRIPTION
## Summary

Adds `"4 hours"` as an accepted value for the `skew_protection` attribute on the `vercel_project` resource.

## Context

The Vercel product supports skew protection as a flexible Maximum Age, configurable up to the project's deployment retention limit ([docs](https://vercel.com/docs/skew-protection)). The provider's `OneOf` validator currently only accepts `"30 minutes"`, `"12 hours"`, `"1 day"`, and `"7 days"` — a small subset of what the API supports. As you can see below, the UI's dropdown for this does not match the Terraform provider validator:

<img width="937" height="716" alt="image" src="https://github.com/user-attachments/assets/8a1f1c09-11ba-41ad-b357-7c17d111593f" />

`"4 hours"` is a useful intermediate value for cases where a 12-hour window is too long but 30 minutes is too short. This change is intentionally minimal — only the single new value is added — to keep the surface area small and merge-able. Happy to expand this to support arbitrary durations (or a broader set of fixed values) if the maintainers prefer; just let me know.

## Files changed

- `vercel/resource_project.go`
  - `stringvalidator.OneOf(...)` for `skew_protection`
  - `toSkewProtectionAge` map (`"4 hours"` → `14400` seconds)
  - `fromSkewProtectionMaxAge` map (`14400` → `"4 hours"`)

The `vercel_project` data source attribute is `Computed`-only with no validator, so no change is needed there. Docs (`docs/resources/project.md`, `docs/data-sources/project.md`) describe the attribute generically and don't enumerate the allowed values, so they don't need an update either.

## Verification

- `go vet ./...` — clean
- `go test -run 'Test[^A][^c][^c]' ./...` (all non-acceptance unit tests) — pass
- I haven't run the `TestAcc_*` acceptance tests since they require Vercel API credentials (`VERCEL_TERRAFORM_TESTING_TEAM` etc.). Happy to coordinate with a maintainer if a live-API run is desired.