### PR TITLE
Support Services project framework

### DIFF
--- a/vercel/validator_framework.go
+++ b/vercel/validator_framework.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
+const servicesFramework = "services"
+
 func validateFramework() validatorFramework {
 	return validatorFramework{}
 }
@@ -35,6 +37,11 @@ func (v validatorFramework) MarkdownDescription(ctx context.Context) string {
 
 func (v validatorFramework) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
 	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	// Services is a project-level build mode and is not returned by the framework catalog.
+	if req.ConfigValue.ValueString() == servicesFramework {
 		return
 	}
 

--- a/vercel/validator_framework.go
+++ b/vercel/validator_framework.go
@@ -11,14 +11,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
-const servicesFramework = "services"
+const frameworksURL = "https://api-frameworks.vercel.sh/api/v1/frameworks?includeExperimental=true"
 
 func validateFramework() validatorFramework {
-	return validatorFramework{}
+	return validatorFramework{frameworksURL: frameworksURL}
 }
 
 type validatorFramework struct {
-	frameworks map[string]struct{}
+	frameworks    map[string]struct{}
+	frameworksURL string
 }
 
 func (v validatorFramework) Description(ctx context.Context) string {
@@ -40,12 +41,7 @@ func (v validatorFramework) ValidateString(ctx context.Context, req validator.St
 		return
 	}
 
-	// Services is a project-level build mode and is not returned by the framework catalog.
-	if req.ConfigValue.ValueString() == servicesFramework {
-		return
-	}
-
-	apires, err := http.Get("https://api-frameworks.zeit.sh/")
+	apires, err := http.Get(v.frameworksURL)
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(
 			req.Path,

--- a/vercel/validator_framework_test.go
+++ b/vercel/validator_framework_test.go
@@ -1,0 +1,21 @@
+package vercel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValidateFrameworkAllowsServices(t *testing.T) {
+	var resp validator.StringResponse
+
+	validateFramework().ValidateString(context.Background(), validator.StringRequest{
+		ConfigValue: types.StringValue(servicesFramework),
+	}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("expected services framework to be valid, got diagnostics: %v", resp.Diagnostics)
+	}
+}

--- a/vercel/validator_framework_test.go
+++ b/vercel/validator_framework_test.go
@@ -2,6 +2,9 @@ package vercel
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -9,10 +12,20 @@ import (
 )
 
 func TestValidateFrameworkAllowsServices(t *testing.T) {
-	var resp validator.StringResponse
+	frameworkValidator := validateFramework()
+	if frameworkValidator.frameworksURL != "https://api-frameworks.vercel.sh/api/v1/frameworks?includeExperimental=true" {
+		t.Fatalf("expected framework validation to include experimental frameworks, got %s", frameworkValidator.frameworksURL)
+	}
 
-	validateFramework().ValidateString(context.Background(), validator.StringRequest{
-		ConfigValue: types.StringValue(servicesFramework),
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `[{"slug":"services"}]`)
+	}))
+	t.Cleanup(server.Close)
+	frameworkValidator.frameworksURL = server.URL
+
+	var resp validator.StringResponse
+	frameworkValidator.ValidateString(context.Background(), validator.StringRequest{
+		ConfigValue: types.StringValue("services"),
 	}, &resp)
 
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
## Why

- Vercel Services is registered as an experimental project framework preset.
- The provider queries the legacy/default framework list, which excludes experimental presets, so `framework = "services"` fails during planning even though the Vercel API accepts it.

## Summary

- Validate against the current frameworks API with experimental presets included.
- Add focused coverage proving a `services` catalog entry is accepted.

## Validation

- Confirmed the current experimental-inclusive catalog returns the `services` preset and the default catalog does not.
- Verified the validator accepts `services` from the catalog without diagnostics.