### PR TITLE
Add `rate_limit_api_id` firewall condition type

### DIFF
--- a/vercel/resource_firewall_config.go
+++ b/vercel/resource_firewall_config.go
@@ -349,6 +349,7 @@ Define Custom Rules to shape the way your traffic is handled by the Vercel Edge 
 																	"geo_as_number",
 																	"ja4_digest",
 																	"ja3_digest",
+																	"rate_limit_api_id",
 																),
 															},
 														},

--- a/vercel/resource_firewall_config_test.go
+++ b/vercel/resource_firewall_config_test.go
@@ -212,6 +212,14 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 						"rules.rule.4.condition_group.0.conditions.0.values.1",
 						"/test2"),
 					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.custom",
+						"rules.rule.5.condition_group.0.conditions.0.type",
+						"rate_limit_api_id"),
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.custom",
+						"rules.rule.5.condition_group.0.conditions.0.value",
+						"login-attempt"),
+					resource.TestCheckResourceAttr(
 						"vercel_firewall_config.ips",
 						"ip_rules.rule.0.action",
 						"deny"),
@@ -578,6 +586,19 @@ resource "vercel_firewall_config" "custom" {
                     "/test2",
                     "/test3"
                 ]
+            }]
+          }]
+        }
+        rule {
+          name =  "test5"
+          action = {
+            action = "log"
+          }
+          condition_group = [{
+            conditions = [{
+                type = "rate_limit_api_id"
+                op = "eq"
+                value = "login-attempt"
             }]
           }]
         }

--- a/vercel/resource_firewall_config_unit_test.go
+++ b/vercel/resource_firewall_config_unit_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
@@ -51,6 +53,60 @@ func TestFirewallConfigResourceSchemaIncludesSessionFixationRule(t *testing.T) {
 
 	if !active.Optional {
 		t.Fatalf("sf.active should be optional")
+	}
+}
+
+func TestFirewallConfigConditionTypeIncludesRateLimitAPIID(t *testing.T) {
+	res := newFirewallConfigResource()
+
+	resp := &resource.SchemaResponse{}
+	res.Schema(context.Background(), resource.SchemaRequest{}, resp)
+
+	rules, ok := resp.Schema.Blocks["rules"].(schema.SingleNestedBlock)
+	if !ok {
+		t.Fatalf("rules block has unexpected type: %T", resp.Schema.Blocks["rules"])
+	}
+
+	rule, ok := rules.Blocks["rule"].(schema.ListNestedBlock)
+	if !ok {
+		t.Fatalf("rule block has unexpected type: %T", rules.Blocks["rule"])
+	}
+
+	conditionGroup, ok := rule.NestedObject.Attributes["condition_group"].(schema.ListNestedAttribute)
+	if !ok {
+		t.Fatalf("condition_group attribute has unexpected type: %T", rule.NestedObject.Attributes["condition_group"])
+	}
+
+	conditions, ok := conditionGroup.NestedObject.Attributes["conditions"].(schema.ListNestedAttribute)
+	if !ok {
+		t.Fatalf("conditions attribute has unexpected type: %T", conditionGroup.NestedObject.Attributes["conditions"])
+	}
+
+	conditionType, ok := conditions.NestedObject.Attributes["type"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("type attribute has unexpected type: %T", conditions.NestedObject.Attributes["type"])
+	}
+
+	hasError := func(value string) bool {
+		errored := false
+		for _, v := range conditionType.Validators {
+			vResp := &validator.StringResponse{}
+			v.ValidateString(context.Background(), validator.StringRequest{
+				Path:        path.Root("type"),
+				ConfigValue: types.StringValue(value),
+			}, vResp)
+			if vResp.Diagnostics.HasError() {
+				errored = true
+			}
+		}
+		return errored
+	}
+
+	if hasError("rate_limit_api_id") {
+		t.Fatalf("rate_limit_api_id should be accepted as a condition type")
+	}
+	if !hasError("not_a_condition_type") {
+		t.Fatalf("invalid condition type should be rejected")
 	}
 }
 


### PR DESCRIPTION
 ## Summary

Adds `rate_limit_api_id` to the accepted condition `type` values on `vercel_firewall_config` rules, so rate-limit rules created via the `@vercel/firewall` SDK can be expressed.

Fixes #469.

## What changed

   - `vercel/resource_firewall_config.go`: `rate_limit_api_id` added to the condition-type `OneOf` validator
   - `vercel/resource_firewall_config_unit_test.go`: unit test that walks the schema and runs the validator directly: accepts `rate_limit_api_id`, still rejects unknown types
   - `vercel/resource_firewall_config_test.go`: new rule w/ a `rate_limit_api_id` condition in the existing acceptance config, mirroring the `ja4_digest`
 case

## Why

The API round-trips these conditions fine and `terraform import` stores them in state, but the validator rejects the type in HCL, so plans fail with:

       Attribute rules.rule[3].condition_group[0].conditions[0].type value must be
       one of: ["host" "path" ... "ja4_digest" "ja3_digest"], got: "rate_limit_api_id"

## Validation

   - [x] `go test ./... -skip '^TestAcc_'`
   - [x] `task lint`
   - [x] Built w/ `dev_overrides` + ran `terraform validate` on the exact config from #469 