### PR TITLE
fix: allow "standard" in build_machine_type validator

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -61,7 +61,7 @@ resource "vercel_project" "example" {
 - `auto_assign_custom_domains` (Boolean) Automatically assign custom production domains after each Production deployment via merge to the production branch or Vercel CLI deploy with --prod. Defaults to `true`
 - `automatically_expose_system_environment_variables` (Boolean) Vercel provides a set of Environment Variables that are automatically populated by the System, such as the URL of the Deployment or the name of the Git branch deployed. To expose them to your Deployments, enable this field
 - `build_command` (String) The build command for this project. If omitted, this value will be automatically detected.
-- `build_machine_type` (String) The build machine type to use for this project. Must be one of "enhanced", "turbo", or "elastic". When set to "elastic", Vercel automatically adjusts the underlying machine type based on build duration.
+- `build_machine_type` (String) The build machine type to use for this project. Must be one of "standard", "enhanced", "turbo", or "elastic". When set to "elastic", Vercel automatically adjusts the underlying machine type based on build duration.
 - `customer_success_code_visibility` (Boolean) Allows Vercel Customer Support to inspect all Deployments' source code in this project to assist with debugging.
 - `dev_command` (String) The dev command for this project. If omitted, this value will be automatically detected.
 - `directory_listing` (Boolean) If no index file is present within a directory, the directory contents will be displayed.

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -624,11 +624,11 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()},
 			},
 			"build_machine_type": schema.StringAttribute{
-				Description: "The build machine type to use for this project. Must be one of \"enhanced\", \"turbo\", or \"elastic\". When set to \"elastic\", Vercel automatically adjusts the underlying machine type based on build duration.",
+				Description: "The build machine type to use for this project. Must be one of \"standard\", \"enhanced\", \"turbo\", or \"elastic\". When set to \"elastic\", Vercel automatically adjusts the underlying machine type based on build duration.",
 				Optional:    true,
 				Computed:    true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("enhanced", "turbo", "elastic"),
+					stringvalidator.OneOf("standard", "enhanced", "turbo", "elastic"),
 				},
 			},
 		},

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -447,6 +447,35 @@ func TestAcc_ProjectBuildMachineTypeUnsetUpdate(t *testing.T) {
 	})
 }
 
+// `standard` is a valid value at the API but was previously missing from
+// the provider's schema validator, so users on plans where `standard`
+// is the desired explicit type had no way to set it from Terraform —
+// leaving the attribute unset was the only workaround.
+func TestAcc_ProjectBuildMachineTypeStandard(t *testing.T) {
+	projectSuffix := acctest.RandString(16)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccProjectDestroy(testClient(t), "vercel_project.test", testTeam(t)),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(testAccProjectConfigWithBuildMachineType(projectSuffix, "standard")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectExists(testClient(t), "vercel_project.test", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_project.test", "build_machine_type", "standard"),
+				),
+			},
+			{
+				Config: cfg(testAccProjectConfigWithBuildMachineType(projectSuffix, "standard")),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAcc_ProjectBuildMachineTypeElastic(t *testing.T) {
 	projectSuffix := acctest.RandString(16)
 	resource.Test(t, resource.TestCase{

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -472,6 +472,51 @@ func TestAcc_ProjectBuildMachineTypeStandard(t *testing.T) {
 					},
 				},
 			},
+			// Round-trip standard ↔ turbo to confirm standard behaves like
+			// a first-class peer of the other concrete machine types.
+			{
+				Config: cfg(testAccProjectConfigWithBuildMachineType(projectSuffix, "turbo")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("vercel_project.test", "build_machine_type", "turbo"),
+				),
+			},
+			{
+				Config: cfg(testAccProjectConfigWithBuildMachineType(projectSuffix, "standard")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("vercel_project.test", "build_machine_type", "standard"),
+				),
+			},
+		},
+	})
+}
+
+// Regression test for https://github.com/vercel/terraform-provider-vercel/issues/513:
+// creating a project with `build_machine_type = "elastic"` (no prior
+// concrete type) used to fail at the API with `bad_request: Invalid
+// request: resourceConfig.buildMachineType should be equal to one of
+// the allowed values "enhanced, turbo, standard"`. This test pins down
+// the first-apply path so the regression cannot return silently.
+func TestAcc_ProjectBuildMachineTypeElasticOnCreate(t *testing.T) {
+	projectSuffix := acctest.RandString(16)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccProjectDestroy(testClient(t), "vercel_project.test", testTeam(t)),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(testAccProjectConfigWithBuildMachineType(projectSuffix, "elastic")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccProjectExists(testClient(t), "vercel_project.test", testTeam(t)),
+					resource.TestCheckResourceAttr("vercel_project.test", "build_machine_type", "elastic"),
+				),
+			},
+			{
+				Config: cfg(testAccProjectConfigWithBuildMachineType(projectSuffix, "elastic")),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Why

The API accepts `"standard"`, `"enhanced"`, `"turbo"`, and `"elastic"` for `resourceConfig.buildMachineType`, but the provider's `OneOf` validator only listed three of them. `"standard"` was rejected at plan time even though the API accepts it, so leaving the attribute unset was the only way to land on standard.

Closes #513.

## Notes

The provider sends `"elastic"` through `buildMachineType`; the API treats that as the elastic-mode trigger and writes `buildMachineSelection: "elastic"` itself. `"standard"` is just one of the concrete fixed types.

There is a related API bug: `POST /v10/projects` rejects `buildMachineType: "elastic"` because the create schema uses the storage enum (`standard | enhanced | turbo`) rather than the input enum that update-project already uses. That fix lives in a separate PR in `vercel/api`.