### PR TITLE
[codex] Handle pagination for client list methods

### DIFF
--- a/client/environment_variable.go
+++ b/client/environment_variable.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -364,16 +365,33 @@ func (c *Client) DeleteEnvironmentVariable(ctx context.Context, projectID, teamI
 	}, nil)
 }
 
-func (c *Client) GetEnvironmentVariables(ctx context.Context, projectID, teamID string) ([]EnvironmentVariable, error) {
-	url := fmt.Sprintf("%s/v8/projects/%s/env?decrypt=true", c.baseURL, projectID)
-	if c.TeamID(teamID) != "" {
-		url = fmt.Sprintf("%s&teamId=%s", url, c.TeamID(teamID))
-	}
+type ListEnvironmentVariablesRequest struct {
+	ProjectID string
+	TeamID    string
+	Limit     int
+	Until     *int64
+	Since     *int64
+}
 
-	envResponse := struct {
-		Env []EnvironmentVariable `json:"envs"`
+type ListEnvironmentVariablesResponse struct {
+	EnvironmentVariables []EnvironmentVariable
+	Pagination           PageInfo
+}
+
+func (c *Client) ListEnvironmentVariablesPage(ctx context.Context, request ListEnvironmentVariablesRequest) (ListEnvironmentVariablesResponse, error) {
+	baseURL := fmt.Sprintf("%s/v8/projects/%s/env", c.baseURL, request.ProjectID)
+	query := url.Values{}
+	query.Set("decrypt", "true")
+	if c.TeamID(request.TeamID) != "" {
+		query.Set("teamId", c.TeamID(request.TeamID))
+	}
+	url := urlWithQuery(baseURL, paginationQuery(query, request.Limit, request.Until, request.Since))
+
+	response := struct {
+		Env        []EnvironmentVariable `json:"envs"`
+		Pagination PageInfo              `json:"pagination"`
 	}{}
-	tflog.Info(ctx, "getting environment variables", map[string]any{
+	tflog.Info(ctx, "listing environment variables", map[string]any{
 		"url": url,
 	})
 	err := c.doRequest(clientRequest{
@@ -381,11 +399,26 @@ func (c *Client) GetEnvironmentVariables(ctx context.Context, projectID, teamID 
 		method: "GET",
 		url:    url,
 		body:   "",
-	}, &envResponse)
-	for i := 0; i < len(envResponse.Env); i++ {
-		envResponse.Env[i].TeamID = c.TeamID(teamID)
+	}, &response)
+	for i := 0; i < len(response.Env); i++ {
+		response.Env[i].TeamID = c.TeamID(request.TeamID)
 	}
-	return envResponse.Env, err
+	return ListEnvironmentVariablesResponse{
+		EnvironmentVariables: response.Env,
+		Pagination:           response.Pagination,
+	}, err
+}
+
+func (c *Client) GetEnvironmentVariables(ctx context.Context, projectID, teamID string) ([]EnvironmentVariable, error) {
+	return collectPages(func(until *int64) ([]EnvironmentVariable, PageInfo, error) {
+		response, err := c.ListEnvironmentVariablesPage(ctx, ListEnvironmentVariablesRequest{
+			ProjectID: projectID,
+			TeamID:    teamID,
+			Limit:     defaultPaginationLimit,
+			Until:     until,
+		})
+		return response.EnvironmentVariables, response.Pagination, err
+	})
 }
 
 // GetEnvironmentVariable gets a singluar environment variable from Vercel based on its ID.

--- a/client/pagination.go
+++ b/client/pagination.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+const defaultPaginationLimit = 100
+
+// PageInfo is the pagination metadata returned by Vercel list endpoints.
+type PageInfo struct {
+	Count int    `json:"count"`
+	Next  *int64 `json:"next"`
+	Prev  *int64 `json:"prev"`
+}
+
+func paginationLimit(limit int) int {
+	if limit > 0 {
+		return limit
+	}
+	return defaultPaginationLimit
+}
+
+func paginationQuery(values url.Values, limit int, until, since *int64) url.Values {
+	query := url.Values{}
+	for key, vals := range values {
+		query[key] = append([]string(nil), vals...)
+	}
+
+	query.Set("limit", strconv.Itoa(paginationLimit(limit)))
+	if until != nil {
+		query.Set("until", strconv.FormatInt(*until, 10))
+	}
+	if since != nil {
+		query.Set("since", strconv.FormatInt(*since, 10))
+	}
+	return query
+}
+
+func urlWithQuery(baseURL string, query url.Values) string {
+	if encoded := query.Encode(); encoded != "" {
+		return fmt.Sprintf("%s?%s", baseURL, encoded)
+	}
+	return baseURL
+}
+
+func collectPages[T any](fetch func(until *int64) ([]T, PageInfo, error)) ([]T, error) {
+	var all []T
+	var until *int64
+
+	for {
+		items, pagination, err := fetch(until)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, items...)
+
+		if pagination.Next == nil {
+			return all, nil
+		}
+		if until != nil && *pagination.Next == *until {
+			return nil, fmt.Errorf("pagination cursor did not advance")
+		}
+		until = pagination.Next
+	}
+}

--- a/client/pagination_test.go
+++ b/client/pagination_test.go
@@ -1,0 +1,227 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}
+
+func newPaginationTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	return New("token").WithBaseURL(server.URL)
+}
+
+func requireQuery(t *testing.T, r *http.Request, key, want string) {
+	t.Helper()
+
+	if got := r.URL.Query().Get(key); got != want {
+		t.Fatalf("query %q = %q, want %q", key, got, want)
+	}
+}
+
+func TestListEnvironmentVariablesPageExposesPagination(t *testing.T) {
+	client := newPaginationTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v8/projects/prj_123/env" {
+			t.Fatalf("path = %q, want /v8/projects/prj_123/env", r.URL.Path)
+		}
+		requireQuery(t, r, "decrypt", "true")
+		requireQuery(t, r, "teamId", "team_123")
+		requireQuery(t, r, "limit", "25")
+		requireQuery(t, r, "until", "222")
+		fmt.Fprintln(w, `{
+			"envs": [{"id":"env_1","key":"A"}],
+			"pagination": {"count":1,"next":111,"prev":333}
+		}`)
+	})
+
+	response, err := client.ListEnvironmentVariablesPage(context.Background(), ListEnvironmentVariablesRequest{
+		ProjectID: "prj_123",
+		TeamID:    "team_123",
+		Limit:     25,
+		Until:     int64Ptr(222),
+	})
+	if err != nil {
+		t.Fatalf("ListEnvironmentVariablesPage() error = %v", err)
+	}
+
+	if len(response.EnvironmentVariables) != 1 {
+		t.Fatalf("got %d env vars, want 1", len(response.EnvironmentVariables))
+	}
+	if response.EnvironmentVariables[0].TeamID != "team_123" {
+		t.Fatalf("TeamID = %q, want team_123", response.EnvironmentVariables[0].TeamID)
+	}
+	if response.Pagination.Next == nil || *response.Pagination.Next != 111 {
+		t.Fatalf("Next = %v, want 111", response.Pagination.Next)
+	}
+	if response.Pagination.Prev == nil || *response.Pagination.Prev != 333 {
+		t.Fatalf("Prev = %v, want 333", response.Pagination.Prev)
+	}
+}
+
+func TestGetEnvironmentVariablesPaginates(t *testing.T) {
+	var seenUntil []string
+	client := newPaginationTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		seenUntil = append(seenUntil, r.URL.Query().Get("until"))
+		requireQuery(t, r, "decrypt", "true")
+		requireQuery(t, r, "teamId", "team_123")
+		requireQuery(t, r, "limit", "100")
+
+		switch r.URL.Query().Get("until") {
+		case "":
+			fmt.Fprintln(w, `{
+				"envs": [{"id":"env_1","key":"A"}],
+				"pagination": {"count":1,"next":123}
+			}`)
+		case "123":
+			fmt.Fprintln(w, `{
+				"envs": [{"id":"env_2","key":"B"}],
+				"pagination": {"count":1}
+			}`)
+		default:
+			t.Fatalf("unexpected until %q", r.URL.Query().Get("until"))
+		}
+	})
+
+	envs, err := client.GetEnvironmentVariables(context.Background(), "prj_123", "team_123")
+	if err != nil {
+		t.Fatalf("GetEnvironmentVariables() error = %v", err)
+	}
+
+	if got, want := len(envs), 2; got != want {
+		t.Fatalf("got %d env vars, want %d", got, want)
+	}
+	if got, want := []string{envs[0].ID, envs[1].ID}, []string{"env_1", "env_2"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("env IDs = %#v, want %#v", got, want)
+	}
+	if !reflect.DeepEqual(seenUntil, []string{"", "123"}) {
+		t.Fatalf("seen until = %#v, want %#v", seenUntil, []string{"", "123"})
+	}
+}
+
+func TestListSharedEnvironmentVariablesPaginates(t *testing.T) {
+	client := newPaginationTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		requireQuery(t, r, "teamId", "team_123")
+		requireQuery(t, r, "limit", "100")
+
+		switch r.URL.Query().Get("until") {
+		case "":
+			fmt.Fprintln(w, `{
+				"data": [{"id":"env_1","key":"A"}],
+				"pagination": {"count":1,"next":123}
+			}`)
+		case "123":
+			fmt.Fprintln(w, `{
+				"data": [{"id":"env_2","key":"B"}],
+				"pagination": {"count":1}
+			}`)
+		default:
+			t.Fatalf("unexpected until %q", r.URL.Query().Get("until"))
+		}
+	})
+
+	envs, err := client.ListSharedEnvironmentVariables(context.Background(), "team_123")
+	if err != nil {
+		t.Fatalf("ListSharedEnvironmentVariables() error = %v", err)
+	}
+
+	if got, want := []string{envs[0].ID, envs[1].ID}, []string{"env_1", "env_2"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("env IDs = %#v, want %#v", got, want)
+	}
+	if envs[0].TeamID != "team_123" || envs[1].TeamID != "team_123" {
+		t.Fatalf("TeamID values = %#v, %#v; want team_123", envs[0].TeamID, envs[1].TeamID)
+	}
+}
+
+func TestListProjectMembersPaginatesWithoutTeam(t *testing.T) {
+	client := newPaginationTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/projects/prj_123/members" {
+			t.Fatalf("path = %q, want /v1/projects/prj_123/members", r.URL.Path)
+		}
+		requireQuery(t, r, "limit", "100")
+
+		switch r.URL.Query().Get("until") {
+		case "":
+			fmt.Fprintln(w, `{
+				"members": [{"uid":"user_1","role":"ADMIN"}],
+				"pagination": {"count":1,"next":123}
+			}`)
+		case "123":
+			fmt.Fprintln(w, `{
+				"members": [{"uid":"user_2","role":"MEMBER"}],
+				"pagination": {"count":1}
+			}`)
+		default:
+			t.Fatalf("unexpected until %q", r.URL.Query().Get("until"))
+		}
+	})
+
+	members, err := client.ListProjectMembers(context.Background(), GetProjectMembersRequest{
+		ProjectID: "prj_123",
+	})
+	if err != nil {
+		t.Fatalf("ListProjectMembers() error = %v", err)
+	}
+
+	if got, want := []string{members[0].UserID, members[1].UserID}, []string{"user_1", "user_2"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("member IDs = %#v, want %#v", got, want)
+	}
+}
+
+func TestGetTeamMemberPaginatesProjectAssignments(t *testing.T) {
+	client := newPaginationTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/teams/team_123/members":
+			requireQuery(t, r, "limit", "1")
+			requireQuery(t, r, "filterByUserIds", "user_123")
+			fmt.Fprintln(w, `{
+				"members": [{
+					"uid":"user_123",
+					"email":"user@example.com",
+					"role":"DEVELOPER",
+					"confirmed":true
+				}]
+			}`)
+		case "/v1/teams/team_123/members/user_123/projects":
+			requireQuery(t, r, "limit", "100")
+			switch r.URL.Query().Get("until") {
+			case "":
+				fmt.Fprintln(w, `{
+					"projects": [{"projectId":"prj_1","role":"ADMIN"}],
+					"pagination": {"count":1,"next":123}
+				}`)
+			case "123":
+				fmt.Fprintln(w, `{
+					"projects": [{"projectId":"prj_2","role":"MEMBER"}],
+					"pagination": {"count":1}
+				}`)
+			default:
+				t.Fatalf("unexpected until %q", r.URL.Query().Get("until"))
+			}
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	})
+
+	member, err := client.GetTeamMember(context.Background(), GetTeamMemberRequest{
+		TeamID: "team_123",
+		UserID: "user_123",
+	})
+	if err != nil {
+		t.Fatalf("GetTeamMember() error = %v", err)
+	}
+
+	if got, want := []string{member.Projects[0].ProjectID, member.Projects[1].ProjectID}, []string{"prj_1", "prj_2"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("project IDs = %#v, want %#v", got, want)
+	}
+}

--- a/client/project_member.go
+++ b/client/project_member.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -111,30 +112,54 @@ func (c *Client) UpdateProjectMembers(ctx context.Context, request UpdateProject
 type GetProjectMembersRequest struct {
 	ProjectID string `json:"-"`
 	TeamID    string `json:"-"`
+	Limit     int    `json:"-"`
+	Until     *int64 `json:"-"`
+	Since     *int64 `json:"-"`
 }
 
-func (c *Client) ListProjectMembers(ctx context.Context, request GetProjectMembersRequest) ([]ProjectMember, error) {
-	url := fmt.Sprintf("%s/v1/projects/%s/members", c.baseURL, request.ProjectID)
+type ListProjectMembersResponse struct {
+	Members    []ProjectMember
+	Pagination PageInfo
+}
+
+func (c *Client) ListProjectMembersPage(ctx context.Context, request GetProjectMembersRequest) (ListProjectMembersResponse, error) {
+	baseURL := fmt.Sprintf("%s/v1/projects/%s/members", c.baseURL, request.ProjectID)
+	query := url.Values{}
 	if c.TeamID(request.TeamID) != "" {
-		url = fmt.Sprintf("%s?teamId=%s&limit=100", url, c.TeamID(request.TeamID))
+		query.Set("teamId", c.TeamID(request.TeamID))
 	}
-	tflog.Info(ctx, "listing project members", map[string]any{
+	url := urlWithQuery(baseURL, paginationQuery(query, request.Limit, request.Until, request.Since))
+
+	tflog.Info(ctx, "listing project members page", map[string]any{
 		"url": url,
 	})
 
 	var resp struct {
-		Members []ProjectMember `json:"members"`
+		Members    []ProjectMember `json:"members"`
+		Pagination PageInfo        `json:"pagination"`
 	}
 	err := c.doRequest(clientRequest{
 		ctx:    ctx,
 		method: "GET",
 		url:    url,
-		body:   string(mustMarshal(request)),
 	}, &resp)
 	if err != nil {
 		tflog.Error(ctx, "error getting project members", map[string]any{
 			"url": url,
 		})
 	}
-	return resp.Members, err
+	return ListProjectMembersResponse{
+		Members:    resp.Members,
+		Pagination: resp.Pagination,
+	}, err
+}
+
+func (c *Client) ListProjectMembers(ctx context.Context, request GetProjectMembersRequest) ([]ProjectMember, error) {
+	return collectPages(func(until *int64) ([]ProjectMember, PageInfo, error) {
+		request.Limit = defaultPaginationLimit
+		request.Until = until
+		request.Since = nil
+		response, err := c.ListProjectMembersPage(ctx, request)
+		return response.Members, response.Pagination, err
+	})
 }

--- a/client/shared_environment_variable.go
+++ b/client/shared_environment_variable.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -140,17 +141,32 @@ func (c *Client) GetSharedEnvironmentVariable(ctx context.Context, teamID, envID
 	return e, err
 }
 
-func (c *Client) ListSharedEnvironmentVariables(ctx context.Context, teamID string) ([]SharedEnvironmentVariableResponse, error) {
-	url := fmt.Sprintf("%s/v1/env/all", c.baseURL)
-	if c.TeamID(teamID) != "" {
-		url = fmt.Sprintf("%s?teamId=%s", url, c.TeamID(teamID))
-	}
+type ListSharedEnvironmentVariablesRequest struct {
+	TeamID string
+	Limit  int
+	Until  *int64
+	Since  *int64
+}
 
-	tflog.Info(ctx, "listing shared environment variables", map[string]any{
+type ListSharedEnvironmentVariablesResponse struct {
+	EnvironmentVariables []SharedEnvironmentVariableResponse
+	Pagination           PageInfo
+}
+
+func (c *Client) ListSharedEnvironmentVariablesPage(ctx context.Context, request ListSharedEnvironmentVariablesRequest) (ListSharedEnvironmentVariablesResponse, error) {
+	baseURL := fmt.Sprintf("%s/v1/env/all", c.baseURL)
+	query := url.Values{}
+	if c.TeamID(request.TeamID) != "" {
+		query.Set("teamId", c.TeamID(request.TeamID))
+	}
+	url := urlWithQuery(baseURL, paginationQuery(query, request.Limit, request.Until, request.Since))
+
+	tflog.Info(ctx, "listing shared environment variables page", map[string]any{
 		"url": url,
 	})
 	res := struct {
-		Data []SharedEnvironmentVariableResponse `json:"data"`
+		Data       []SharedEnvironmentVariableResponse `json:"data"`
+		Pagination PageInfo                            `json:"pagination"`
 	}{}
 	err := c.doRequest(clientRequest{
 		ctx:    ctx,
@@ -159,9 +175,23 @@ func (c *Client) ListSharedEnvironmentVariables(ctx context.Context, teamID stri
 		body:   "",
 	}, &res)
 	for i := 0; i < len(res.Data); i++ {
-		res.Data[i].TeamID = c.TeamID(teamID)
+		res.Data[i].TeamID = c.TeamID(request.TeamID)
 	}
-	return res.Data, err
+	return ListSharedEnvironmentVariablesResponse{
+		EnvironmentVariables: res.Data,
+		Pagination:           res.Pagination,
+	}, err
+}
+
+func (c *Client) ListSharedEnvironmentVariables(ctx context.Context, teamID string) ([]SharedEnvironmentVariableResponse, error) {
+	return collectPages(func(until *int64) ([]SharedEnvironmentVariableResponse, PageInfo, error) {
+		response, err := c.ListSharedEnvironmentVariablesPage(ctx, ListSharedEnvironmentVariablesRequest{
+			TeamID: teamID,
+			Limit:  defaultPaginationLimit,
+			Until:  until,
+		})
+		return response.EnvironmentVariables, response.Pagination, err
+	})
 }
 
 type UpdateSharedEnvironmentVariableRequestProjectIDUpdates struct {

--- a/client/team_member.go
+++ b/client/team_member.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -109,6 +110,58 @@ type TeamMember struct {
 	} `json:"accessGroups"`
 }
 
+type ListTeamMemberProjectsRequest struct {
+	TeamID string
+	UserID string
+	Limit  int
+	Until  *int64
+	Since  *int64
+}
+
+type ListTeamMemberProjectsResponse struct {
+	Projects   []ProjectRole
+	Pagination PageInfo
+}
+
+func (c *Client) ListTeamMemberProjectsPage(ctx context.Context, request ListTeamMemberProjectsRequest) (ListTeamMemberProjectsResponse, error) {
+	baseURL := fmt.Sprintf("%s/v1/teams/%s/members/%s/projects", c.baseURL, request.TeamID, request.UserID)
+	query := paginationQuery(url.Values{}, request.Limit, request.Until, request.Since)
+	url := urlWithQuery(baseURL, query)
+
+	tflog.Info(ctx, "listing team member projects page", map[string]any{
+		"url": url,
+	})
+	var response struct {
+		Projects   []ProjectRole `json:"projects"`
+		Pagination PageInfo      `json:"pagination"`
+	}
+	err := c.doRequest(clientRequest{
+		ctx:    ctx,
+		method: "GET",
+		url:    url,
+		body:   "",
+	}, &response)
+	if err != nil {
+		return ListTeamMemberProjectsResponse{}, err
+	}
+	return ListTeamMemberProjectsResponse{
+		Projects:   response.Projects,
+		Pagination: response.Pagination,
+	}, nil
+}
+
+func (c *Client) ListTeamMemberProjects(ctx context.Context, teamID, userID string) ([]ProjectRole, error) {
+	return collectPages(func(until *int64) ([]ProjectRole, PageInfo, error) {
+		response, err := c.ListTeamMemberProjectsPage(ctx, ListTeamMemberProjectsRequest{
+			TeamID: teamID,
+			UserID: userID,
+			Limit:  defaultPaginationLimit,
+			Until:  until,
+		})
+		return response.Projects, response.Pagination, err
+	})
+}
+
 func (c *Client) GetTeamMember(ctx context.Context, request GetTeamMemberRequest) (TeamMember, error) {
 	url := fmt.Sprintf("%s/v2/teams/%s/members?limit=1&filterByUserIds=%s", c.baseURL, request.TeamID, request.UserID)
 	tflog.Info(ctx, "getting team member", map[string]any{
@@ -139,19 +192,10 @@ func (c *Client) GetTeamMember(ctx context.Context, request GetTeamMemberRequest
 	if !response.Members[0].Confirmed || (response.Members[0].Role != "DEVELOPER" && response.Members[0].Role != "CONTRIBUTOR") {
 		return response.Members[0], nil
 	}
-	url = fmt.Sprintf("%s/v1/teams/%s/members/%s/projects?limit=100", c.baseURL, request.TeamID, request.UserID)
-	var response2 struct {
-		Projects []ProjectRole `json:"projects"`
-	}
-	err = c.doRequest(clientRequest{
-		ctx:    ctx,
-		method: "GET",
-		url:    url,
-		body:   "",
-	}, &response2)
+	projects, err := c.ListTeamMemberProjects(ctx, request.TeamID, request.UserID)
 	if err != nil {
 		return TeamMember{}, err
 	}
-	response.Members[0].Projects = response2.Projects
+	response.Members[0].Projects = projects
 	return response.Members[0], err
 }


### PR DESCRIPTION
## Summary

Adds cursor-aware page APIs for the client list methods that currently need complete results in provider code, while keeping existing read-all methods stable for Terraform resources and data sources.

Closes #300.

## What changed

- Added shared pagination metadata/query helpers for Vercel `limit`/`until`/`since` list endpoints.
- Added page-level APIs for project environment variables, shared environment variables, project members, and team member project assignments.
- Updated existing read-all methods to aggregate every page before returning.
- Added unit tests for exposed pagination metadata and two-page aggregation behavior.

## Why

The provider currently reads only the first page for several list-backed operations. That can produce incomplete state or conflict detection once an account/project exceeds the API's first page size. External client users also need access to page metadata rather than only provider-oriented read-all behavior.

## Validation

- `go test ./...`
