### PR TITLE
Fix firewall condition negation drift

### DIFF
--- a/docs/resources/firewall_config.md
+++ b/docs/resources/firewall_config.md
@@ -539,7 +539,7 @@ Required:
 Optional:
 
 - `key` (String) Key within type to match against
-- `neg` (Boolean) Negate the condition
+- `neg` (Boolean) Negate the condition. Defaults to false.
 - `value` (String) Value to match against. Not required for existence operators (`ex`, `nex`). Use `values` instead for `inc` and `ninc` operators.
 - `values` (List of String) Values to match against if op is inc, ninc
 

--- a/vercel/resource_firewall_config.go
+++ b/vercel/resource_firewall_config.go
@@ -376,8 +376,10 @@ Define Custom Rules to shape the way your traffic is handled by the Vercel Edge 
 															},
 														},
 														"neg": schema.BoolAttribute{
-															Description: "Negate the condition",
+															Description: "Negate the condition. Defaults to false.",
 															Optional:    true,
+															Computed:    true,
+															Default:     booldefault.StaticBool(false),
 														},
 														"key": schema.StringAttribute{
 															Description: "Key within type to match against",
@@ -826,11 +828,7 @@ func fromCondition(condition client.Condition, ref Condition) (Condition, error)
 		}
 	}
 
-	// Neg and Key are optional
-	if ref.Neg == types.BoolNull() {
-		c.Neg = types.BoolNull()
-	}
-	// if key is present it's possible for value to be optional
+	// If key is present it's possible for value to be optional.
 	if ref.Key == types.StringNull() {
 		c.Key = types.StringNull()
 	} else {

--- a/vercel/resource_firewall_config_unit_test.go
+++ b/vercel/resource_firewall_config_unit_test.go
@@ -2,13 +2,67 @@ package vercel
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
+
+func TestFirewallConditionNegDefaultsToFalse(t *testing.T) {
+	res := newFirewallConfigResource()
+
+	resp := &resource.SchemaResponse{}
+	res.Schema(context.Background(), resource.SchemaRequest{}, resp)
+
+	rules := resp.Schema.Blocks["rules"].(schema.SingleNestedBlock)
+	rule := rules.Blocks["rule"].(schema.ListNestedBlock)
+	conditionGroups := rule.NestedObject.Attributes["condition_group"].(schema.ListNestedAttribute)
+	conditions := conditionGroups.NestedObject.Attributes["conditions"].(schema.ListNestedAttribute)
+	neg := conditions.NestedObject.Attributes["neg"].(schema.BoolAttribute)
+
+	if neg.Default == nil {
+		t.Fatal("neg should have a default")
+	}
+	if !neg.Computed {
+		t.Fatal("neg should be computed so API values can be stored in state")
+	}
+
+	defaultResp := &defaults.BoolResponse{}
+	neg.Default.DefaultBool(context.Background(), defaults.BoolRequest{}, defaultResp)
+	if defaultResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics applying neg default: %v", defaultResp.Diagnostics)
+	}
+	if defaultResp.PlanValue.IsNull() || defaultResp.PlanValue.ValueBool() {
+		t.Fatalf("neg should default to false, got %s", defaultResp.PlanValue)
+	}
+}
+
+func TestFromConditionPreservesNegFromAPI(t *testing.T) {
+	for _, apiNeg := range []bool{false, true} {
+		t.Run(fmt.Sprintf("neg_%t", apiNeg), func(t *testing.T) {
+			condition, err := fromCondition(client.Condition{
+				Type:  "header",
+				Op:    "eq",
+				Neg:   apiNeg,
+				Key:   "x-origin-verify",
+				Value: "secret",
+			}, Condition{
+				Neg: types.BoolNull(),
+				Key: types.StringValue("x-origin-verify"),
+			})
+			if err != nil {
+				t.Fatalf("unexpected error converting condition: %v", err)
+			}
+			if condition.Neg.IsNull() || condition.Neg.ValueBool() != apiNeg {
+				t.Fatalf("expected API neg value %t, got %s", apiNeg, condition.Neg)
+			}
+		})
+	}
+}
 
 func TestFirewallConfigResourceSchemaIncludesSessionFixationRule(t *testing.T) {
 	res := newFirewallConfigResource()


### PR DESCRIPTION
Preserve firewall condition negation returned by the API instead of replacing it with null when the setting was omitted from configuration. Default omitted negation to false so Terraform has an explicit desired value and can surface a remote true value as drift.

This prevents dashboard-authored negated conditions from being partially hidden in state and then overwritten from an incomplete plan. It also updates the generated resource documentation to describe the default.

Addresses the provider state drift reported in #559.
