### PR TITLE
Make shared environment variable project IDs optional

### DIFF
--- a/client/shared_environment_variable.go
+++ b/client/shared_environment_variable.go
@@ -28,7 +28,7 @@ type SharedEnvVarRequest struct {
 
 type SharedEnvironmentVariableRequest struct {
 	Type                         string                `json:"type"`
-	ProjectIDs                   []string              `json:"projectId"`
+	ProjectIDs                   []string              `json:"projectId,omitempty"`
 	Target                       []string              `json:"target"`
 	ApplyToAllCustomEnvironments bool                  `json:"applyToAllCustomEnvironments"`
 	EnvironmentVariables         []SharedEnvVarRequest `json:"evs"`

--- a/docs/resources/shared_environment_variable.md
+++ b/docs/resources/shared_environment_variable.md
@@ -65,7 +65,6 @@ resource "vercel_shared_environment_variable" "example_development" {
 ### Required
 
 - `key` (String) The name of the Environment Variable.
-- `project_ids` (Set of String) The ID of the Vercel project.
 - `sensitive` (Boolean) Whether the Environment Variable is sensitive (meaning it cannot be read via the API or Vercel Dashboard once set). This must be explicitly set. If a [team-wide environment variable policy](https://vercel.com/docs/projects/environment-variables/sensitive-environment-variables#environment-variables-policy) is active, environment variables may have to be sensitive. Variables targeting only `development` must set this to `false`. Variables targeting `preview`, `production`, or custom environments may have to set this to `true`. A variable cannot target `development` together with `preview`, `production`, or custom environments while that team policy is enabled.
 
 ### Optional
@@ -74,6 +73,7 @@ resource "vercel_shared_environment_variable" "example_development" {
 
 - `apply_to_all_custom_environments` (Boolean) Whether the shared environment variable should be applied to all custom environments in the linked projects.
 - `comment` (String) A comment explaining what the environment variable is for.
+- `project_ids` (Set of String) The ID of the Vercel project.
 - `target` (Set of String) The environments that the Environment Variable should be present on. Valid targets are either `production`, `preview`, or `development`.
 - `team_id` (String) The ID of the Vercel team. Shared environment variables require a team.
 - `value` (String, Sensitive) (Optional, exactly one of `value` or `value_wo` is required) The value of the Environment Variable.

--- a/vercel/resource_shared_environment_variable.go
+++ b/vercel/resource_shared_environment_variable.go
@@ -176,7 +176,7 @@ For more detailed information, please see the [Vercel documentation](https://ver
 				},
 			},
 			"project_ids": schema.SetAttribute{
-				Required:    true,
+				Optional:    true,
 				Description: "The ID of the Vercel project.",
 				ElementType: types.StringType,
 			},
@@ -342,10 +342,12 @@ func (e *SharedEnvironmentVariable) toCreateSharedEnvironmentVariableRequest(ctx
 	}
 
 	var projectIDs []string
-	ds := e.ProjectIDs.ElementsAs(ctx, &projectIDs, false)
-	diags = append(diags, ds...)
-	if diags.HasError() {
-		return req, false
+	if !e.ProjectIDs.IsNull() && !e.ProjectIDs.IsUnknown() {
+		ds := e.ProjectIDs.ElementsAs(ctx, &projectIDs, false)
+		diags = append(diags, ds...)
+		if diags.HasError() {
+			return req, false
+		}
 	}
 
 	var envVariableType string
@@ -391,10 +393,12 @@ func (e *SharedEnvironmentVariable) toUpdateSharedEnvironmentVariableRequest(ctx
 	}
 
 	var projectIDs []string
-	ds := e.ProjectIDs.ElementsAs(ctx, &projectIDs, false)
-	diags = append(diags, ds...)
-	if diags.HasError() {
-		return req, false
+	if !e.ProjectIDs.IsNull() && !e.ProjectIDs.IsUnknown() {
+		ds := e.ProjectIDs.ElementsAs(ctx, &projectIDs, false)
+		diags = append(diags, ds...)
+		if diags.HasError() {
+			return req, false
+		}
 	}
 	var envVariableType string
 
@@ -422,15 +426,10 @@ func (e *SharedEnvironmentVariable) toUpdateSharedEnvironmentVariableRequest(ctx
 // convertResponseToSharedEnvironmentVariable is used to populate terraform state based on an API response.
 // Where possible, values from the API response are used to populate state. If not possible,
 // values from plan are used.
-func convertResponseToSharedEnvironmentVariable(response client.SharedEnvironmentVariableResponse, v types.String) SharedEnvironmentVariable {
+func convertResponseToSharedEnvironmentVariable(response client.SharedEnvironmentVariableResponse, v types.String, projectIDs types.Set) SharedEnvironmentVariable {
 	target := []attr.Value{}
 	for _, t := range response.Target {
 		target = append(target, types.StringValue(t))
-	}
-
-	projectIDs := []attr.Value{}
-	for _, t := range response.ProjectIDs {
-		projectIDs = append(projectIDs, types.StringValue(t))
 	}
 
 	value := types.StringNull()
@@ -448,7 +447,7 @@ func convertResponseToSharedEnvironmentVariable(response client.SharedEnvironmen
 		Key:                          types.StringValue(response.Key),
 		Value:                        value,
 		ValueWO:                      types.StringNull(),
-		ProjectIDs:                   types.SetValueMust(types.StringType, projectIDs),
+		ProjectIDs:                   projectIDs,
 		TeamID:                       toTeamID(response.TeamID),
 		ID:                           types.StringValue(response.ID),
 		Sensitive:                    types.BoolValue(response.Type == "sensitive"),
@@ -485,7 +484,7 @@ func (r *sharedEnvironmentVariableResource) Create(ctx context.Context, req reso
 		return
 	}
 
-	result := convertResponseToSharedEnvironmentVariable(response, plan.Value)
+	result := convertResponseToSharedEnvironmentVariable(response, plan.Value, plan.ProjectIDs)
 
 	tflog.Info(ctx, "created shared environment variable", map[string]any{
 		"id":      result.ID.ValueString(),
@@ -526,7 +525,7 @@ func (r *sharedEnvironmentVariableResource) Read(ctx context.Context, req resour
 		return
 	}
 
-	result := convertResponseToSharedEnvironmentVariable(out, state.Value)
+	result := convertResponseToSharedEnvironmentVariable(out, state.Value, state.ProjectIDs)
 	tflog.Info(ctx, "read shared environment variable", map[string]any{
 		"id":      result.ID.ValueString(),
 		"team_id": result.TeamID.ValueString(),
@@ -567,7 +566,7 @@ func (r *sharedEnvironmentVariableResource) Update(ctx context.Context, req reso
 		return
 	}
 
-	result := convertResponseToSharedEnvironmentVariable(response, plan.Value)
+	result := convertResponseToSharedEnvironmentVariable(response, plan.Value, plan.ProjectIDs)
 
 	tflog.Info(ctx, "updated shared environment variable", map[string]any{
 		"id":      result.ID.ValueString(),
@@ -642,7 +641,12 @@ func (r *sharedEnvironmentVariableResource) ImportState(ctx context.Context, req
 		value = types.StringValue(out.Value)
 	}
 
-	result := convertResponseToSharedEnvironmentVariable(out, value)
+	projectIDs := make([]attr.Value, 0, len(out.ProjectIDs))
+	for _, projectID := range out.ProjectIDs {
+		projectIDs = append(projectIDs, types.StringValue(projectID))
+	}
+
+	result := convertResponseToSharedEnvironmentVariable(out, value, types.SetValueMust(types.StringType, projectIDs))
 	tflog.Info(ctx, "imported shared environment variable", map[string]any{
 		"team_id": result.TeamID.ValueString(),
 		"env_id":  result.ID.ValueString(),

--- a/vercel/resource_shared_environment_variable_unit_test.go
+++ b/vercel/resource_shared_environment_variable_unit_test.go
@@ -26,21 +26,6 @@ func TestSharedEnvironmentVariableResourceSchemaRequiresSensitive(t *testing.T) 
 	assertBoolRequired(t, sensitiveAttr, "sensitive")
 }
 
-func TestSharedEnvironmentVariableResourceSchemaMakesProjectIDsOptional(t *testing.T) {
-	res := newSharedEnvironmentVariableResource()
-
-	resp := &resource.SchemaResponse{}
-	res.Schema(context.Background(), resource.SchemaRequest{}, resp)
-
-	projectIDsAttr, ok := resp.Schema.Attributes["project_ids"].(schema.SetAttribute)
-	if !ok {
-		t.Fatalf("project_ids attribute has unexpected type: %T", resp.Schema.Attributes["project_ids"])
-	}
-	if !projectIDsAttr.Optional || projectIDsAttr.Required || projectIDsAttr.Computed {
-		t.Errorf("project_ids optional = %t, required = %t, computed = %t; want optional only", projectIDsAttr.Optional, projectIDsAttr.Required, projectIDsAttr.Computed)
-	}
-}
-
 func TestSharedEnvironmentVariableCreateRequestOmitsUnconfiguredProjectIDs(t *testing.T) {
 	env := SharedEnvironmentVariable{
 		Target:                       stringSet("production"),
@@ -82,6 +67,24 @@ func TestConvertResponseDoesNotTrackProjectsWhenProjectIDsAreUnconfigured(t *tes
 
 	if !result.ProjectIDs.IsNull() {
 		t.Errorf("ProjectIDs = %#v, want null", result.ProjectIDs)
+	}
+}
+
+func TestConvertResponseTracksConfiguredProjectIDs(t *testing.T) {
+	projectIDs := stringSet("prj_123")
+	result := convertResponseToSharedEnvironmentVariable(client.SharedEnvironmentVariableResponse{
+		ID:         "env_123",
+		Key:        "EXAMPLE",
+		ProjectIDs: []string{"prj_456"},
+	}, types.StringValue("value"), projectIDs)
+
+	var got []string
+	diags := result.ProjectIDs.ElementsAs(context.Background(), &got, false)
+	if diags.HasError() {
+		t.Fatalf("ProjectIDs.ElementsAs() returned diagnostics: %v", diags)
+	}
+	if len(got) != 1 || got[0] != "prj_123" {
+		t.Errorf("ProjectIDs = %#v, want []string{\"prj_123\"}", got)
 	}
 }
 

--- a/vercel/resource_shared_environment_variable_unit_test.go
+++ b/vercel/resource_shared_environment_variable_unit_test.go
@@ -2,7 +2,6 @@ package vercel
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -24,37 +23,6 @@ func TestSharedEnvironmentVariableResourceSchemaRequiresSensitive(t *testing.T) 
 	}
 
 	assertBoolRequired(t, sensitiveAttr, "sensitive")
-}
-
-func TestSharedEnvironmentVariableCreateRequestOmitsUnconfiguredProjectIDs(t *testing.T) {
-	env := SharedEnvironmentVariable{
-		Target:                       stringSet("production"),
-		Key:                          types.StringValue("EXAMPLE"),
-		Value:                        types.StringValue("value"),
-		ProjectIDs:                   types.SetNull(types.StringType),
-		TeamID:                       types.StringValue("team_123"),
-		Sensitive:                    types.BoolValue(true),
-		ApplyToAllCustomEnvironments: types.BoolValue(false),
-	}
-
-	req, ok := env.toCreateSharedEnvironmentVariableRequest(context.Background(), nil, types.StringNull())
-	if !ok {
-		t.Fatal("toCreateSharedEnvironmentVariableRequest() returned false")
-	}
-	if req.EnvironmentVariable.ProjectIDs != nil {
-		t.Errorf("ProjectIDs = %#v, want nil", req.EnvironmentVariable.ProjectIDs)
-	}
-
-	payload, err := json.Marshal(req.EnvironmentVariable)
-	if err != nil {
-		t.Fatalf("json.Marshal() returned an error: %v", err)
-	}
-	if string(payload) == "" {
-		t.Fatal("json.Marshal() returned an empty payload")
-	}
-	if containsJSONField(t, payload, "projectId") {
-		t.Errorf("payload %s contains projectId", payload)
-	}
 }
 
 func TestConvertResponseDoesNotTrackProjectsWhenProjectIDsAreUnconfigured(t *testing.T) {
@@ -86,17 +54,6 @@ func TestConvertResponseTracksConfiguredProjectIDs(t *testing.T) {
 	if len(got) != 1 || got[0] != "prj_123" {
 		t.Errorf("ProjectIDs = %#v, want []string{\"prj_123\"}", got)
 	}
-}
-
-func containsJSONField(t *testing.T, payload []byte, field string) bool {
-	t.Helper()
-
-	var value map[string]json.RawMessage
-	if err := json.Unmarshal(payload, &value); err != nil {
-		t.Fatalf("json.Unmarshal() returned an error: %v", err)
-	}
-	_, ok := value[field]
-	return ok
 }
 
 func TestSharedEnvironmentVariableSensitiveSemantics(t *testing.T) {

--- a/vercel/resource_shared_environment_variable_unit_test.go
+++ b/vercel/resource_shared_environment_variable_unit_test.go
@@ -2,6 +2,7 @@ package vercel
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -23,6 +24,76 @@ func TestSharedEnvironmentVariableResourceSchemaRequiresSensitive(t *testing.T) 
 	}
 
 	assertBoolRequired(t, sensitiveAttr, "sensitive")
+}
+
+func TestSharedEnvironmentVariableResourceSchemaMakesProjectIDsOptional(t *testing.T) {
+	res := newSharedEnvironmentVariableResource()
+
+	resp := &resource.SchemaResponse{}
+	res.Schema(context.Background(), resource.SchemaRequest{}, resp)
+
+	projectIDsAttr, ok := resp.Schema.Attributes["project_ids"].(schema.SetAttribute)
+	if !ok {
+		t.Fatalf("project_ids attribute has unexpected type: %T", resp.Schema.Attributes["project_ids"])
+	}
+	if !projectIDsAttr.Optional || projectIDsAttr.Required || projectIDsAttr.Computed {
+		t.Errorf("project_ids optional = %t, required = %t, computed = %t; want optional only", projectIDsAttr.Optional, projectIDsAttr.Required, projectIDsAttr.Computed)
+	}
+}
+
+func TestSharedEnvironmentVariableCreateRequestOmitsUnconfiguredProjectIDs(t *testing.T) {
+	env := SharedEnvironmentVariable{
+		Target:                       stringSet("production"),
+		Key:                          types.StringValue("EXAMPLE"),
+		Value:                        types.StringValue("value"),
+		ProjectIDs:                   types.SetNull(types.StringType),
+		TeamID:                       types.StringValue("team_123"),
+		Sensitive:                    types.BoolValue(true),
+		ApplyToAllCustomEnvironments: types.BoolValue(false),
+	}
+
+	req, ok := env.toCreateSharedEnvironmentVariableRequest(context.Background(), nil, types.StringNull())
+	if !ok {
+		t.Fatal("toCreateSharedEnvironmentVariableRequest() returned false")
+	}
+	if req.EnvironmentVariable.ProjectIDs != nil {
+		t.Errorf("ProjectIDs = %#v, want nil", req.EnvironmentVariable.ProjectIDs)
+	}
+
+	payload, err := json.Marshal(req.EnvironmentVariable)
+	if err != nil {
+		t.Fatalf("json.Marshal() returned an error: %v", err)
+	}
+	if string(payload) == "" {
+		t.Fatal("json.Marshal() returned an empty payload")
+	}
+	if containsJSONField(t, payload, "projectId") {
+		t.Errorf("payload %s contains projectId", payload)
+	}
+}
+
+func TestConvertResponseDoesNotTrackProjectsWhenProjectIDsAreUnconfigured(t *testing.T) {
+	projectIDs := types.SetNull(types.StringType)
+	result := convertResponseToSharedEnvironmentVariable(client.SharedEnvironmentVariableResponse{
+		ID:         "env_123",
+		Key:        "EXAMPLE",
+		ProjectIDs: []string{"prj_123"},
+	}, types.StringValue("value"), projectIDs)
+
+	if !result.ProjectIDs.IsNull() {
+		t.Errorf("ProjectIDs = %#v, want null", result.ProjectIDs)
+	}
+}
+
+func containsJSONField(t *testing.T, payload []byte, field string) bool {
+	t.Helper()
+
+	var value map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &value); err != nil {
+		t.Fatalf("json.Unmarshal() returned an error: %v", err)
+	}
+	_, ok := value[field]
+	return ok
 }
 
 func TestSharedEnvironmentVariableSensitiveSemantics(t *testing.T) {


### PR DESCRIPTION
## Summary
- make shared environment variable project_ids optional in the provider schema
- omit projectId from create/update payloads when not configured
- preserve imported project IDs in state and add unit coverage

## Notes

This happens when you want to use vercel_shared_environment_variable_project_link: the vercel_shared_environment_variable resource will verify that it has no project ids assigned and will crash