### PR TITLE
Add wait_for_ready to project domains

### DIFF
--- a/docs/resources/project_domain.md
+++ b/docs/resources/project_domain.md
@@ -30,6 +30,13 @@ resource "vercel_project_domain" "example" {
   domain     = "i-love.vercel.app"
 }
 
+# Wait for the domain to be verified before resources that depend on it run.
+resource "vercel_project_domain" "example_wait_for_ready" {
+  project_id     = vercel_project.example.id
+  domain         = "i-wait.vercel.app"
+  wait_for_ready = true
+}
+
 # A redirect of a domain name to a second domain name.
 # The status_code can optionally be controlled.
 resource "vercel_project_domain" "example_redirect" {
@@ -56,6 +63,7 @@ resource "vercel_project_domain" "example_redirect" {
 - `redirect` (String) The domain name that serves as a target destination for redirects.
 - `redirect_status_code` (Number) The HTTP status code to use when serving as a redirect.
 - `team_id` (String) The ID of the team the project exists under. Required when configuring a team resource if a default team has not been set in the provider.
+- `wait_for_ready` (Boolean) Wait until the project domain is verified before considering it created. This is useful when another resource, such as an alias, depends on the domain being ready immediately.
 
 ### Read-Only
 

--- a/examples/resources/vercel_project_domain/resource.tf
+++ b/examples/resources/vercel_project_domain/resource.tf
@@ -9,6 +9,13 @@ resource "vercel_project_domain" "example" {
   domain     = "i-love.vercel.app"
 }
 
+# Wait for the domain to be verified before resources that depend on it run.
+resource "vercel_project_domain" "example_wait_for_ready" {
+  project_id     = vercel_project.example.id
+  domain         = "i-wait.vercel.app"
+  wait_for_ready = true
+}
+
 # A redirect of a domain name to a second domain name.
 # The status_code can optionally be controlled.
 resource "vercel_project_domain" "example_redirect" {

--- a/vercel/resource_project_domain.go
+++ b/vercel/resource_project_domain.go
@@ -3,6 +3,7 @@ package vercel
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -16,6 +17,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/vercel/terraform-provider-vercel/v5/client"
+)
+
+const (
+	projectDomainReadyPollInterval = 5 * time.Second
+	projectDomainReadyTimeout      = 10 * time.Minute
 )
 
 var (
@@ -114,6 +120,10 @@ By default, Project Domains will be automatically applied to any ` + "`productio
 					),
 				},
 			},
+			"wait_for_ready": schema.BoolAttribute{
+				Description: "Wait until the project domain is verified before considering it created. This is useful when another resource, such as an alias, depends on the domain being ready immediately.",
+				Optional:    true,
+			},
 			"verified": schema.BoolAttribute{
 				Description: "Whether the domain is verified for use with the project. If `false`, the challenges in `verification` must be completed before the domain will serve traffic for the project.",
 				Computed:    true,
@@ -173,6 +183,7 @@ type ProjectDomain struct {
 	Redirect            types.String `tfsdk:"redirect"`
 	RedirectStatusCode  types.Int64  `tfsdk:"redirect_status_code"`
 	TeamID              types.String `tfsdk:"team_id"`
+	WaitForReady        types.Bool   `tfsdk:"wait_for_ready"`
 	Verified            types.Bool   `tfsdk:"verified"`
 	Verification        types.List   `tfsdk:"verification"`
 }
@@ -271,7 +282,23 @@ func (r *projectDomainResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	if plan.WaitForReady.ValueBool() {
+		out, err = r.waitForProjectDomainReady(ctx, plan.ProjectID.ValueString(), plan.Domain.ValueString(), plan.TeamID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error waiting for project domain",
+				fmt.Sprintf("Could not wait for domain %s for project %s to become verified: %s",
+					plan.Domain.ValueString(),
+					plan.ProjectID.ValueString(),
+					err,
+				),
+			)
+			return
+		}
+	}
+
 	result := convertResponseToProjectDomain(out)
+	result.WaitForReady = plan.WaitForReady
 	tflog.Info(ctx, "added domain to project", map[string]any{
 		"project_id": result.ProjectID.ValueString(),
 		"domain":     result.Domain.ValueString(),
@@ -313,6 +340,7 @@ func (r *projectDomainResource) Read(ctx context.Context, req resource.ReadReque
 	}
 
 	result := convertResponseToProjectDomain(out)
+	result.WaitForReady = state.WaitForReady
 	tflog.Info(ctx, "read project domain", map[string]any{
 		"project_id": result.ProjectID.ValueString(),
 		"domain":     result.Domain.ValueString(),
@@ -354,7 +382,23 @@ func (r *projectDomainResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	if plan.WaitForReady.ValueBool() {
+		out, err = r.waitForProjectDomainReady(ctx, plan.ProjectID.ValueString(), plan.Domain.ValueString(), plan.TeamID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error waiting for project domain",
+				fmt.Sprintf("Could not wait for domain %s for project %s to become verified: %s",
+					plan.Domain.ValueString(),
+					plan.ProjectID.ValueString(),
+					err,
+				),
+			)
+			return
+		}
+	}
+
 	result := convertResponseToProjectDomain(out)
+	result.WaitForReady = plan.WaitForReady
 	tflog.Info(ctx, "update project domain", map[string]any{
 		"project_id": result.ProjectID.ValueString(),
 		"domain":     result.Domain.ValueString(),
@@ -439,5 +483,35 @@ func (r *projectDomainResource) ImportState(ctx context.Context, req resource.Im
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+}
+
+func (r *projectDomainResource) waitForProjectDomainReady(ctx context.Context, projectID, domain, teamID string) (client.ProjectDomainResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, projectDomainReadyTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(projectDomainReadyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		out, err := r.client.GetProjectDomain(ctx, projectID, domain, teamID)
+		if err != nil {
+			return out, err
+		}
+		if out.Verified {
+			return out, nil
+		}
+
+		tflog.Info(ctx, "project domain is not verified yet", map[string]any{
+			"project_id": projectID,
+			"domain":     domain,
+			"team_id":    teamID,
+		})
+
+		select {
+		case <-ctx.Done():
+			return out, ctx.Err()
+		case <-ticker.C:
+		}
 	}
 }

--- a/vercel/resource_project_domain_test.go
+++ b/vercel/resource_project_domain_test.go
@@ -91,6 +91,23 @@ func TestAcc_ProjectDomainCustomEnvironment(t *testing.T) {
 	})
 }
 
+func TestAcc_ProjectDomainWaitForReady(t *testing.T) {
+	randomSuffix := acctest.RandString(16)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             noopDestroyCheck,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(testAccProjectDomainConfigWaitForReady(randomSuffix)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("vercel_project_domain.test", "wait_for_ready", "true"),
+					resource.TestCheckResourceAttrSet("vercel_project_domain.test", "custom_environment_id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccProjectDomainExists(testClient *client.Client, n, teamID, domain string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -229,6 +246,26 @@ resource "vercel_project_domain" "test" {
     domain = "test-acc-domain-%[1]s-foobar.vercel.app"
     project_id = vercel_project.test.id
     custom_environment_id = vercel_custom_environment.test.id
+}
+`, randomSuffix)
+}
+
+func testAccProjectDomainConfigWaitForReady(randomSuffix string) string {
+	return fmt.Sprintf(`
+resource "vercel_project" "test" {
+  name = "test-acc-domain-%[1]s"
+}
+
+resource "vercel_custom_environment" "test" {
+    name = "test-acc-custom-environment"
+    project_id = vercel_project.test.id
+}
+
+resource "vercel_project_domain" "test" {
+    domain = "test-acc-domain-%[1]s-wait.vercel.app"
+    project_id = vercel_project.test.id
+    custom_environment_id = vercel_custom_environment.test.id
+    wait_for_ready = true
 }
 `, randomSuffix)
 }


### PR DESCRIPTION
## Summary

Adds an optional `wait_for_ready` field to `vercel_project_domain`. When enabled, create/update waits for the Vercel project domain API to report `verified = true` before Terraform considers the resource ready.

Closes #287.

## Details

- Captures the project domain `verified` field in the client response.
- Reads project domains through the documented v9 endpoint so the verified readiness signal is available.
- Polls every 5 seconds, with a 10-minute cap, when `wait_for_ready = true`.
- Documents the new field and adds an example.
- Adds acceptance test coverage for a custom-environment project domain with `wait_for_ready = true`.

## Validation

- `GOCACHE=/tmp/terraform-provider-vercel-go-cache go test ./client ./vercel -run 'TestProjectDomain|TestAcc_ProjectDomainWaitForReady'`
- `GOCACHE=/tmp/terraform-provider-vercel-go-cache go test ./... -run '^$'`

Full runtime `go test ./...` was not completed in the sandbox because unrelated tests require local listener/GPG access; an unsandboxed run was rejected because it may perform git writes or create external resources.
