### PR TITLE
Fix main acceptance compat tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,9 +156,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubuntu-tf-1.4
+          - name: ubuntu-tf-1.11
             os: ubuntu-latest
-            terraform: "1.4.*"
+            terraform: "1.11.*"
           - name: windows-tf-1.14
             os: windows-latest
             terraform: "1.14.*"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Requirements
 
-- [Terraform](https://developer.hashicorp.com/terraform/install) 1.1 or higher
+- [Terraform](https://developer.hashicorp.com/terraform/install) 1.11 or higher
 - [Go](https://golang.org/doc/install) 1.26 (to build the provider plugin)
 - [GoReleaser](https://goreleaser.com/install)
 - [Task](https://taskfile.dev/installation) v3 (to run Taskfile commands)

--- a/vercel/data_source_blob_object_test.go
+++ b/vercel/data_source_blob_object_test.go
@@ -47,7 +47,7 @@ resource "vercel_blob_store" "test" {
 resource "vercel_blob_object" "test" {
   store_id              = vercel_blob_store.test.id
   pathname              = "terraform/data-source.txt"
-  source                = "%s"
+  source                = %s
   content_type          = "text/plain"
   cache_control_max_age = 3600
 }
@@ -59,5 +59,5 @@ data "vercel_blob_object" "test" {
     vercel_blob_object.test,
   ]
 }
-`, storeName, source)
+`, storeName, hclStringLiteral(source))
 }

--- a/vercel/data_source_deployment_test.go
+++ b/vercel/data_source_deployment_test.go
@@ -168,7 +168,7 @@ resource "vercel_project" "test" {
 }
 
 data "vercel_project_directory" "test" {
-  path = "%[3]s"
+  path = %[3]s
 }
 
 resource "vercel_deployment" "test" {
@@ -184,7 +184,7 @@ data "vercel_deployment" "by_id" {
 data "vercel_deployment" "by_url" {
   id = vercel_deployment.test.url
 }
-`, name, testGithubRepo(t), filepath.Clean(repoDir))
+`, name, testGithubRepo(t), hclStringLiteral(filepath.Clean(repoDir)))
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/vercel/provider_test.go
+++ b/vercel/provider_test.go
@@ -3,6 +3,7 @@ package vercel_test
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -39,6 +40,10 @@ provider "vercel" {
 
 %[2]s
 `, team, config)
+}
+
+func hclStringLiteral(value string) string {
+	return strconv.Quote(value)
 }
 
 func apiToken(t *testing.T) string {

--- a/vercel/resource_blob_object_test.go
+++ b/vercel/resource_blob_object_test.go
@@ -77,11 +77,11 @@ resource "vercel_blob_store" "test" {
 resource "vercel_blob_object" "test" {
   store_id              = vercel_blob_store.test.id
   pathname              = "terraform/object.txt"
-  source                = "%s"
+  source                = %s
   content_type          = "text/plain"
   cache_control_max_age = 3600
 }
-`, storeName, source)
+`, storeName, hclStringLiteral(source))
 }
 
 func testAccBlobObjectResourceUpdatedConfig(storeName, source string) string {
@@ -93,11 +93,11 @@ resource "vercel_blob_store" "test" {
 resource "vercel_blob_object" "test" {
   store_id              = vercel_blob_store.test.id
   pathname              = "terraform/object.txt"
-  source                = "%s"
+  source                = %s
   content_type          = "text/plain"
   cache_control_max_age = 7200
 }
-`, storeName, source)
+`, storeName, hclStringLiteral(source))
 }
 
 func testCheckBlobObjectExists(testClient *client.Client, teamID, resourceName string) resource.TestCheckFunc {

--- a/vercel/resource_deployment_test.go
+++ b/vercel/resource_deployment_test.go
@@ -549,7 +549,7 @@ resource "vercel_project" "test" {
 }
 
 data "vercel_project_directory" "test" {
-  path = "%[3]s"
+  path = %[3]s
 }
 
 resource "vercel_deployment" "test" {
@@ -566,7 +566,7 @@ data "vercel_deployment" "by_id" {
 data "vercel_deployment" "by_url" {
   id = vercel_deployment.test.url
 }
-`, projectSuffix, testGithubRepo(t), filepath.Clean(repoDir))
+`, projectSuffix, testGithubRepo(t), hclStringLiteral(filepath.Clean(repoDir)))
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -607,7 +607,7 @@ resource "vercel_project" "test" {
 }
 
 data "vercel_project_directory" "test" {
-  path = "%[2]s"
+  path = %[2]s
 }
 
 resource "vercel_deployment" "test" {
@@ -615,7 +615,7 @@ resource "vercel_deployment" "test" {
   files       = data.vercel_project_directory.test.files
   path_prefix = data.vercel_project_directory.test.path
 }
-`, projectSuffix, filepath.Clean(tmpDir))
+`, projectSuffix, hclStringLiteral(filepath.Clean(tmpDir)))
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,


### PR DESCRIPTION
## Summary

- bump the oldest full-suite Terraform compat job from 1.4 to 1.11
- update the README minimum Terraform version to match write-only attribute support
- quote dynamically generated HCL path strings so Windows acceptance tests do not treat backslashes as escapes

## Root cause

The provider now exposes write-only `value_wo` attributes, which Terraform only supports in 1.11 and later. The full acceptance compat job still ran against Terraform 1.4, so the `value_wo` tests failed before apply.

The Windows compat job also embedded raw Windows paths in quoted HCL strings. Terraform parsed backslashes like `\a`, `\v`, and `\U` as escape sequences, causing plan-time failures in blob object and deployment tests.

## Validation

- `git diff --check`
- `env GOCACHE=/private/tmp/terraform-provider-vercel-go-build go test ./... -skip '^TestAcc_'`
