### PR TITLE
Deprecate public_source and stop sending it to the API

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -186,7 +186,6 @@ type ProjectResponse struct {
 	Name                                 string                      `json:"name"`
 	OutputDirectory                      *string                     `json:"outputDirectory"`
 	PreviewDeploymentSuffix              *string                     `json:"previewDeploymentSuffix"`
-	PublicSource                         *bool                       `json:"publicSource"`
 	RootDirectory                        *string                     `json:"rootDirectory"`
 	ServerlessFunctionRegion             *string                     `json:"serverlessFunctionRegion"`
 	VercelAuthentication                 *VercelAuthentication       `json:"ssoProtection"`
@@ -353,7 +352,6 @@ type UpdateProjectRequest struct {
 	Name                                 *string                         `json:"name,omitempty"`
 	OutputDirectory                      *string                         `json:"outputDirectory"`
 	PreviewDeploymentSuffix              *string                         `json:"previewDeploymentSuffix"`
-	PublicSource                         *bool                           `json:"publicSource"`
 	RootDirectory                        *string                         `json:"rootDirectory"`
 	ServerlessFunctionRegion             string                          `json:"serverlessFunctionRegion,omitempty"`
 	VercelAuthentication                 *VercelAuthentication           `json:"ssoProtection"`

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -70,7 +70,7 @@ data "vercel_project" "example" {
 - `prioritise_production_builds` (Boolean) If enabled, builds for the Production environment will be prioritized over Preview environments.
 - `protection_bypass_for_automation` (Boolean, Deprecated) Allows automation services to bypass Deployment Protection on this project when using an HTTP header named `x-vercel-protection-bypass` with a value from `protection_bypass_for_automation_secret`. Deprecated: use the `vercel_project_protection_bypass` resource instead.
 - `protection_bypass_for_automation_secret` (List of String, Sensitive, Deprecated) The automation bypass secrets for this project. Use each value as the `x-vercel-protection-bypass` header. Deprecated: use the `vercel_project_protection_bypass` resource instead.
-- `public_source` (Boolean) Specifies whether the source code and logs of the deployments for this project should be public or not.
+- `public_source` (Boolean, Deprecated) Deprecated. The public source feature has been removed from Vercel; this attribute is no longer populated.
 - `resource_config` (Attributes) Resource Configuration for the project. (see [below for nested schema](#nestedatt--resource_config))
 - `root_directory` (String) The name of a directory or relative path to the source code of your project. When null is used it will default to the project root.
 - `serverless_function_region` (String) The region on Vercel's network to which your Serverless Functions are deployed. It should be close to any data source your Serverless Function might depend on. A new Deployment is required for your changes to take effect. Please see [Vercel's documentation](https://vercel.com/docs/concepts/edge-network/regions) for a full list of regions.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -131,7 +131,7 @@ resource "vercel_project" "with_trusted_sources" {
 - `preview_deployment_suffix` (String) The preview deployment suffix to apply to preview deployment URLs for this project. If not set, Vercel's default suffix will be used.
 - `preview_deployments_disabled` (Boolean) Disable creation of Preview Deployments for this project.
 - `prioritise_production_builds` (Boolean) If enabled, builds for the Production environment will be prioritized over Preview environments.
-- `public_source` (Boolean) By default, visitors to the `/_logs` and `/_src` paths of your Production and Preview Deployments must log in with Vercel (requires being a member of your team) to see the Source, Logs and Deployment Status of your project. Setting `public_source` to `true` disables this behaviour, meaning the Source, Logs and Deployment Status can be publicly viewed.
+- `public_source` (Boolean, Deprecated) Deprecated. The public source feature has been removed from Vercel; this attribute no longer has any effect.
 - `resource_config` (Attributes) Resource Configuration for the project. (see [below for nested schema](#nestedatt--resource_config))
 - `root_directory` (String) The name of a directory or relative path to the source code of your project. If omitted, it will default to the project root.
 - `serverless_function_region` (String, Deprecated) The region on Vercel's network to which your Serverless Functions are deployed. It should be close to any data source your Serverless Function might depend on. A new Deployment is required for your changes to take effect. Please see [Vercel's documentation](https://vercel.com/docs/concepts/edge-network/regions) for a full list of regions.

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -336,8 +336,9 @@ For more detailed information, please see the [Vercel documentation](https://ver
 				Description: "The preview deployment suffix to apply to preview deployment URLs for this project.",
 			},
 			"public_source": schema.BoolAttribute{
-				Computed:    true,
-				Description: "Specifies whether the source code and logs of the deployments for this project should be public or not.",
+				Computed:           true,
+				DeprecationMessage: "This attribute is deprecated and no longer has any effect. The public source feature has been removed from Vercel and is no longer returned by the API. It will be removed in a future major version of this provider.",
+				Description:        "Deprecated. The public source feature has been removed from Vercel; this attribute is no longer populated.",
 			},
 			"enable_affected_projects_deployments": schema.BoolAttribute{
 				Computed:    true,

--- a/vercel/data_source_project_test.go
+++ b/vercel/data_source_project_test.go
@@ -22,7 +22,8 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vercel_project.test", "framework", "nextjs"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "install_command", "npm install"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "output_directory", ".output"),
-					resource.TestCheckResourceAttr("data.vercel_project.test", "public_source", "true"),
+					// public_source is deprecated and no longer returned by the API.
+					resource.TestCheckNoResourceAttr("data.vercel_project.test", "public_source"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "root_directory", "ui/src"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "vercel_authentication.deployment_type", "standard_protection"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "password_protection.deployment_type", "standard_protection"),

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -488,8 +488,9 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				Description: "The preview deployment suffix to apply to preview deployment URLs for this project. If not set, Vercel's default suffix will be used.",
 			},
 			"public_source": schema.BoolAttribute{
-				Optional:    true,
-				Description: "By default, visitors to the `/_logs` and `/_src` paths of your Production and Preview Deployments must log in with Vercel (requires being a member of your team) to see the Source, Logs and Deployment Status of your project. Setting `public_source` to `true` disables this behaviour, meaning the Source, Logs and Deployment Status can be publicly viewed.",
+				Optional:           true,
+				DeprecationMessage: "This attribute is deprecated and no longer has any effect. The public source feature has been removed from Vercel, so this value is ignored and no longer sent to the API. It will be removed in a future major version of this provider.",
+				Description:        "Deprecated. The public source feature has been removed from Vercel; this attribute no longer has any effect.",
 			},
 			"root_directory": schema.StringAttribute{
 				Optional:    true,
@@ -1059,7 +1060,6 @@ func (p *Project) toCreateProjectRequest(ctx context.Context, envs []Environment
 		OIDCTokenConfig:                   oidc.toCreateProjectRequest(),
 		OutputDirectory:                   p.OutputDirectory.ValueStringPointer(),
 		PreviewDeploymentSuffix:           p.PreviewDeploymentSuffix.ValueStringPointer(),
-		PublicSource:                      p.PublicSource.ValueBoolPointer(),
 		RootDirectory:                     p.RootDirectory.ValueStringPointer(),
 		ResourceConfig:                    resourceConfig.toClientResourceConfig(ctx, p.OnDemandConcurrentBuilds, p.BuildMachineType, p.ServerlessFunctionRegion),
 		EnablePreviewFeedback:             oneBoolPointer(p.EnablePreviewFeedback, p.PreviewComments),
@@ -1158,7 +1158,6 @@ func (p *Project) toUpdateProjectRequest(ctx context.Context, oldName string) (r
 		Name:                                 name,
 		OutputDirectory:                      p.OutputDirectory.ValueStringPointer(),
 		PreviewDeploymentSuffix:              p.PreviewDeploymentSuffix.ValueStringPointer(),
-		PublicSource:                         p.PublicSource.ValueBoolPointer(),
 		RootDirectory:                        p.RootDirectory.ValueStringPointer(),
 		PasswordProtection:                   pp.toUpdateProjectRequest(),
 		VercelAuthentication:                 vercelAuthentication.toVercelAuthentication(),
@@ -2149,7 +2148,7 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 		Name:                              types.StringValue(response.Name),
 		OutputDirectory:                   uncoerceString(fields.OutputDirectory, types.StringPointerValue(response.OutputDirectory)),
 		PreviewDeploymentSuffix:           types.StringPointerValue(response.PreviewDeploymentSuffix),
-		PublicSource:                      uncoerceBool(fields.PublicSource, types.BoolPointerValue(response.PublicSource)),
+		PublicSource:                      fields.PublicSource, // Deprecated: no longer sent to or returned by the API; echo prior value to avoid a perpetual diff.
 		RootDirectory:                     types.StringPointerValue(response.RootDirectory),
 		ServerlessFunctionRegion:          serverlessFunctionRegion,
 		TeamID:                            toTeamID(response.TeamID),

--- a/vercel/resource_project_public_source_unit_test.go
+++ b/vercel/resource_project_public_source_unit_test.go
@@ -1,0 +1,44 @@
+package vercel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/vercel/terraform-provider-vercel/v4/client"
+)
+
+// public_source is deprecated: it is no longer sent to or returned by the
+// Vercel API. A configured value must still be preserved so it does not
+// produce a perpetual diff.
+func TestConvertResponseToProjectPreservesConfiguredPublicSource(t *testing.T) {
+	plan := nullProject
+	plan.PublicSource = types.BoolValue(true)
+
+	result, err := convertResponseToProject(context.Background(), client.ProjectResponse{
+		ID:   "prj_123",
+		Name: "example",
+		// API no longer returns publicSource.
+	}, plan, nil)
+	if err != nil {
+		t.Fatalf("convertResponseToProject() returned error: %v", err)
+	}
+
+	if got := result.PublicSource; got.IsNull() || !got.ValueBool() {
+		t.Fatalf("PublicSource = %v, want true (configured value preserved)", got)
+	}
+}
+
+func TestConvertResponseToProjectLeavesUnconfiguredPublicSourceNull(t *testing.T) {
+	result, err := convertResponseToProject(context.Background(), client.ProjectResponse{
+		ID:   "prj_123",
+		Name: "example",
+	}, nullProject, nil)
+	if err != nil {
+		t.Fatalf("convertResponseToProject() returned error: %v", err)
+	}
+
+	if !result.PublicSource.IsNull() {
+		t.Fatalf("PublicSource = %v, want null for unconfigured deprecated field", result.PublicSource)
+	}
+}

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -717,7 +717,10 @@ func TestAcc_ProjectImport(t *testing.T) {
 				ResourceName:      "vercel_project.test",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: getProjectImportID("vercel_project.test"),
+				// public_source is deprecated and no longer backed by the API, so
+				// its configured value cannot be recovered on import.
+				ImportStateVerifyIgnore: []string{"public_source"},
+				ImportStateIdFunc:       getProjectImportID("vercel_project.test"),
 			},
 		},
 	})


### PR DESCRIPTION
## Why

The `publicSource` project setting is deprecated on the Vercel API side, The provider always includes `publicSource` in the project create/update request body, so project create/update now fails with `bad_request - Invalid request: should NOT have additional property \`publicSource\``.

## What

Non-breaking deprecation (no config changes forced on practitioners):

- **Stop sending** `publicSource` in the create/update request bodies (removed from `CreateProjectRequest` / `UpdateProjectRequest`).
- **Deprecate** the `public_source` attribute on both the `vercel_project` resource and data source via `DeprecationMessage`. Kept in the schema so existing configs keep working; full removal deferred to a future major version.
- **Avoid a perpetual diff:** the API no longer returns the field, so the read echoes the configured value instead of reading it from the response.
- Updated generated docs and added unit tests covering the no-permadiff behavior.

## Validation

- `go build ./...`, `go vet ./...`, `gofmt` clean
- New unit tests assert a configured `public_source` is preserved (no permadiff) and an unconfigured one stays null
- Acceptance tests require live credentials and were not run locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)