### PR TITLE
feat: add protected_sourcemaps

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -63,7 +63,6 @@ type CreateProjectRequest struct {
 	EnableProductionFeedback          *bool                 `json:"enableProductionFeedback,omitempty"`
 	VercelAuthentication              *VercelAuthentication `json:"ssoProtection,omitempty"`
 	PreviewDeploymentsDisabled        *bool                 `json:"previewDeploymentsDisabled,omitempty"`
-	ProtectedSourcemaps               *bool                 `json:"protectedSourcemaps,omitempty"`
 }
 
 // CreateProject will create a project within Vercel.

--- a/client/project.go
+++ b/client/project.go
@@ -63,6 +63,7 @@ type CreateProjectRequest struct {
 	EnableProductionFeedback          *bool                 `json:"enableProductionFeedback,omitempty"`
 	VercelAuthentication              *VercelAuthentication `json:"ssoProtection,omitempty"`
 	PreviewDeploymentsDisabled        *bool                 `json:"previewDeploymentsDisabled,omitempty"`
+	ProtectedSourcemaps               *bool                 `json:"protectedSourcemaps,omitempty"`
 }
 
 // CreateProject will create a project within Vercel.
@@ -208,6 +209,7 @@ type ProjectResponse struct {
 	GitForkProtection                    bool                        `json:"gitForkProtection"`
 	ProductionDeploymentsFastLane        bool                        `json:"productionDeploymentsFastLane"`
 	DirectoryListing                     bool                        `json:"directoryListing"`
+	ProtectedSourcemaps                  bool                        `json:"protectedSourcemaps"`
 	SkewProtectionMaxAge                 int                         `json:"skewProtectionMaxAge"`
 	GitComments                          *GitComments                `json:"gitComments"`
 	GitProviderOptions                   *GitProviderOptionsResponse `json:"gitProviderOptions"`
@@ -374,6 +376,7 @@ type UpdateProjectRequest struct {
 	GitForkProtection                    bool                            `json:"gitForkProtection"`
 	ProductionDeploymentsFastLane        bool                            `json:"productionDeploymentsFastLane"`
 	DirectoryListing                     bool                            `json:"directoryListing"`
+	ProtectedSourcemaps                  bool                            `json:"protectedSourcemaps"`
 	SkewProtectionMaxAge                 int                             `json:"skewProtectionMaxAge"`
 	GitComments                          *GitComments                    `json:"gitComments"`
 	GitProviderOptions                   *GitProviderOptions             `json:"gitProviderOptions,omitempty"`

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -68,6 +68,7 @@ data "vercel_project" "example" {
 - `preview_deployment_suffix` (String) The preview deployment suffix to apply to preview deployment URLs for this project.
 - `preview_deployments_disabled` (Boolean) Whether Preview Deployments are disabled for this project.
 - `prioritise_production_builds` (Boolean) If enabled, builds for the Production environment will be prioritized over Preview environments.
+- `protected_sourcemaps` (Boolean) Specifies whether sourcemaps are protected and require authentication to access.
 - `protection_bypass_for_automation` (Boolean, Deprecated) Allows automation services to bypass Deployment Protection on this project when using an HTTP header named `x-vercel-protection-bypass` with a value from `protection_bypass_for_automation_secret`. Deprecated: use the `vercel_project_protection_bypass` resource instead.
 - `protection_bypass_for_automation_secret` (List of String, Sensitive, Deprecated) The automation bypass secrets for this project. Use each value as the `x-vercel-protection-bypass` header. Deprecated: use the `vercel_project_protection_bypass` resource instead.
 - `public_source` (Boolean) Specifies whether the source code and logs of the deployments for this project should be public or not.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -44,8 +44,9 @@ resource "vercel_project" "with_git" {
 # Deployments will need to be created manually through
 # terraform, or via the vercel CLI.
 resource "vercel_project" "example" {
-  name      = "example-project"
-  framework = "nextjs"
+  name                 = "example-project"
+  framework            = "nextjs"
+  protected_sourcemaps = true
 }
 
 locals {
@@ -131,6 +132,7 @@ resource "vercel_project" "with_trusted_sources" {
 - `preview_deployment_suffix` (String) The preview deployment suffix to apply to preview deployment URLs for this project. If not set, Vercel's default suffix will be used.
 - `preview_deployments_disabled` (Boolean) Disable creation of Preview Deployments for this project.
 - `prioritise_production_builds` (Boolean) If enabled, builds for the Production environment will be prioritized over Preview environments.
+- `protected_sourcemaps` (Boolean) Specifies whether sourcemaps are protected and require authentication to access.
 - `public_source` (Boolean) By default, visitors to the `/_logs` and `/_src` paths of your Production and Preview Deployments must log in with Vercel (requires being a member of your team) to see the Source, Logs and Deployment Status of your project. Setting `public_source` to `true` disables this behaviour, meaning the Source, Logs and Deployment Status can be publicly viewed.
 - `resource_config` (Attributes) Resource Configuration for the project. (see [below for nested schema](#nestedatt--resource_config))
 - `root_directory` (String) The name of a directory or relative path to the source code of your project. If omitted, it will default to the project root.

--- a/examples/resources/vercel_project/resource.tf
+++ b/examples/resources/vercel_project/resource.tf
@@ -15,8 +15,9 @@ resource "vercel_project" "with_git" {
 # Deployments will need to be created manually through
 # terraform, or via the vercel CLI.
 resource "vercel_project" "example" {
-  name      = "example-project"
-  framework = "nextjs"
+  name                 = "example-project"
+  framework            = "nextjs"
+  protected_sourcemaps = true
 }
 
 locals {

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -446,6 +446,10 @@ For more detailed information, please see the [Vercel documentation](https://ver
 				Computed:    true,
 				Description: "Allows Vercel Customer Support to inspect all Deployments' source code in this project to assist with debugging.",
 			},
+			"protected_sourcemaps": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Specifies whether sourcemaps are protected and require authentication to access.",
+			},
 			"git_fork_protection": schema.BoolAttribute{
 				Computed:    true,
 				Description: "Ensures that pull requests targeting your Git repository must be authorized by a member of your Team before deploying if your Project has Environment Variables or if the pull request includes a change to vercel.json.",
@@ -565,6 +569,7 @@ type ProjectDataSource struct {
 	GitLFS                              types.Bool   `tfsdk:"git_lfs"`
 	FunctionFailover                    types.Bool   `tfsdk:"function_failover"`
 	CustomerSuccessCodeVisibility       types.Bool   `tfsdk:"customer_success_code_visibility"`
+	ProtectedSourcemaps                 types.Bool   `tfsdk:"protected_sourcemaps"`
 	GitForkProtection                   types.Bool   `tfsdk:"git_fork_protection"`
 	PrioritiseProductionBuilds          types.Bool   `tfsdk:"prioritise_production_builds"`
 	DirectoryListing                    types.Bool   `tfsdk:"directory_listing"`
@@ -665,6 +670,7 @@ func convertResponseToProjectDataSource(ctx context.Context, response client.Pro
 		GitLFS:                              project.GitLFS,
 		FunctionFailover:                    project.FunctionFailover,
 		CustomerSuccessCodeVisibility:       project.CustomerSuccessCodeVisibility,
+		ProtectedSourcemaps:                 project.ProtectedSourcemaps,
 		GitForkProtection:                   project.GitForkProtection,
 		PrioritiseProductionBuilds:          project.PrioritiseProductionBuilds,
 		DirectoryListing:                    project.DirectoryListing,

--- a/vercel/data_source_project_test.go
+++ b/vercel/data_source_project_test.go
@@ -22,7 +22,6 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vercel_project.test", "framework", "nextjs"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "install_command", "npm install"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "output_directory", ".output"),
-					resource.TestCheckResourceAttr("data.vercel_project.test", "public_source", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "root_directory", "ui/src"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "vercel_authentication.deployment_type", "standard_protection"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "password_protection.deployment_type", "standard_protection"),
@@ -52,6 +51,7 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vercel_project.test", "git_lfs", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "function_failover", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "customer_success_code_visibility", "true"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "protected_sourcemaps", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "git_fork_protection", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "prioritise_production_builds", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "directory_listing", "true"),
@@ -101,7 +101,6 @@ resource "vercel_project" "test" {
   framework = "nextjs"
   install_command = "npm install"
   output_directory = ".output"
-  public_source = true
   root_directory = "ui/src"
   preview_deployments_disabled = true
   vercel_authentication = {
@@ -146,6 +145,7 @@ resource "vercel_project" "test" {
   git_lfs = true
   function_failover = true
   customer_success_code_visibility = true
+  protected_sourcemaps = true
   git_fork_protection = true
   prioritise_production_builds = true
   directory_listing = true

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -800,7 +800,7 @@ type Project struct {
 	GitLFS                            types.Bool   `tfsdk:"git_lfs"`
 	FunctionFailover                  types.Bool   `tfsdk:"function_failover"`
 	CustomerSuccessCodeVisibility     types.Bool   `tfsdk:"customer_success_code_visibility"`
-	ProtectedSourcemaps              types.Bool   `tfsdk:"protected_sourcemaps"`
+	ProtectedSourcemaps               types.Bool   `tfsdk:"protected_sourcemaps"`
 	GitForkProtection                 types.Bool   `tfsdk:"git_fork_protection"`
 	PrioritiseProductionBuilds        types.Bool   `tfsdk:"prioritise_production_builds"`
 	DirectoryListing                  types.Bool   `tfsdk:"directory_listing"`
@@ -1074,7 +1074,6 @@ func (p *Project) toCreateProjectRequest(ctx context.Context, envs []Environment
 		EnableProductionFeedback:          p.EnableProductionFeedback.ValueBoolPointer(),
 		VercelAuthentication:              vercelAuthentication.toVercelAuthentication(),
 		PreviewDeploymentsDisabled:        p.PreviewDeploymentsDisabled.ValueBoolPointer(),
-		ProtectedSourcemaps:               p.ProtectedSourcemaps.ValueBoolPointer(),
 	}, diags
 }
 
@@ -1808,8 +1807,8 @@ func (t *OptionsAllowlist) toUpdateProjectRequest() *client.OptionsAllowlist {
 * API returns a different value. This causes an inconsistent plan error.
 
 * We avoid this issue by choosing to use values from the terraform state,
-* but only if they are _explicitly stated_ *and* they are _falsy_ values
-* *and* the response value was null. This is important as drift detection
+* but only if they are _explicitly stated_ and the response value was null.
+* This is important as drift detection
 * would fail to work if the value was always selected, so this is as stringent
 * as possible to allow drift-detection in the majority of scenarios.
 
@@ -1842,7 +1841,7 @@ func uncoerceString(plan, res types.String) types.String {
 	return res
 }
 func uncoerceBool(plan, res types.Bool) types.Bool {
-	if !plan.ValueBool() && !plan.IsNull() && res.IsNull() {
+	if !plan.IsNull() && !plan.IsUnknown() && res.IsNull() {
 		return plan
 	}
 	return res
@@ -2179,7 +2178,7 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 		GitLFS:                            types.BoolValue(response.GitLFS),
 		FunctionFailover:                  types.BoolValue(response.ServerlessFunctionZeroConfigFailover),
 		CustomerSuccessCodeVisibility:     types.BoolValue(response.CustomerSupportCodeVisibility),
-		ProtectedSourcemaps:              types.BoolValue(response.ProtectedSourcemaps),
+		ProtectedSourcemaps:               types.BoolValue(response.ProtectedSourcemaps),
 		GitForkProtection:                 types.BoolValue(response.GitForkProtection),
 		PrioritiseProductionBuilds:        types.BoolValue(response.ProductionDeploymentsFastLane),
 		DirectoryListing:                  types.BoolValue(response.DirectoryListing),

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -618,6 +618,12 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()},
 				Description:   "Allows Vercel Customer Support to inspect all Deployments' source code in this project to assist with debugging.",
 			},
+			"protected_sourcemaps": schema.BoolAttribute{
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()},
+				Description:   "Specifies whether sourcemaps are protected and require authentication to access.",
+			},
 			"git_fork_protection": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
@@ -794,6 +800,7 @@ type Project struct {
 	GitLFS                            types.Bool   `tfsdk:"git_lfs"`
 	FunctionFailover                  types.Bool   `tfsdk:"function_failover"`
 	CustomerSuccessCodeVisibility     types.Bool   `tfsdk:"customer_success_code_visibility"`
+	ProtectedSourcemaps              types.Bool   `tfsdk:"protected_sourcemaps"`
 	GitForkProtection                 types.Bool   `tfsdk:"git_fork_protection"`
 	PrioritiseProductionBuilds        types.Bool   `tfsdk:"prioritise_production_builds"`
 	DirectoryListing                  types.Bool   `tfsdk:"directory_listing"`
@@ -832,6 +839,7 @@ func (p Project) RequiresUpdateAfterCreation() bool {
 		knownBool(p.GitLFS) ||
 		knownBool(p.FunctionFailover) ||
 		knownBool(p.CustomerSuccessCodeVisibility) ||
+		knownBool(p.ProtectedSourcemaps) ||
 		(knownBool(p.GitForkProtection) && !p.GitForkProtection.ValueBool()) ||
 		knownBool(p.PrioritiseProductionBuilds) ||
 		knownBool(p.DirectoryListing) ||
@@ -1066,6 +1074,7 @@ func (p *Project) toCreateProjectRequest(ctx context.Context, envs []Environment
 		EnableProductionFeedback:          p.EnableProductionFeedback.ValueBoolPointer(),
 		VercelAuthentication:              vercelAuthentication.toVercelAuthentication(),
 		PreviewDeploymentsDisabled:        p.PreviewDeploymentsDisabled.ValueBoolPointer(),
+		ProtectedSourcemaps:               p.ProtectedSourcemaps.ValueBoolPointer(),
 	}, diags
 }
 
@@ -1175,6 +1184,7 @@ func (p *Project) toUpdateProjectRequest(ctx context.Context, oldName string) (r
 		GitLFS:                               p.GitLFS.ValueBool(),
 		ServerlessFunctionZeroConfigFailover: p.FunctionFailover.ValueBool(),
 		CustomerSupportCodeVisibility:        p.CustomerSuccessCodeVisibility.ValueBool(),
+		ProtectedSourcemaps:                  p.ProtectedSourcemaps.ValueBool(),
 		GitForkProtection:                    p.GitForkProtection.ValueBool(),
 		ProductionDeploymentsFastLane:        p.PrioritiseProductionBuilds.ValueBool(),
 		DirectoryListing:                     p.DirectoryListing.ValueBool(),
@@ -2169,6 +2179,7 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 		GitLFS:                            types.BoolValue(response.GitLFS),
 		FunctionFailover:                  types.BoolValue(response.ServerlessFunctionZeroConfigFailover),
 		CustomerSuccessCodeVisibility:     types.BoolValue(response.CustomerSupportCodeVisibility),
+		ProtectedSourcemaps:              types.BoolValue(response.ProtectedSourcemaps),
 		GitForkProtection:                 types.BoolValue(response.GitForkProtection),
 		PrioritiseProductionBuilds:        types.BoolValue(response.ProductionDeploymentsFastLane),
 		DirectoryListing:                  types.BoolValue(response.DirectoryListing),

--- a/vercel/resource_project_read_unit_test.go
+++ b/vercel/resource_project_read_unit_test.go
@@ -86,6 +86,41 @@ func TestConvertResponseToProjectHandlesMissingResourceConfigAndBranchSensitiveE
 	}
 }
 
+func TestConvertResponseToProjectProtectedSourcemaps(t *testing.T) {
+	ctx := context.Background()
+	result, err := convertResponseToProject(ctx, client.ProjectResponse{
+		ID:                  "prj_123",
+		Name:                "example",
+		TeamID:              "team_123",
+		ProtectedSourcemaps: true,
+	}, projectForReadTests(), nil)
+	if err != nil {
+		t.Fatalf("convertResponseToProject() returned error: %v", err)
+	}
+	if !result.ProtectedSourcemaps.ValueBool() {
+		t.Fatal("ProtectedSourcemaps = false, want true")
+	}
+}
+
+func TestConvertResponseToProjectKeepsConfiguredBoolWhenResponseIsNull(t *testing.T) {
+	ctx := context.Background()
+	plan := projectForReadTests()
+	plan.PublicSource = types.BoolValue(true)
+
+	result, err := convertResponseToProject(ctx, client.ProjectResponse{
+		ID:           "prj_123",
+		Name:         "example",
+		TeamID:       "team_123",
+		PublicSource: nil,
+	}, plan, nil)
+	if err != nil {
+		t.Fatalf("convertResponseToProject() returned error: %v", err)
+	}
+	if !result.PublicSource.ValueBool() {
+		t.Fatal("PublicSource = false/null, want configured true")
+	}
+}
+
 func TestConvertResponseToProjectTrustedSources(t *testing.T) {
 	ctx := context.Background()
 	projectLabel := "Source project"

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -83,6 +83,7 @@ func TestAcc_Project(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_project.test", "git_lfs", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "function_failover", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "customer_success_code_visibility", "true"),
+					resource.TestCheckResourceAttr("vercel_project.test", "protected_sourcemaps", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_fork_protection", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "prioritise_production_builds", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "directory_listing", "true"),
@@ -114,6 +115,7 @@ func TestAcc_Project(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_project.test", "enable_preview_feedback", "false"),
 					resource.TestCheckResourceAttr("vercel_project.test", "enable_production_feedback", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "preview_deployments_disabled", "false"),
+					resource.TestCheckResourceAttr("vercel_project.test", "protected_sourcemaps", "false"),
 					resource.TestCheckResourceAttr("vercel_project.test", "on_demand_concurrent_builds", "false"),
 					resource.TestCheckResourceAttr("vercel_project.test", "build_machine_type", "enhanced"),
 				),
@@ -900,6 +902,7 @@ resource "vercel_project" "test" {
   enable_preview_feedback = false
   enable_production_feedback = true
   preview_deployments_disabled = false
+  protected_sourcemaps = false
 }
 `, projectSuffix)
 }
@@ -1209,6 +1212,7 @@ resource "vercel_project" "test" {
   git_lfs = true
   function_failover = true
   customer_success_code_visibility = true
+  protected_sourcemaps = true
   git_fork_protection = true
   prioritise_production_builds = true
   directory_listing = true

--- a/vercel/resource_project_unit_test.go
+++ b/vercel/resource_project_unit_test.go
@@ -24,6 +24,40 @@ func TestProjectRequiresUpdateAfterCreationOnlyForConfiguredFields(t *testing.T)
 	}
 }
 
+func TestProjectRequiresUpdateAfterCreationForProtectedSourcemaps(t *testing.T) {
+	project := projectForUpdateRequestTests()
+	project.ProtectedSourcemaps = types.BoolValue(false)
+
+	if !project.RequiresUpdateAfterCreation() {
+		t.Fatal("RequiresUpdateAfterCreation() = false, want true for configured protected_sourcemaps")
+	}
+}
+
+func TestProjectProtectedSourcemapsToUpdateProjectRequest(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name  string
+		value bool
+	}{
+		{name: "enabled", value: true},
+		{name: "disabled", value: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			project := projectForUpdateRequestTests()
+			project.ProtectedSourcemaps = types.BoolValue(tc.value)
+
+			request, diags := project.toUpdateProjectRequest(ctx, project.Name.ValueString())
+			if diags.HasError() {
+				t.Fatalf("toUpdateProjectRequest() returned diagnostics: %v", diags)
+			}
+			if request.ProtectedSourcemaps != tc.value {
+				t.Fatalf("ProtectedSourcemaps = %v, want %v", request.ProtectedSourcemaps, tc.value)
+			}
+		})
+	}
+}
+
 func TestProjectTrustedSourcesToUpdateProjectRequest(t *testing.T) {
 	ctx := context.Background()
 	project := projectForUpdateRequestTests()

--- a/vercel/resource_project_unit_test.go
+++ b/vercel/resource_project_unit_test.go
@@ -114,6 +114,7 @@ func projectForUpdateRequestTests() Project {
 		GitLFS:                            types.BoolUnknown(),
 		FunctionFailover:                  types.BoolUnknown(),
 		CustomerSuccessCodeVisibility:     types.BoolUnknown(),
+		ProtectedSourcemaps:               types.BoolUnknown(),
 		GitForkProtection:                 types.BoolValue(true),
 		PrioritiseProductionBuilds:        types.BoolUnknown(),
 		DirectoryListing:                  types.BoolUnknown(),


### PR DESCRIPTION
Adds protected_sourcemaps support for projects with tests and generated docs.\n\nIncludes acceptance coverage for resource update/data source read, plus a bool-state fix for project update responses that omit configured bool fields.\n\nValidated with targeted unit tests, project acceptance tests, and task lint.