### PR TITLE
Remove `projectId` from user token resource

### DIFF
--- a/client/user_token.go
+++ b/client/user_token.go
@@ -20,15 +20,13 @@ type UserToken struct {
 	ExpiresAt   *int64  `json:"expiresAt"`
 	LeakedAt    *int64  `json:"leakedAt"`
 	LeakedURL   *string `json:"leakedUrl"`
-	ProjectID   *string `json:"projectId"`
 	BearerToken *string
 }
 
 type CreateUserTokenRequest struct {
-	Name      string  `json:"name"`
-	ExpiresAt *int64  `json:"expiresAt,omitempty"`
-	ProjectID *string `json:"projectId,omitempty"`
-	TeamID    string  `json:"-"`
+	Name      string `json:"name"`
+	ExpiresAt *int64 `json:"expiresAt,omitempty"`
+	TeamID    string `json:"-"`
 }
 
 func (c *Client) CreateUserToken(ctx context.Context, request CreateUserTokenRequest) (u UserToken, err error) {

--- a/docs/resources/user_token.md
+++ b/docs/resources/user_token.md
@@ -42,7 +42,6 @@ resource "vercel_user_token" "example_expiring" {
 ### Optional
 
 - `expires_at` (Number) The Unix timestamp in milliseconds when the token should expire.
-- `project_id` (String) The ID of the project this token should be scoped to. Requires team scope.
 - `team_id` (String) The ID of the Vercel team scope for this token. Required when creating a team-scoped token if a default team has not been set in the provider.
 
 ### Read-Only

--- a/vercel/resource_user_token.go
+++ b/vercel/resource_user_token.go
@@ -88,11 +88,6 @@ The ` + "`bearer_token`" + ` value is only returned during creation and cannot b
 					int64validator.AtLeast(1),
 				},
 			},
-			"project_id": schema.StringAttribute{
-				Description:   "The ID of the project this token should be scoped to. Requires team scope.",
-				Optional:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
-			},
 			"team_id": schema.StringAttribute{
 				Description:   "The ID of the Vercel team scope for this token. Required when creating a team-scoped token if a default team has not been set in the provider.",
 				Optional:      true,
@@ -153,7 +148,6 @@ type UserToken struct {
 	ID          types.String `tfsdk:"id"`
 	Name        types.String `tfsdk:"name"`
 	ExpiresAt   types.Int64  `tfsdk:"expires_at"`
-	ProjectID   types.String `tfsdk:"project_id"`
 	TeamID      types.String `tfsdk:"team_id"`
 	BearerToken types.String `tfsdk:"bearer_token"`
 	Type        types.String `tfsdk:"type"`
@@ -175,7 +169,6 @@ func responseToUserToken(out client.UserToken, bearerToken types.String) UserTok
 		ID:          types.StringValue(out.ID),
 		Name:        types.StringValue(out.Name),
 		ExpiresAt:   types.Int64PointerValue(out.ExpiresAt),
-		ProjectID:   types.StringPointerValue(out.ProjectID),
 		TeamID:      types.StringPointerValue(out.TeamID),
 		BearerToken: bearerToken,
 		Type:        types.StringValue(out.Type),
@@ -214,19 +207,9 @@ func (r *userTokenResource) Create(ctx context.Context, req resource.CreateReque
 		)
 		return
 	}
-	if !plan.ProjectID.IsNull() && r.client.TeamID(plan.TeamID.ValueString()) == "" {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("project_id"),
-			"Project-scoped token requires team scope",
-			"`project_id` can only be used when the token is created in a team scope. Set `team_id` or configure a default team on the provider.",
-		)
-		return
-	}
-
 	out, err := r.client.CreateUserToken(ctx, client.CreateUserTokenRequest{
 		Name:      name,
 		ExpiresAt: plan.ExpiresAt.ValueInt64Pointer(),
-		ProjectID: plan.ProjectID.ValueStringPointer(),
 		TeamID:    plan.TeamID.ValueString(),
 	})
 	if err != nil {


### PR DESCRIPTION
This was documented in the public API but never actually supported (well, it was behind a very limited feature flag). Most users who tried to use this would have seen their request fail; therefore, let's remove it. This might technically be a breaking change.