### PR TITLE
Add project environment variable deletion warning

### DIFF
--- a/docs/resources/project_environment_variables.md
+++ b/docs/resources/project_environment_variables.md
@@ -4,6 +4,7 @@ page_title: "vercel_project_environment_variables Resource - terraform-provider-
 subcategory: ""
 description: |-
   Provides a resource for managing a number of Project Environment Variables.
+  ~> Removing entries from the variables attribute deletes the corresponding Environment Variables from the Vercel Project. Destroying this resource deletes all Environment Variables it manages. Environment Variables not managed by this resource are left unchanged.
   This resource defines multiple Environment Variables on a Vercel Project.
   For more detailed information, please see the Vercel documentation https://vercel.com/docs/concepts/projects/environment-variables.
   ~> Terraform currently provides this Project Environment Variables resource (multiple Environment Variables), a single Project Environment Variable Resource, and a Project resource with Environment Variables defined in-line via the environment field.
@@ -14,6 +15,8 @@ description: |-
 # vercel_project_environment_variables (Resource)
 
 Provides a resource for managing a number of Project Environment Variables.
+
+~> Removing entries from the `variables` attribute deletes the corresponding Environment Variables from the Vercel Project. Destroying this resource deletes all Environment Variables it manages. Environment Variables not managed by this resource are left unchanged.
 
 This resource defines multiple Environment Variables on a Vercel Project.
 

--- a/vercel/resource_project_environment_variables.go
+++ b/vercel/resource_project_environment_variables.go
@@ -72,6 +72,8 @@ func (r *projectEnvironmentVariablesResource) Schema(_ context.Context, req reso
 		Description: `
 Provides a resource for managing a number of Project Environment Variables.
 
+~> Removing entries from the ` + "`variables`" + ` attribute deletes the corresponding Environment Variables from the Vercel Project. Destroying this resource deletes all Environment Variables it manages. Environment Variables not managed by this resource are left unchanged.
+
 This resource defines multiple Environment Variables on a Vercel Project.
 
 For more detailed information, please see the [Vercel documentation](https://vercel.com/docs/concepts/projects/environment-variables).


### PR DESCRIPTION
Document the deletion behavior of `vercel_project_environment_variables` from the resource schema so generated documentation stays in sync. Clarify that removing managed entries or destroying the resource deletes managed variables, while unmanaged variables remain unchanged.

Supersedes #564 with source-backed documentation and wording aligned to the resource's current behavior.
