### PR TITLE
Add firewall rate_limit_api_id condition

### DIFF
--- a/vercel/resource_firewall_config.go
+++ b/vercel/resource_firewall_config.go
@@ -349,6 +349,7 @@ Define Custom Rules to shape the way your traffic is handled by the Vercel Edge 
 																	"geo_as_number",
 																	"ja4_digest",
 																	"ja3_digest",
+																	"rate_limit_api_id",
 																),
 															},
 														},

--- a/vercel/resource_firewall_config_test.go
+++ b/vercel/resource_firewall_config_test.go
@@ -212,6 +212,18 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 						"rules.rule.4.condition_group.0.conditions.0.values.1",
 						"/test2"),
 					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.custom",
+						"rules.rule.5.name",
+						"test_rate_limit_api"),
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.custom",
+						"rules.rule.5.condition_group.0.conditions.0.type",
+						"rate_limit_api_id"),
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.custom",
+						"rules.rule.5.condition_group.0.conditions.0.value",
+						"login-attempt"),
+					resource.TestCheckResourceAttr(
 						"vercel_firewall_config.ips",
 						"ip_rules.rule.0.action",
 						"deny"),
@@ -408,6 +420,18 @@ func TestAcc_FirewallConfigResource(t *testing.T) {
 						"rules.rule.0.condition_group.0.conditions.0.values.1",
 						"3.4.5.6"),
 					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.custom",
+						"rules.rule.4.name",
+						"test_rate_limit_api"),
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.custom",
+						"rules.rule.4.condition_group.0.conditions.0.type",
+						"rate_limit_api_id"),
+					resource.TestCheckResourceAttr(
+						"vercel_firewall_config.custom",
+						"rules.rule.4.condition_group.0.conditions.0.value",
+						"login-attempt-updated"),
+					resource.TestCheckResourceAttr(
 						"vercel_firewall_config.ips",
 						"ip_rules.rule.0.action",
 						"deny"),
@@ -578,6 +602,26 @@ resource "vercel_firewall_config" "custom" {
                     "/test2",
                     "/test3"
                 ]
+            }]
+          }]
+        }
+        rule {
+          name =  "test_rate_limit_api"
+          action = {
+            action = "rate_limit"
+            rate_limit = {
+                limit = 5
+                window = 600
+                algo = "fixed_window"
+                keys = ["header:x-vercel-rate-limit-key"]
+                action = "challenge"
+            }
+          }
+          condition_group = [{
+            conditions = [{
+                type = "rate_limit_api_id"
+                op = "eq"
+                value = "login-attempt"
             }]
           }]
         }
@@ -767,6 +811,26 @@ resource "vercel_firewall_config" "custom" {
                     "/api2",
                     "/api3"
                 ]
+            }]
+          }]
+        }
+        rule {
+          name =  "test_rate_limit_api"
+          action = {
+            action = "rate_limit"
+            rate_limit = {
+                limit = 10
+                window = 600
+                algo = "fixed_window"
+                keys = ["header:x-vercel-rate-limit-key"]
+                action = "challenge"
+            }
+          }
+          condition_group = [{
+            conditions = [{
+                type = "rate_limit_api_id"
+                op = "eq"
+                value = "login-attempt-updated"
             }]
           }]
         }


### PR DESCRIPTION
## Summary

Adds `rate_limit_api_id` to the supported `vercel_firewall_config` condition types so firewall rules created through the Firewall SDK can be represented in Terraform.

## Details

- Allows `rate_limit_api_id` in the firewall condition type validator.
- Extends the firewall config acceptance scenario to create and update a rate-limit rule using `rate_limit_api_id`.

Fixes #469.

## Validation

- `GOCACHE=/tmp/codex-go-cache go test ./vercel -run 'TestFirewallConfig|TestFromCRS|TestMatchFirewallRules|TestOnlyFirewallRulesChanged|TestMoveFirewallRuleID'`

Live acceptance coverage is included in `TestAcc_FirewallConfigResource` and will run in CI with acceptance credentials.