### PR TITLE
fix(go): update module path to v5

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - "-s -w -X github.com/vercel/terraform-provider-vercel/v4/client.version={{.Version}}"
+      - "-s -w -X github.com/vercel/terraform-provider-vercel/v5/client.version={{.Version}}"
     goos:
       - freebsd
       - windows

--- a/client/edge_config_token_test.go
+++ b/client/edge_config_token_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestGetEdgeConfigToken(t *testing.T) {

--- a/client/feature_flag_test.go
+++ b/client/feature_flag_test.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"testing"
 
-	vercelclient "github.com/vercel/terraform-provider-vercel/v4/client"
+	vercelclient "github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestCreateFeatureFlag(t *testing.T) {

--- a/client/firewall_config_test.go
+++ b/client/firewall_config_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	vercelclient "github.com/vercel/terraform-provider-vercel/v4/client"
+	vercelclient "github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestUpdateFirewallConfig(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vercel/terraform-provider-vercel/v4
+module github.com/vercel/terraform-provider-vercel/v5
 
 go 1.26
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/vercel/terraform-provider-vercel/v4/vercel"
+	"github.com/vercel/terraform-provider-vercel/v5/vercel"
 )
 
 func main() {

--- a/sweep/main.go
+++ b/sweep/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func main() {

--- a/vercel/blob_object_shared.go
+++ b/vercel/blob_object_shared.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 const defaultBlobObjectCacheControlMaxAge int64 = 30 * 24 * 60 * 60

--- a/vercel/blob_shared.go
+++ b/vercel/blob_shared.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 const (

--- a/vercel/bulk_redirects.go
+++ b/vercel/bulk_redirects.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var bulkRedirectObjectType = types.ObjectType{

--- a/vercel/bulk_redirects_test.go
+++ b/vercel/bulk_redirects_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestFindLiveBulkRedirectVersion(t *testing.T) {

--- a/vercel/data_source_access_group.go
+++ b/vercel/data_source_access_group.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_access_group_project.go
+++ b/vercel/data_source_access_group_project.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_alias.go
+++ b/vercel/data_source_alias.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_attack_challenge_mode.go
+++ b/vercel/data_source_attack_challenge_mode.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_blob_object.go
+++ b/vercel/data_source_blob_object.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/data_source_blob_project_connections.go
+++ b/vercel/data_source_blob_project_connections.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/data_source_blob_store.go
+++ b/vercel/data_source_blob_store.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/data_source_blob_store_secrets.go
+++ b/vercel/data_source_blob_store_secrets.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/data_source_blob_stores.go
+++ b/vercel/data_source_blob_stores.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/data_source_bulk_redirects.go
+++ b/vercel/data_source_bulk_redirects.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/data_source_custom_environment.go
+++ b/vercel/data_source_custom_environment.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_deployment.go
+++ b/vercel/data_source_deployment.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_domain_config.go
+++ b/vercel/data_source_domain_config.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_dsync_groups.go
+++ b/vercel/data_source_dsync_groups.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/data_source_edge_config.go
+++ b/vercel/data_source_edge_config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_edge_config_item.go
+++ b/vercel/data_source_edge_config_item.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_edge_config_schema.go
+++ b/vercel/data_source_edge_config_schema.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_edge_config_token.go
+++ b/vercel/data_source_edge_config_token.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_endpoint_verification.go
+++ b/vercel/data_source_endpoint_verification.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_feature_flag.go
+++ b/vercel/data_source_feature_flag.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/data_source_feature_flag_sdk_key.go
+++ b/vercel/data_source_feature_flag_sdk_key.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/data_source_feature_flag_segment.go
+++ b/vercel/data_source_feature_flag_segment.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/data_source_file.go
+++ b/vercel/data_source_file.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_log_drain.go
+++ b/vercel/data_source_log_drain.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_microfrontend_group.go
+++ b/vercel/data_source_microfrontend_group.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_microfrontend_group_membership.go
+++ b/vercel/data_source_microfrontend_group_membership.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_network.go
+++ b/vercel/data_source_network.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_prebuilt_project.go
+++ b/vercel/data_source_prebuilt_project.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
-	"github.com/vercel/terraform-provider-vercel/v4/file"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
+	"github.com/vercel/terraform-provider-vercel/v5/file"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_project_deployment_retention.go
+++ b/vercel/data_source_project_deployment_retention.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/data_source_project_directory.go
+++ b/vercel/data_source_project_directory.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
-	"github.com/vercel/terraform-provider-vercel/v4/file"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
+	"github.com/vercel/terraform-provider-vercel/v5/file"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_project_members.go
+++ b/vercel/data_source_project_members.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/data_source_project_rolling_release.go
+++ b/vercel/data_source_project_rolling_release.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/data_source_project_routes.go
+++ b/vercel/data_source_project_routes.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/data_source_shared_environment_variable.go
+++ b/vercel/data_source_shared_environment_variable.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/data_source_team_config.go
+++ b/vercel/data_source_team_config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/data_source_team_member.go
+++ b/vercel/data_source_team_member.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/feature_flag_shared.go
+++ b/vercel/feature_flag_shared.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var featureFlagKeyRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,512}$`)

--- a/vercel/git_metadata.go
+++ b/vercel/git_metadata.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // findRepoRoot traverses upward from startDir until it finds either

--- a/vercel/project_routes_types.go
+++ b/vercel/project_routes_types.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var projectRouteConditionAttrType = types.ObjectType{

--- a/vercel/provider.go
+++ b/vercel/provider.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 type vercelProvider struct{}

--- a/vercel/provider_test.go
+++ b/vercel/provider_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
-	"github.com/vercel/terraform-provider-vercel/v4/vercel"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
+	"github.com/vercel/terraform-provider-vercel/v5/vercel"
 )
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){

--- a/vercel/resource_access_group.go
+++ b/vercel/resource_access_group.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_access_group_project.go
+++ b/vercel/resource_access_group_project.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_access_group_project_test.go
+++ b/vercel/resource_access_group_project_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestAcc_AccessGroupProjectResource(t *testing.T) {

--- a/vercel/resource_access_group_test.go
+++ b/vercel/resource_access_group_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestAcc_AccessGroupResource(t *testing.T) {

--- a/vercel/resource_alias.go
+++ b/vercel/resource_alias.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_alias_test.go
+++ b/vercel/resource_alias_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testCheckAliasExists(testClient *client.Client, teamID, alias string) resource.TestCheckFunc {

--- a/vercel/resource_attack_challenge_mode.go
+++ b/vercel/resource_attack_challenge_mode.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_blob_object.go
+++ b/vercel/resource_blob_object.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_blob_object_test.go
+++ b/vercel/resource_blob_object_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestAcc_BlobObjectResource(t *testing.T) {

--- a/vercel/resource_blob_project_connection.go
+++ b/vercel/resource_blob_project_connection.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_blob_project_connection_test.go
+++ b/vercel/resource_blob_project_connection_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestAcc_BlobProjectConnectionResource(t *testing.T) {

--- a/vercel/resource_blob_store.go
+++ b/vercel/resource_blob_store.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_blob_store_test.go
+++ b/vercel/resource_blob_store_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestAcc_BlobStoreResource(t *testing.T) {

--- a/vercel/resource_bulk_redirects.go
+++ b/vercel/resource_bulk_redirects.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_bulk_redirects_test.go
+++ b/vercel/resource_bulk_redirects_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testAccBulkRedirectsLiveVersion(testClient *client.Client, projectID, teamID string) (*client.BulkRedirectVersion, error) {

--- a/vercel/resource_custom_certificate.go
+++ b/vercel/resource_custom_certificate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_custom_certificate_test.go
+++ b/vercel/resource_custom_certificate_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testCheckCustomCertificateDoesNotExist(testClient *client.Client, teamID string, n string) resource.TestCheckFunc {

--- a/vercel/resource_custom_environment.go
+++ b/vercel/resource_custom_environment.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_custom_environment_test.go
+++ b/vercel/resource_custom_environment_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testCheckCustomEnvironmentExists(testClient *client.Client, teamID string, n string) resource.TestCheckFunc {

--- a/vercel/resource_deployment.go
+++ b/vercel/resource_deployment.go
@@ -23,8 +23,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
-	"github.com/vercel/terraform-provider-vercel/v4/file"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
+	"github.com/vercel/terraform-provider-vercel/v5/file"
 )
 
 var (

--- a/vercel/resource_deployment_test.go
+++ b/vercel/resource_deployment_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testAccDeploymentExists(testClient *client.Client, n string, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_dns_record.go
+++ b/vercel/resource_dns_record.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_dns_record_test.go
+++ b/vercel/resource_dns_record_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testAccDNSRecordDestroy(testClient *client.Client, n, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_edge_config.go
+++ b/vercel/resource_edge_config.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_edge_config_item.go
+++ b/vercel/resource_edge_config_item.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_edge_config_item_test.go
+++ b/vercel/resource_edge_config_item_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func getEdgeConfigItemImportID(n string) resource.ImportStateIdFunc {

--- a/vercel/resource_edge_config_schema.go
+++ b/vercel/resource_edge_config_schema.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_edge_config_schema_test.go
+++ b/vercel/resource_edge_config_schema_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testCheckEdgeConfigSchemaExists(testClient *client.Client, teamID, n string) resource.TestCheckFunc {

--- a/vercel/resource_edge_config_test.go
+++ b/vercel/resource_edge_config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testCheckEdgeConfigExists(testClient *client.Client, teamID, n string) resource.TestCheckFunc {

--- a/vercel/resource_edge_config_token.go
+++ b/vercel/resource_edge_config_token.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_edge_config_token_test.go
+++ b/vercel/resource_edge_config_token_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testCheckEdgeConfigTokenExists(testClient *client.Client, teamID, n string) resource.TestCheckFunc {

--- a/vercel/resource_feature_flag_config.go
+++ b/vercel/resource_feature_flag_config.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_feature_flag_definition.go
+++ b/vercel/resource_feature_flag_definition.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_feature_flag_sdk_key.go
+++ b/vercel/resource_feature_flag_sdk_key.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_feature_flag_segment.go
+++ b/vercel/resource_feature_flag_segment.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_feature_flag_test.go
+++ b/vercel/resource_feature_flag_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestAcc_FeatureFlagSegmentResource(t *testing.T) {

--- a/vercel/resource_firewall_bypass.go
+++ b/vercel/resource_firewall_bypass.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_firewall_config.go
+++ b/vercel/resource_firewall_config.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_firewall_config_unit_test.go
+++ b/vercel/resource_firewall_config_unit_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestFirewallConfigResourceSchemaIncludesSessionFixationRule(t *testing.T) {

--- a/vercel/resource_integration_project_access.go
+++ b/vercel/resource_integration_project_access.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_integration_project_access_test.go
+++ b/vercel/resource_integration_project_access_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testCheckIntegrationProjectAccessDestroyed(testClient *client.Client, n, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_log_drain.go
+++ b/vercel/resource_log_drain.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_log_drain_test.go
+++ b/vercel/resource_log_drain_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testCheckLogDrainExists(testClient *client.Client, teamID, n string) resource.TestCheckFunc {

--- a/vercel/resource_microfrontend_group.go
+++ b/vercel/resource_microfrontend_group.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_microfrontend_group_membership.go
+++ b/vercel/resource_microfrontend_group_membership.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_microfrontend_group_test.go
+++ b/vercel/resource_microfrontend_group_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testCheckMicrofrontendGroupExists(testClient *client.Client, teamID, n string) resource.TestCheckFunc {

--- a/vercel/resource_network.go
+++ b/vercel/resource_network.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_network_test.go
+++ b/vercel/resource_network_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestAcc_NetworkResource(t *testing.T) {

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_project_crons.go
+++ b/vercel/resource_project_crons.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Compile-time assertions to ensure the implementation conforms to the expected interfaces.

--- a/vercel/resource_project_crons_test.go
+++ b/vercel/resource_project_crons_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testAccProjectCronsExists(testClient *client.Client, n, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_project_deployment_retention.go
+++ b/vercel/resource_project_deployment_retention.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_project_deployment_retention_test.go
+++ b/vercel/resource_project_deployment_retention_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testAccProjectDeploymentRetentionExists(testClient *client.Client, n, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_project_domain.go
+++ b/vercel/resource_project_domain.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_project_domain_test.go
+++ b/vercel/resource_project_domain_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestAcc_ProjectDomain(t *testing.T) {

--- a/vercel/resource_project_environment_defaults_unit_test.go
+++ b/vercel/resource_project_environment_defaults_unit_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestProjectEnvironmentVariablesResourceSchemaRequiresSensitive(t *testing.T) {

--- a/vercel/resource_project_environment_variable.go
+++ b/vercel/resource_project_environment_variable.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_project_environment_variable_test.go
+++ b/vercel/resource_project_environment_variable_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testAccProjectEnvironmentVariableExists(testClient *client.Client, n, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_project_environment_variable_unit_test.go
+++ b/vercel/resource_project_environment_variable_unit_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestConvertResponseToProjectEnvironmentVariableKeepsWriteOnlyValueNull(t *testing.T) {

--- a/vercel/resource_project_environment_variables.go
+++ b/vercel/resource_project_environment_variables.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func strPtrEqual(a, b *string) bool {

--- a/vercel/resource_project_environment_variables_unit_test.go
+++ b/vercel/resource_project_environment_variables_unit_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestProjectEnvironmentVariablesModifyPlanSkipsPolicyValidationForExistingVariables(t *testing.T) {

--- a/vercel/resource_project_members.go
+++ b/vercel/resource_project_members.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_project_protection_bypass.go
+++ b/vercel/resource_project_protection_bypass.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_project_protection_bypass_test.go
+++ b/vercel/resource_project_protection_bypass_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestAcc_ProjectProtectionBypass(t *testing.T) {

--- a/vercel/resource_project_read_unit_test.go
+++ b/vercel/resource_project_read_unit_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestConvertResponseToProjectHandlesMissingResourceConfigAndBranchSensitiveEnv(t *testing.T) {

--- a/vercel/resource_project_regions_unit_test.go
+++ b/vercel/resource_project_regions_unit_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestConvertResponseToProjectCanonicalizesLegacyServerlessRegion(t *testing.T) {

--- a/vercel/resource_project_rolling_release.go
+++ b/vercel/resource_project_rolling_release.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_project_rolling_release_test.go
+++ b/vercel/resource_project_rolling_release_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func getRollingReleaseImportId(n string) resource.ImportStateIdFunc {

--- a/vercel/resource_project_route.go
+++ b/vercel/resource_project_route.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_project_route_test.go
+++ b/vercel/resource_project_route_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func getProjectRouteImportID(n string) resource.ImportStateIdFunc {

--- a/vercel/resource_project_schema_unit_test.go
+++ b/vercel/resource_project_schema_unit_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestProjectResourceSchemaOmitsDeprecatedAutomationBypassAttributes(t *testing.T) {

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestAcc_Project(t *testing.T) {

--- a/vercel/resource_shared_environment_variable.go
+++ b/vercel/resource_shared_environment_variable.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_shared_environment_variable_project_link.go
+++ b/vercel/resource_shared_environment_variable_project_link.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_shared_environment_variable_project_link_test.go
+++ b/vercel/resource_shared_environment_variable_project_link_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testCheckSharedEnvironmentVariableProjectUnlinked(testClient *client.Client, envVarName, projectName, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_shared_environment_variable_test.go
+++ b/vercel/resource_shared_environment_variable_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testAccSharedEnvironmentVariableExists(testClient *client.Client, n, teamID string) resource.TestCheckFunc {

--- a/vercel/resource_shared_environment_variable_unit_test.go
+++ b/vercel/resource_shared_environment_variable_unit_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func TestSharedEnvironmentVariableResourceSchemaRequiresSensitive(t *testing.T) {

--- a/vercel/resource_team_config.go
+++ b/vercel/resource_team_config.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_team_member.go
+++ b/vercel/resource_team_member.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_user_token.go
+++ b/vercel/resource_user_token.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 var (

--- a/vercel/resource_user_token_test.go
+++ b/vercel/resource_user_token_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testCheckUserTokenExists(testClient *client.Client, n string) resource.TestCheckFunc {

--- a/vercel/resource_webhook.go
+++ b/vercel/resource_webhook.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 // Ensure the implementation satisfies the expected interfaces.

--- a/vercel/resource_webhook_test.go
+++ b/vercel/resource_webhook_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/vercel/terraform-provider-vercel/v4/client"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func testCheckWebhookExists(testClient *client.Client, teamID, n string) resource.TestCheckFunc {


### PR DESCRIPTION
Fixes #522.

### What

Bumps the Go module path from `…/v4` to `…/v5` to match the published `v5.x` tags, as required by [Go semantic import versioning](https://go.dev/ref/mod#major-version-suffixes).

- `go.mod` module path `…/v4` → `…/v5`
- All `134` internal `.go` import statements `…/v4` → `…/v5`
- `.goreleaser.yml` `ldflags` version-injection path `…/v4/client.version` → `…/v5/client.version`

136 files changed, mechanical path-only edit — no dependency or logic changes (`go.sum` untouched).

### Why

The whole `v5.x` line (`v5.0.0` … `v5.3.0`) shipped with `go.mod` still declaring `…/v4`, so the module is uninstallable at its own major version:

```console
$ go install github.com/vercel/terraform-provider-vercel/v5@v5.3.0
go: ... module path must match major version ("github.com/vercel/terraform-provider-vercel/v4")
```

This breaks downstream Go consumers — most importantly the **Pulumi Terraform bridge** / `pulumi-vercel`, the same consumer behind the Pulumi-compat work in #430.

### Verification

- `go build ./...` — exit 0
- `go vet ./...` — exit 0
- `gofmt -l .` — empty
- `go mod verify` — all modules verified
- `git grep terraform-provider-vercel/v4` — 0 matches remaining

### A gentle ask 🙏

This is the **third** time the module path has lagged a major release — I previously fixed v3→v4 in #429, and it was v1→v2 in #227. Each miss breaks the Pulumi bridge until it's patched. Could we please keep the `/vN` suffix tidy as part of the release process — ideally a CI guard that asserts the `go.mod` major suffix matches the tag — so this doesn't recur on v6? Happy to send that guard as a follow-up if useful.
