### PR TITLE
feat: add protected_sourcemaps

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -207,6 +207,7 @@ type ProjectResponse struct {
 	GitForkProtection                    bool                        `json:"gitForkProtection"`
 	ProductionDeploymentsFastLane        bool                        `json:"productionDeploymentsFastLane"`
 	DirectoryListing                     bool                        `json:"directoryListing"`
+	ProtectedSourcemaps                  bool                        `json:"protectedSourcemaps"`
 	SkewProtectionMaxAge                 int                         `json:"skewProtectionMaxAge"`
 	GitComments                          *GitComments                `json:"gitComments"`
 	GitProviderOptions                   *GitProviderOptionsResponse `json:"gitProviderOptions"`
@@ -372,6 +373,7 @@ type UpdateProjectRequest struct {
 	GitForkProtection                    bool                            `json:"gitForkProtection"`
 	ProductionDeploymentsFastLane        bool                            `json:"productionDeploymentsFastLane"`
 	DirectoryListing                     bool                            `json:"directoryListing"`
+	ProtectedSourcemaps                  bool                            `json:"protectedSourcemaps"`
 	SkewProtectionMaxAge                 int                             `json:"skewProtectionMaxAge"`
 	GitComments                          *GitComments                    `json:"gitComments"`
 	GitProviderOptions                   *GitProviderOptions             `json:"gitProviderOptions,omitempty"`

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -68,6 +68,7 @@ data "vercel_project" "example" {
 - `preview_deployment_suffix` (String) The preview deployment suffix to apply to preview deployment URLs for this project.
 - `preview_deployments_disabled` (Boolean) Whether Preview Deployments are disabled for this project.
 - `prioritise_production_builds` (Boolean) If enabled, builds for the Production environment will be prioritized over Preview environments.
+- `protected_sourcemaps` (Boolean) Specifies whether sourcemaps are protected and require authentication to access.
 - `protection_bypass_for_automation` (Boolean, Deprecated) Allows automation services to bypass Deployment Protection on this project when using an HTTP header named `x-vercel-protection-bypass` with a value from `protection_bypass_for_automation_secret`. Deprecated: use the `vercel_project_protection_bypass` resource instead.
 - `protection_bypass_for_automation_secret` (List of String, Sensitive, Deprecated) The automation bypass secrets for this project. Use each value as the `x-vercel-protection-bypass` header. Deprecated: use the `vercel_project_protection_bypass` resource instead.
 - `public_source` (Boolean, Deprecated) Deprecated. The public source feature has been removed from Vercel; this attribute is no longer populated.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -44,8 +44,9 @@ resource "vercel_project" "with_git" {
 # Deployments will need to be created manually through
 # terraform, or via the vercel CLI.
 resource "vercel_project" "example" {
-  name      = "example-project"
-  framework = "nextjs"
+  name                 = "example-project"
+  framework            = "nextjs"
+  protected_sourcemaps = true
 }
 
 locals {
@@ -131,6 +132,7 @@ resource "vercel_project" "with_trusted_sources" {
 - `preview_deployment_suffix` (String) The preview deployment suffix to apply to preview deployment URLs for this project. If not set, Vercel's default suffix will be used.
 - `preview_deployments_disabled` (Boolean) Disable creation of Preview Deployments for this project.
 - `prioritise_production_builds` (Boolean) If enabled, builds for the Production environment will be prioritized over Preview environments.
+- `protected_sourcemaps` (Boolean) Specifies whether sourcemaps are protected and require authentication to access.
 - `public_source` (Boolean, Deprecated) Deprecated. The public source feature has been removed from Vercel; this attribute no longer has any effect.
 - `resource_config` (Attributes) Resource Configuration for the project. (see [below for nested schema](#nestedatt--resource_config))
 - `root_directory` (String) The name of a directory or relative path to the source code of your project. If omitted, it will default to the project root.

--- a/examples/resources/vercel_project/resource.tf
+++ b/examples/resources/vercel_project/resource.tf
@@ -15,8 +15,9 @@ resource "vercel_project" "with_git" {
 # Deployments will need to be created manually through
 # terraform, or via the vercel CLI.
 resource "vercel_project" "example" {
-  name      = "example-project"
-  framework = "nextjs"
+  name                 = "example-project"
+  framework            = "nextjs"
+  protected_sourcemaps = true
 }
 
 locals {

--- a/vercel/data_source_project.go
+++ b/vercel/data_source_project.go
@@ -447,6 +447,10 @@ For more detailed information, please see the [Vercel documentation](https://ver
 				Computed:    true,
 				Description: "Allows Vercel Customer Support to inspect all Deployments' source code in this project to assist with debugging.",
 			},
+			"protected_sourcemaps": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Specifies whether sourcemaps are protected and require authentication to access.",
+			},
 			"git_fork_protection": schema.BoolAttribute{
 				Computed:    true,
 				Description: "Ensures that pull requests targeting your Git repository must be authorized by a member of your Team before deploying if your Project has Environment Variables or if the pull request includes a change to vercel.json.",
@@ -566,6 +570,7 @@ type ProjectDataSource struct {
 	GitLFS                              types.Bool   `tfsdk:"git_lfs"`
 	FunctionFailover                    types.Bool   `tfsdk:"function_failover"`
 	CustomerSuccessCodeVisibility       types.Bool   `tfsdk:"customer_success_code_visibility"`
+	ProtectedSourcemaps                 types.Bool   `tfsdk:"protected_sourcemaps"`
 	GitForkProtection                   types.Bool   `tfsdk:"git_fork_protection"`
 	PrioritiseProductionBuilds          types.Bool   `tfsdk:"prioritise_production_builds"`
 	DirectoryListing                    types.Bool   `tfsdk:"directory_listing"`
@@ -666,6 +671,7 @@ func convertResponseToProjectDataSource(ctx context.Context, response client.Pro
 		GitLFS:                              project.GitLFS,
 		FunctionFailover:                    project.FunctionFailover,
 		CustomerSuccessCodeVisibility:       project.CustomerSuccessCodeVisibility,
+		ProtectedSourcemaps:                 project.ProtectedSourcemaps,
 		GitForkProtection:                   project.GitForkProtection,
 		PrioritiseProductionBuilds:          project.PrioritiseProductionBuilds,
 		DirectoryListing:                    project.DirectoryListing,

--- a/vercel/data_source_project_test.go
+++ b/vercel/data_source_project_test.go
@@ -53,6 +53,7 @@ func TestAcc_ProjectDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vercel_project.test", "git_lfs", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "function_failover", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "customer_success_code_visibility", "true"),
+					resource.TestCheckResourceAttr("data.vercel_project.test", "protected_sourcemaps", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "git_fork_protection", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "prioritise_production_builds", "true"),
 					resource.TestCheckResourceAttr("data.vercel_project.test", "directory_listing", "true"),
@@ -102,7 +103,6 @@ resource "vercel_project" "test" {
   framework = "nextjs"
   install_command = "npm install"
   output_directory = ".output"
-  public_source = true
   root_directory = "ui/src"
   preview_deployments_disabled = true
   vercel_authentication = {
@@ -147,6 +147,7 @@ resource "vercel_project" "test" {
   git_lfs = true
   function_failover = true
   customer_success_code_visibility = true
+  protected_sourcemaps = true
   git_fork_protection = true
   prioritise_production_builds = true
   directory_listing = true

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -619,6 +619,12 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()},
 				Description:   "Allows Vercel Customer Support to inspect all Deployments' source code in this project to assist with debugging.",
 			},
+			"protected_sourcemaps": schema.BoolAttribute{
+				Optional:      true,
+				Computed:      true,
+				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseNonNullStateForUnknown()},
+				Description:   "Specifies whether sourcemaps are protected and require authentication to access.",
+			},
 			"git_fork_protection": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
@@ -795,6 +801,7 @@ type Project struct {
 	GitLFS                            types.Bool   `tfsdk:"git_lfs"`
 	FunctionFailover                  types.Bool   `tfsdk:"function_failover"`
 	CustomerSuccessCodeVisibility     types.Bool   `tfsdk:"customer_success_code_visibility"`
+	ProtectedSourcemaps               types.Bool   `tfsdk:"protected_sourcemaps"`
 	GitForkProtection                 types.Bool   `tfsdk:"git_fork_protection"`
 	PrioritiseProductionBuilds        types.Bool   `tfsdk:"prioritise_production_builds"`
 	DirectoryListing                  types.Bool   `tfsdk:"directory_listing"`
@@ -833,6 +840,7 @@ func (p Project) RequiresUpdateAfterCreation() bool {
 		knownBool(p.GitLFS) ||
 		knownBool(p.FunctionFailover) ||
 		knownBool(p.CustomerSuccessCodeVisibility) ||
+		knownBool(p.ProtectedSourcemaps) ||
 		(knownBool(p.GitForkProtection) && !p.GitForkProtection.ValueBool()) ||
 		knownBool(p.PrioritiseProductionBuilds) ||
 		knownBool(p.DirectoryListing) ||
@@ -1174,6 +1182,7 @@ func (p *Project) toUpdateProjectRequest(ctx context.Context, oldName string) (r
 		GitLFS:                               p.GitLFS.ValueBool(),
 		ServerlessFunctionZeroConfigFailover: p.FunctionFailover.ValueBool(),
 		CustomerSupportCodeVisibility:        p.CustomerSuccessCodeVisibility.ValueBool(),
+		ProtectedSourcemaps:                  p.ProtectedSourcemaps.ValueBool(),
 		GitForkProtection:                    p.GitForkProtection.ValueBool(),
 		ProductionDeploymentsFastLane:        p.PrioritiseProductionBuilds.ValueBool(),
 		DirectoryListing:                     p.DirectoryListing.ValueBool(),
@@ -2168,6 +2177,7 @@ func convertResponseToProject(ctx context.Context, response client.ProjectRespon
 		GitLFS:                            types.BoolValue(response.GitLFS),
 		FunctionFailover:                  types.BoolValue(response.ServerlessFunctionZeroConfigFailover),
 		CustomerSuccessCodeVisibility:     types.BoolValue(response.CustomerSupportCodeVisibility),
+		ProtectedSourcemaps:               types.BoolValue(response.ProtectedSourcemaps),
 		GitForkProtection:                 types.BoolValue(response.GitForkProtection),
 		PrioritiseProductionBuilds:        types.BoolValue(response.ProductionDeploymentsFastLane),
 		DirectoryListing:                  types.BoolValue(response.DirectoryListing),

--- a/vercel/resource_project_read_unit_test.go
+++ b/vercel/resource_project_read_unit_test.go
@@ -86,6 +86,22 @@ func TestConvertResponseToProjectHandlesMissingResourceConfigAndBranchSensitiveE
 	}
 }
 
+func TestConvertResponseToProjectProtectedSourcemaps(t *testing.T) {
+	ctx := context.Background()
+	result, err := convertResponseToProject(ctx, client.ProjectResponse{
+		ID:                  "prj_123",
+		Name:                "example",
+		TeamID:              "team_123",
+		ProtectedSourcemaps: true,
+	}, projectForReadTests(), nil)
+	if err != nil {
+		t.Fatalf("convertResponseToProject() returned error: %v", err)
+	}
+	if !result.ProtectedSourcemaps.ValueBool() {
+		t.Fatal("ProtectedSourcemaps = false, want true")
+	}
+}
+
 func TestConvertResponseToProjectTrustedSources(t *testing.T) {
 	ctx := context.Background()
 	projectLabel := "Source project"

--- a/vercel/resource_project_test.go
+++ b/vercel/resource_project_test.go
@@ -83,6 +83,7 @@ func TestAcc_Project(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_project.test", "git_lfs", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "function_failover", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "customer_success_code_visibility", "true"),
+					resource.TestCheckResourceAttr("vercel_project.test", "protected_sourcemaps", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "git_fork_protection", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "prioritise_production_builds", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "directory_listing", "true"),
@@ -114,6 +115,7 @@ func TestAcc_Project(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_project.test", "enable_preview_feedback", "false"),
 					resource.TestCheckResourceAttr("vercel_project.test", "enable_production_feedback", "true"),
 					resource.TestCheckResourceAttr("vercel_project.test", "preview_deployments_disabled", "false"),
+					resource.TestCheckResourceAttr("vercel_project.test", "protected_sourcemaps", "false"),
 					resource.TestCheckResourceAttr("vercel_project.test", "on_demand_concurrent_builds", "false"),
 					resource.TestCheckResourceAttr("vercel_project.test", "build_machine_type", "enhanced"),
 				),
@@ -903,6 +905,7 @@ resource "vercel_project" "test" {
   enable_preview_feedback = false
   enable_production_feedback = true
   preview_deployments_disabled = false
+  protected_sourcemaps = false
 }
 `, projectSuffix)
 }
@@ -1212,6 +1215,7 @@ resource "vercel_project" "test" {
   git_lfs = true
   function_failover = true
   customer_success_code_visibility = true
+  protected_sourcemaps = true
   git_fork_protection = true
   prioritise_production_builds = true
   directory_listing = true

--- a/vercel/resource_project_unit_test.go
+++ b/vercel/resource_project_unit_test.go
@@ -24,6 +24,40 @@ func TestProjectRequiresUpdateAfterCreationOnlyForConfiguredFields(t *testing.T)
 	}
 }
 
+func TestProjectRequiresUpdateAfterCreationForProtectedSourcemaps(t *testing.T) {
+	project := projectForUpdateRequestTests()
+	project.ProtectedSourcemaps = types.BoolValue(false)
+
+	if !project.RequiresUpdateAfterCreation() {
+		t.Fatal("RequiresUpdateAfterCreation() = false, want true for configured protected_sourcemaps")
+	}
+}
+
+func TestProjectProtectedSourcemapsToUpdateProjectRequest(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name  string
+		value bool
+	}{
+		{name: "enabled", value: true},
+		{name: "disabled", value: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			project := projectForUpdateRequestTests()
+			project.ProtectedSourcemaps = types.BoolValue(tc.value)
+
+			request, diags := project.toUpdateProjectRequest(ctx, project.Name.ValueString())
+			if diags.HasError() {
+				t.Fatalf("toUpdateProjectRequest() returned diagnostics: %v", diags)
+			}
+			if request.ProtectedSourcemaps != tc.value {
+				t.Fatalf("ProtectedSourcemaps = %v, want %v", request.ProtectedSourcemaps, tc.value)
+			}
+		})
+	}
+}
+
 func TestProjectTrustedSourcesToUpdateProjectRequest(t *testing.T) {
 	ctx := context.Background()
 	project := projectForUpdateRequestTests()
@@ -114,6 +148,7 @@ func projectForUpdateRequestTests() Project {
 		GitLFS:                            types.BoolUnknown(),
 		FunctionFailover:                  types.BoolUnknown(),
 		CustomerSuccessCodeVisibility:     types.BoolUnknown(),
+		ProtectedSourcemaps:               types.BoolUnknown(),
 		GitForkProtection:                 types.BoolValue(true),
 		PrioritiseProductionBuilds:        types.BoolUnknown(),
 		DirectoryListing:                  types.BoolUnknown(),


### PR DESCRIPTION
Adds protected_sourcemaps support for projects with acceptance/unit coverage and generated docs.\n\nThis branch is based on latest main so CI can run the full suite with repository secrets.\n\nValidated locally with docs generation, targeted unit tests, lint, and project acceptance tests.