### PR TITLE
Deprecate project public_source field

### DIFF
--- a/client/project.go
+++ b/client/project.go
@@ -55,7 +55,6 @@ type CreateProjectRequest struct {
 	OIDCTokenConfig                   *OIDCTokenConfig      `json:"oidcTokenConfig,omitempty"`
 	OutputDirectory                   *string               `json:"outputDirectory"`
 	PreviewDeploymentSuffix           *string               `json:"previewDeploymentSuffix"`
-	PublicSource                      *bool                 `json:"publicSource"`
 	RootDirectory                     *string               `json:"rootDirectory"`
 	ServerlessFunctionRegion          string                `json:"serverlessFunctionRegion,omitempty"`
 	ResourceConfig                    *ResourceConfig       `json:"resourceConfig,omitempty"`

--- a/vercel/resource_project_read_unit_test.go
+++ b/vercel/resource_project_read_unit_test.go
@@ -102,6 +102,24 @@ func TestConvertResponseToProjectProtectedSourcemaps(t *testing.T) {
 	}
 }
 
+func TestConvertResponseToProjectKeepsDeprecatedPublicSourceFromPlan(t *testing.T) {
+	ctx := context.Background()
+	plan := projectForReadTests()
+	plan.PublicSource = types.BoolValue(true)
+
+	result, err := convertResponseToProject(ctx, client.ProjectResponse{
+		ID:     "prj_123",
+		Name:   "example",
+		TeamID: "team_123",
+	}, plan, nil)
+	if err != nil {
+		t.Fatalf("convertResponseToProject() returned error: %v", err)
+	}
+	if !result.PublicSource.ValueBool() {
+		t.Fatal("PublicSource = false/null, want configured true")
+	}
+}
+
 func TestConvertResponseToProjectTrustedSources(t *testing.T) {
 	ctx := context.Background()
 	projectLabel := "Source project"


### PR DESCRIPTION
## Summary

Deprecates the `vercel_project.public_source` and project data source `public_source` attributes now that Vercel no longer supports project-level public source/log visibility.

This also stops sending `publicSource` in create project payloads. For the resource, the deprecated Terraform value is preserved from config/state when reading so existing configurations do not hit perpetual diffs or inconsistent-result errors when the API omits the field.

## Root cause

`publicSource` was removed from the Projects API after the source/log visibility backfill. Older provider behavior still sent the field and expected it back, so `public_source = true` could apply successfully and then read back as null.

## Validation

- `env GOCACHE=/private/tmp/tpv-go-build-cache-public-source go test ./vercel -run 'TestConvertResponseToProject|TestProject|TestDataSourceProject'`
- `env GOCACHE=/private/tmp/tpv-go-build-cache-public-source go test ./client -run '^$'`

A broader `go test ./client ./vercel` was attempted before the rebase, but this sandbox cannot bind `httptest` ports and cannot access the local GPG agent for acceptance-style tests that create signed git commits.
