### PR TITLE
feat: add protected_sourcemaps attribute to vercel_project resource

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -63,6 +63,7 @@ type CreateProjectRequest struct {
 	EnableProductionFeedback          *bool                 `json:"enableProductionFeedback,omitempty"`
 	VercelAuthentication              *VercelAuthentication `json:"ssoProtection,omitempty"`
 	PreviewDeploymentsDisabled        *bool                 `json:"previewDeploymentsDisabled,omitempty"`
+	ProtectedSourcemaps               *bool                 `json:"protectedSourcemaps,omitempty"`
 }
 
 // CreateProject will create a project within Vercel.
@@ -208,6 +209,7 @@ type ProjectResponse struct {
 	GitForkProtection                    bool                        `json:"gitForkProtection"`
 	ProductionDeploymentsFastLane        bool                        `json:"productionDeploymentsFastLane"`
 	DirectoryListing                     bool                        `json:"directoryListing"`
+	ProtectedSourcemaps                  bool                        `json:"protectedSourcemaps"`
 	SkewProtectionMaxAge                 int                         `json:"skewProtectionMaxAge"`
 	GitComments                          *GitComments                `json:"gitComments"`
 	GitProviderOptions                   *GitProviderOptionsResponse `json:"gitProviderOptions"`
@@ -374,6 +376,7 @@ type UpdateProjectRequest struct {
 	GitForkProtection                    bool                            `json:"gitForkProtection"`
 	ProductionDeploymentsFastLane        bool                            `json:"productionDeploymentsFastLane"`
 	DirectoryListing                     bool                            `json:"directoryListing"`
+	ProtectedSourcemaps                  bool                            `json:"protectedSourcemaps"`
 	SkewProtectionMaxAge                 int                             `json:"skewProtectionMaxAge"`
 	GitComments                          *GitComments                    `json:"gitComments"`
 	GitProviderOptions                   *GitProviderOptions             `json:"gitProviderOptions,omitempty"`

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -446,6 +446,10 @@ For more detailed information, please see the [Vercel documentation](https://ver
 				Computed:    true,
 				Description: "Allows Vercel Customer Support to inspect all Deployments' source code in this project to assist with debugging.",
 			},
+			"protected_sourcemaps": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Specifies whether sourcemaps are protected and require authentication to access.",
+			},
 			"git_fork_protection": schema.BoolAttribute{
 				Computed:    true,
 				Description: "Ensures that pull requests targeting your Git repository must be authorized by a member of your Team before deploying if your Project has Environment Variables or if the pull request includes a change to vercel.json.",
@@ -565,6 +569,7 @@ type ProjectDataSource struct {
 	GitLFS                              types.Bool   `tfsdk:"git_lfs"`
 	FunctionFailover                    types.Bool   `tfsdk:"function_failover"`
 	CustomerSuccessCodeVisibility       types.Bool   `tfsdk:"customer_success_code_visibility"`
+	ProtectedSourcemaps                 types.Bool   `tfsdk:"protected_sourcemaps"`
 	GitForkProtection                   types.Bool   `tfsdk:"git_fork_protection"`
 	PrioritiseProductionBuilds          types.Bool   `tfsdk:"prioritise_production_builds"`
 	DirectoryListing                    types.Bool   `tfsdk:"directory_listing"`
@@ -665,6 +670,7 @@ func convertResponseToProjectDataSource(ctx context.Context, response client.Pro
 		GitLFS:                              project.GitLFS,
 		FunctionFailover:                    project.FunctionFailover,
 		CustomerSuccessCodeVisibility:       project.CustomerSuccessCodeVisibility,
+		ProtectedSourcemaps:                 project.ProtectedSourcemaps,
 		GitForkProtection:                   project.GitForkProtection,
 		PrioritiseProductionBuilds:          project.PrioritiseProductionBuilds,
 		DirectoryListing:                    project.DirectoryListing,

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -618,6 +618,12 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()},
 				Description:   "Allows Vercel Customer Support to inspect all Deployments' source code in this project to assist with debugging.",
 			},
+			"protected_sourcemaps": schema.BoolAttribute{
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()},
+				Description:   "Specifies whether sourcemaps are protected and require authentication to access.",
+			},
 			"git_fork_protection": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
@@ -794,6 +800,7 @@ type Project struct {
 	GitLFS                            types.Bool   `tfsdk:"git_lfs"`
 	FunctionFailover                  types.Bool   `tfsdk:"function_failover"`
 	CustomerSuccessCodeVisibility     types.Bool   `tfsdk:"customer_success_code_visibility"`
+	ProtectedSourcemaps              types.Bool   `tfsdk:"protected_sourcemaps"`
 	GitForkProtection                 types.Bool   `tfsdk:"git_fork_protection"`
 	PrioritiseProductionBuilds        types.Bool   `tfsdk:"prioritise_production_builds"`
 	DirectoryListing                  types.Bool   `tfsdk:"directory_listing"`
@@ -832,6 +839,7 @@ func (p Project) RequiresUpdateAfterCreation() bool {
 		knownBool(p.GitLFS) ||
 		knownBool(p.FunctionFailover) ||
 		knownBool(p.CustomerSuccessCodeVisibility) ||
+		knownBool(p.ProtectedSourcemaps) ||
 		(knownBool(p.GitForkProtection) && !p.GitForkProtection.ValueBool()) ||
 		knownBool(p.PrioritiseProductionBuilds) ||
 		knownBool(p.DirectoryListing) ||
@@ -1066,6 +1074,7 @@ func (p *Project) toCreateProjectRequest(ctx context.Context, envs []Environment
 		EnableProductionFeedback:          p.EnableProductionFeedback.ValueBoolPointer(),
 		VercelAuthentication:              vercelAuthentication.toVercelAuthentication(),
 		PreviewDeploymentsDisabled:        p.PreviewDeploymentsDisabled.ValueBoolPointer(),
+		ProtectedSourcemaps:               p.ProtectedSourcemaps.ValueBoolPointer(),
 	}, diags
 }
 
@@ -1175,6 +1184,7 @@ func (p *Project) toUpdateProjectRequest(ctx context.Context, oldName string) (r
 		GitLFS:                               p.GitLFS.ValueBool(),
 		ServerlessFunctionZeroConfigFailover: p.FunctionFailover.ValueBool(),
 		CustomerSupportCodeVisibility:        p.CustomerSuccessCodeVisibility.ValueBool(),
+		ProtectedSourcemaps:                  p.ProtectedSourcemaps.ValueBool(),
 		GitForkProtection:                    p.GitForkProtection.ValueBool(),
 		ProductionDeploymentsFastLane:        p.PrioritiseProductionBuilds.ValueBool(),
 		DirectoryListing:                     p.DirectoryListing.ValueBool(),
@@ -2169,6 +2179,7 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 		GitLFS:                            types.BoolValue(response.GitLFS),
 		FunctionFailover:                  types.BoolValue(response.ServerlessFunctionZeroConfigFailover),
 		CustomerSuccessCodeVisibility:     types.BoolValue(response.CustomerSupportCodeVisibility),
+		ProtectedSourcemaps:              types.BoolValue(response.ProtectedSourcemaps),
 		GitForkProtection:                 types.BoolValue(response.GitForkProtection),
 		PrioritiseProductionBuilds:        types.BoolValue(response.ProductionDeploymentsFastLane),
 		DirectoryListing:                  types.BoolValue(response.DirectoryListing),

--- a/vercel/resource_project_unit_test.go
+++ b/vercel/resource_project_unit_test.go
@@ -114,6 +114,7 @@ func projectForUpdateRequestTests() Project {
 		GitLFS:                            types.BoolUnknown(),
 		FunctionFailover:                  types.BoolUnknown(),
 		CustomerSuccessCodeVisibility:     types.BoolUnknown(),
+		ProtectedSourcemaps:               types.BoolUnknown(),
 		GitForkProtection:                 types.BoolValue(true),
 		PrioritiseProductionBuilds:        types.BoolUnknown(),
 		DirectoryListing:                  types.BoolUnknown(),


### PR DESCRIPTION
## Summary

- Adds `protected_sourcemaps` boolean attribute to the `vercel_project` resource and data source
- Maps to the existing `protectedSourcemaps` field on the Vercel project API ([docs](https://vercel.com/docs/deployment-protection/protected-source-maps))
- When enabled, source maps require authentication to access

Closes #532

## Changes

- `client/project.go`: Added `ProtectedSourcemaps` field to `CreateProjectRequest`, `ProjectResponse`, and `UpdateProjectRequest` structs
- `vercel/resource_project.go`: Added schema attribute, model field, and wiring for create/update/read
- `vercel/data_source_project.go`: Added computed attribute to the data source
- `vercel/resource_project_unit_test.go`: Added field to test fixture

## Example Usage

```hcl
resource "vercel_project" "example" {
  name                 = "my-project"
  protected_sourcemaps = true
}
```

## Test Plan

- [x] `go build ./...` passes
- [x] Unit tests pass (`go test ./vercel/ -run "^Test[^A]" -short`)
- [x] Verified with `terraform plan` against a real project — correctly shows `protected_sourcemaps = false -> true`