### PR TITLE
fix: change tflog.Error to tflog.Info for successful project creation

### DIFF
--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -2451,7 +2451,7 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 		)
 		return
 	}
-	tflog.Error(ctx, "created project", map[string]any{
+	tflog.Info(ctx, "created project", map[string]any{
 		"team_id":    result.TeamID.ValueString(),
 		"project_id": result.ID.ValueString(),
 		"project":    result,


### PR DESCRIPTION
## Summary

When creating a Vercel Project, the provider logs the successful creation at ERROR level (`tflog.Error`), causing Pulumi's bridge to interpret it as a resource failure. The project is successfully created but the deployment fails.

## Root Cause

Line 2454 of `vercel/resource_project.go` uses `tflog.Error` instead of `tflog.Info`:

```diff
- tflog.Error(ctx, "created project", map[string]any{...})
+ tflog.Info(ctx, "created project", map[string]any{...})
```

For comparison, the update path at line 2534 correctly uses `tflog.Info`:
```go
tflog.Info(ctx, "updated newly created project", ...)
```

## Impact

- **Pulumi**: The ERROR-level diagnostic causes the bridge to mark the Vercel project resource as failed, breaking stack deployments
- **Terraform**: The error log is misleading in Terraform output, suggesting a problem when none exists

## Fix

Changed `tflog.Error` to `tflog.Info` for the successful project creation log.

Related Pulumi issue: https://github.com/pulumiverse/pulumi-vercel/issues/401
