### PR TITLE
Expose verification records on vercel_project_domain

### DIFF
--- a/client/project_domain.go
+++ b/client/project_domain.go
@@ -43,7 +43,7 @@ func (c *Client) CreateProjectDomain(ctx context.Context, projectID, teamID stri
 
 // DeleteProjectDomain removes any association of a domain name with a Vercel project.
 func (c *Client) DeleteProjectDomain(ctx context.Context, projectID, domain, teamID string) error {
-	url := fmt.Sprintf("%s/v8/projects/%s/domains/%s", c.baseURL, projectID, domain)
+	url := fmt.Sprintf("%s/v9/projects/%s/domains/%s", c.baseURL, projectID, domain)
 	if c.TeamID(teamID) != "" {
 		url = fmt.Sprintf("%s?teamId=%s", url, c.TeamID(teamID))
 	}
@@ -59,21 +59,32 @@ func (c *Client) DeleteProjectDomain(ctx context.Context, projectID, domain, tea
 	}, nil)
 }
 
+// ProjectDomainVerification describes a DNS challenge that must be satisfied to
+// verify ownership of a project domain.
+type ProjectDomainVerification struct {
+	Type   string `json:"type"`
+	Domain string `json:"domain"`
+	Value  string `json:"value"`
+	Reason string `json:"reason"`
+}
+
 // ProjectDomainResponse defines the information that Vercel exposes about a domain that is
 // associated with a vercel project.
 type ProjectDomainResponse struct {
-	Name                string  `json:"name"`
-	ProjectID           string  `json:"projectId"`
-	TeamID              string  `json:"-"`
-	Redirect            *string `json:"redirect"`
-	RedirectStatusCode  *int64  `json:"redirectStatusCode"`
-	GitBranch           *string `json:"gitBranch"`
-	CustomEnvironmentID *string `json:"customEnvironmentId"`
+	Name                string                      `json:"name"`
+	ProjectID           string                      `json:"projectId"`
+	TeamID              string                      `json:"-"`
+	Redirect            *string                     `json:"redirect"`
+	RedirectStatusCode  *int64                      `json:"redirectStatusCode"`
+	GitBranch           *string                     `json:"gitBranch"`
+	CustomEnvironmentID *string                     `json:"customEnvironmentId"`
+	Verified            bool                        `json:"verified"`
+	Verification        []ProjectDomainVerification `json:"verification"`
 }
 
 // GetProjectDomain retrieves information about a project domain from Vercel.
 func (c *Client) GetProjectDomain(ctx context.Context, projectID, domain, teamID string) (r ProjectDomainResponse, err error) {
-	url := fmt.Sprintf("%s/v8/projects/%s/domains/%s", c.baseURL, projectID, domain)
+	url := fmt.Sprintf("%s/v9/projects/%s/domains/%s", c.baseURL, projectID, domain)
 	if c.TeamID(teamID) != "" {
 		url = fmt.Sprintf("%s?teamId=%s", url, c.TeamID(teamID))
 	}
@@ -101,7 +112,7 @@ type UpdateProjectDomainRequest struct {
 
 // UpdateProjectDomain updates an existing project domain within Vercel.
 func (c *Client) UpdateProjectDomain(ctx context.Context, projectID, domain, teamID string, request UpdateProjectDomainRequest) (r ProjectDomainResponse, err error) {
-	url := fmt.Sprintf("%s/v8/projects/%s/domains/%s", c.baseURL, projectID, domain)
+	url := fmt.Sprintf("%s/v9/projects/%s/domains/%s", c.baseURL, projectID, domain)
 	if c.TeamID(teamID) != "" {
 		url = fmt.Sprintf("%s?teamId=%s", url, c.TeamID(teamID))
 	}

--- a/docs/resources/project_domain.md
+++ b/docs/resources/project_domain.md
@@ -60,6 +60,18 @@ resource "vercel_project_domain" "example_redirect" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `verification` (Attributes List) A list of verification challenges, one of which must be completed to verify the domain for use on the project. Once the challenge is satisfied, the domain will be verified automatically on the next refresh. Typically used to configure DNS records (e.g. a `TXT` record) for domains hosted with an external DNS provider. (see [below for nested schema](#nestedatt--verification))
+- `verified` (Boolean) Whether the domain is verified for use with the project. If `false`, the challenges in `verification` must be completed before the domain will serve traffic for the project.
+
+<a id="nestedatt--verification"></a>
+### Nested Schema for `verification`
+
+Read-Only:
+
+- `domain` (String) The domain name on which the DNS record must be created.
+- `reason` (String) A human-readable explanation of why this challenge was issued.
+- `type` (String) The type of DNS record that must be created to satisfy the challenge (e.g. `TXT`).
+- `value` (String) The value that the DNS record must contain.
 
 ## Import
 

--- a/vercel/resource_project_domain.go
+++ b/vercel/resource_project_domain.go
@@ -113,23 +113,71 @@ By default, Project Domains will be automatically applied to any ` + "`productio
 					),
 				},
 			},
+			"verified": schema.BoolAttribute{
+				Description: "Whether the domain is verified for use with the project. If `false`, the challenges in `verification` must be completed before the domain will serve traffic for the project.",
+				Computed:    true,
+			},
+			"verification": schema.ListNestedAttribute{
+				Description: "A list of verification challenges, one of which must be completed to verify the domain for use on the project. Once the challenge is satisfied, the domain will be verified automatically on the next refresh. Typically used to configure DNS records (e.g. a `TXT` record) for domains hosted with an external DNS provider.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"type": schema.StringAttribute{
+							Description: "The type of DNS record that must be created to satisfy the challenge (e.g. `TXT`).",
+							Computed:    true,
+						},
+						"domain": schema.StringAttribute{
+							Description: "The domain name on which the DNS record must be created.",
+							Computed:    true,
+						},
+						"value": schema.StringAttribute{
+							Description: "The value that the DNS record must contain.",
+							Computed:    true,
+						},
+						"reason": schema.StringAttribute{
+							Description: "A human-readable explanation of why this challenge was issued.",
+							Computed:    true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
 
+// ProjectDomainVerification mirrors a single verification challenge returned by the Vercel API.
+type ProjectDomainVerification struct {
+	Type   types.String `tfsdk:"type"`
+	Domain types.String `tfsdk:"domain"`
+	Value  types.String `tfsdk:"value"`
+	Reason types.String `tfsdk:"reason"`
+}
+
 // ProjectDomain reflects the state terraform stores internally for a project domain.
 type ProjectDomain struct {
-	Domain              types.String `tfsdk:"domain"`
-	GitBranch           types.String `tfsdk:"git_branch"`
-	CustomEnvironmentID types.String `tfsdk:"custom_environment_id"`
-	ID                  types.String `tfsdk:"id"`
-	ProjectID           types.String `tfsdk:"project_id"`
-	Redirect            types.String `tfsdk:"redirect"`
-	RedirectStatusCode  types.Int64  `tfsdk:"redirect_status_code"`
-	TeamID              types.String `tfsdk:"team_id"`
+	Domain              types.String                `tfsdk:"domain"`
+	GitBranch           types.String                `tfsdk:"git_branch"`
+	CustomEnvironmentID types.String                `tfsdk:"custom_environment_id"`
+	ID                  types.String                `tfsdk:"id"`
+	ProjectID           types.String                `tfsdk:"project_id"`
+	Redirect            types.String                `tfsdk:"redirect"`
+	RedirectStatusCode  types.Int64                 `tfsdk:"redirect_status_code"`
+	TeamID              types.String                `tfsdk:"team_id"`
+	Verified            types.Bool                  `tfsdk:"verified"`
+	Verification        []ProjectDomainVerification `tfsdk:"verification"`
 }
 
 func convertResponseToProjectDomain(response client.ProjectDomainResponse) ProjectDomain {
+	verification := make([]ProjectDomainVerification, 0, len(response.Verification))
+	for _, v := range response.Verification {
+		verification = append(verification, ProjectDomainVerification{
+			Type:   types.StringValue(v.Type),
+			Domain: types.StringValue(v.Domain),
+			Value:  types.StringValue(v.Value),
+			Reason: types.StringValue(v.Reason),
+		})
+	}
+
 	return ProjectDomain{
 		Domain:              types.StringValue(response.Name),
 		GitBranch:           types.StringPointerValue(response.GitBranch),
@@ -139,6 +187,8 @@ func convertResponseToProjectDomain(response client.ProjectDomainResponse) Proje
 		Redirect:            types.StringPointerValue(response.Redirect),
 		RedirectStatusCode:  types.Int64PointerValue(response.RedirectStatusCode),
 		TeamID:              toTeamID(response.TeamID),
+		Verified:            types.BoolValue(response.Verified),
+		Verification:        verification,
 	}
 }
 

--- a/vercel/resource_project_domain_test.go
+++ b/vercel/resource_project_domain_test.go
@@ -40,6 +40,8 @@ func TestAcc_ProjectDomain(t *testing.T) {
 					testAccProjectDomainExists(testClient(t), "vercel_project.test", testTeam(t), "2"+domain),
 					testTeamID,
 					resource.TestCheckResourceAttr("vercel_project_domain.test", "domain", "2"+domain),
+					resource.TestCheckResourceAttrSet("vercel_project_domain.test", "verified"),
+					resource.TestCheckResourceAttrSet("vercel_project_domain.test", "verification.#"),
 				),
 			},
 			// Update testing

--- a/vercel/resource_project_domain_unit_test.go
+++ b/vercel/resource_project_domain_unit_test.go
@@ -1,0 +1,54 @@
+package vercel
+
+import (
+	"testing"
+
+	"github.com/vercel/terraform-provider-vercel/v5/client"
+)
+
+func TestConvertResponseToProjectDomainIncludesVerification(t *testing.T) {
+	redirectStatusCode := int64(308)
+	redirect := "example.com"
+	gitBranch := "main"
+	customEnvironmentID := "env_123"
+
+	result := convertResponseToProjectDomain(client.ProjectDomainResponse{
+		Name:                "www.example.com",
+		ProjectID:           "prj_123",
+		TeamID:              "team_123",
+		Redirect:            &redirect,
+		RedirectStatusCode:  &redirectStatusCode,
+		GitBranch:           &gitBranch,
+		CustomEnvironmentID: &customEnvironmentID,
+		Verified:            false,
+		Verification: []client.ProjectDomainVerification{
+			{
+				Type:   "TXT",
+				Domain: "_vercel.www.example.com",
+				Value:  "vc-domain-verify=www.example.com,abc123",
+				Reason: "pending_domain_verification",
+			},
+		},
+	})
+
+	if got := result.Verified.ValueBool(); got {
+		t.Fatalf("Verified = %t, want false", got)
+	}
+	if len(result.Verification) != 1 {
+		t.Fatalf("len(Verification) = %d, want 1", len(result.Verification))
+	}
+
+	verification := result.Verification[0]
+	if got := verification.Type.ValueString(); got != "TXT" {
+		t.Fatalf("Verification[0].Type = %q, want TXT", got)
+	}
+	if got := verification.Domain.ValueString(); got != "_vercel.www.example.com" {
+		t.Fatalf("Verification[0].Domain = %q, want _vercel.www.example.com", got)
+	}
+	if got := verification.Value.ValueString(); got != "vc-domain-verify=www.example.com,abc123" {
+		t.Fatalf("Verification[0].Value = %q, want vc-domain-verify=www.example.com,abc123", got)
+	}
+	if got := verification.Reason.ValueString(); got != "pending_domain_verification" {
+		t.Fatalf("Verification[0].Reason = %q, want pending_domain_verification", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds computed `verified` and `verification` attributes to the `vercel_project_domain` resource so users can provision external DNS verification records.
- Updates project-domain GET/PATCH/DELETE client calls from `v8` to `v9`, which is the documented API version for the verification challenge flow.
- Regenerates provider docs and adds focused unit coverage for mapping verification challenges into Terraform state.

Refs #199.
Replaces #474.

## Validation

- `go test ./client ./vercel`
- `task lint`
- `task docs`
- `task build`