### PR TITLE
Add write-only value version to project environment variables

### DIFF
--- a/client/environment_variable.go
+++ b/client/environment_variable.go
@@ -315,7 +315,7 @@ func (c *Client) CreateEnvironmentVariables(ctx context.Context, request CreateE
 // UpdateEnvironmentVariableRequest defines the information that needs to be passed to Vercel in order to
 // update an environment variable.
 type UpdateEnvironmentVariableRequest struct {
-	Value                string   `json:"value"`
+	Value                *string  `json:"value,omitempty"`
 	Target               []string `json:"target"`
 	CustomEnvironmentIDs []string `json:"customEnvironmentIds,omitempty"`
 	GitBranch            *string  `json:"gitBranch,omitempty"`
@@ -343,7 +343,9 @@ func (c *Client) UpdateEnvironmentVariable(ctx context.Context, request UpdateEn
 		body:   payload,
 	}, &e)
 	// The API response returns an encrypted environment variable, but we want to return the decrypted version.
-	e.Value = request.Value
+	if request.Value != nil {
+		e.Value = *request.Value
+	}
 	e.TeamID = c.TeamID(request.TeamID)
 	return e, err
 }

--- a/docs/resources/project_environment_variable.md
+++ b/docs/resources/project_environment_variable.md
@@ -78,12 +78,13 @@ ephemeral "vault_kv_secret_v2" "example" {
   name  = "example"
 }
 resource "vercel_project_environment_variable" "example_ephemeral" {
-  project_id = vercel_project.example.id
-  key        = "foo"
-  value_wo   = ephemeral.vault_kv_secret_v2.example.data["example"]
-  target     = ["production"]
-  sensitive  = true
-  comment    = "an ephemeral secret"
+  project_id       = vercel_project.example.id
+  key              = "foo"
+  value_wo         = ephemeral.vault_kv_secret_v2.example.data["example"]
+  value_wo_version = 1
+  target           = ["production"]
+  sensitive        = true
+  comment          = "an ephemeral secret"
 }
 ```
 
@@ -107,6 +108,7 @@ resource "vercel_project_environment_variable" "example_ephemeral" {
 - `team_id` (String) The ID of the Vercel team.Required when configuring a team resource if a default team has not been set in the provider.
 - `value` (String, Sensitive) (Optional, exactly one of `value` or `value_wo` is required) The value of the Environment Variable.
 - `value_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) (Optional, Write-Only, exactly one of `value` or `value_wo` is required) The value of the Environment Variable, from an `ephemeral` resource.
+- `value_wo_version` (Number) An integer used to trigger an update to `value_wo`. Increment this value when an update to the write-only value is required.
 
 ### Read-Only
 

--- a/examples/resources/vercel_project_environment_variable/resource.tf
+++ b/examples/resources/vercel_project_environment_variable/resource.tf
@@ -46,10 +46,11 @@ ephemeral "vault_kv_secret_v2" "example" {
   name  = "example"
 }
 resource "vercel_project_environment_variable" "example_ephemeral" {
-  project_id = vercel_project.example.id
-  key        = "foo"
-  value_wo   = ephemeral.vault_kv_secret_v2.example.data["example"]
-  target     = ["production"]
-  sensitive  = true
-  comment    = "an ephemeral secret"
+  project_id       = vercel_project.example.id
+  key              = "foo"
+  value_wo         = ephemeral.vault_kv_secret_v2.example.data["example"]
+  value_wo_version = 1
+  target           = ["production"]
+  sensitive        = true
+  comment          = "an ephemeral secret"
 }

--- a/vercel/resource_project_environment_variable.go
+++ b/vercel/resource_project_environment_variable.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -134,6 +135,14 @@ At this time you cannot use a Vercel Project resource with in-line ` + "`environ
 					),
 				},
 			},
+			"value_wo_version": schema.Int64Attribute{
+				Optional:    true,
+				Description: "An integer used to trigger an update to `value_wo`. Increment this value when an update to the write-only value is required.",
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+					int64validator.AlsoRequires(path.MatchRoot("value_wo")),
+				},
+			},
 			"git_branch": schema.StringAttribute{
 				Optional:    true,
 				Description: "The git branch of the Environment Variable.",
@@ -180,6 +189,7 @@ type ProjectEnvironmentVariable struct {
 	Key                  types.String `tfsdk:"key"`
 	Value                types.String `tfsdk:"value"`
 	ValueWO              types.String `tfsdk:"value_wo"`
+	ValueWOVersion       types.Int64  `tfsdk:"value_wo_version"`
 	TeamID               types.String `tfsdk:"team_id"`
 	ProjectID            types.String `tfsdk:"project_id"`
 	ID                   types.String `tfsdk:"id"`
@@ -193,6 +203,12 @@ func (e ProjectEnvironmentVariable) isExplicitlyNonSensitive() bool {
 
 func (e ProjectEnvironmentVariable) isSensitive() bool {
 	return !e.isExplicitlyNonSensitive()
+}
+
+func shouldUpdateProjectEnvironmentVariableValueWO(state, plan ProjectEnvironmentVariable) bool {
+	versionChanged := !plan.ValueWOVersion.Equal(state.ValueWOVersion)
+	switchedToValueWO := !state.Value.IsNull() && plan.Value.IsNull()
+	return versionChanged || switchedToValueWO
 }
 
 func (e ProjectEnvironmentVariable) hasTarget(ctx context.Context, target string) (bool, diag.Diagnostics) {
@@ -334,10 +350,11 @@ func (e *ProjectEnvironmentVariable) toUpdateEnvironmentVariableRequest(ctx cont
 	} else {
 		envVariableType = "encrypted"
 	}
-	var value string
-	value = e.Value.ValueString()
-	if value == "" {
-		value = valueWO.ValueString()
+	var value *string
+	if !e.Value.IsNull() {
+		value = e.Value.ValueStringPointer()
+	} else if !valueWO.IsNull() {
+		value = valueWO.ValueStringPointer()
 	}
 	return client.UpdateEnvironmentVariableRequest{
 		Value:                value,
@@ -355,7 +372,7 @@ func (e *ProjectEnvironmentVariable) toUpdateEnvironmentVariableRequest(ctx cont
 // convertResponseToProjectEnvironmentVariable is used to populate terraform state based on an API response.
 // Where possible, values from the API response are used to populate state. If not possible,
 // values from plan are used.
-func convertResponseToProjectEnvironmentVariable(response client.EnvironmentVariable, projectID types.String, v types.String) ProjectEnvironmentVariable {
+func convertResponseToProjectEnvironmentVariable(response client.EnvironmentVariable, projectID types.String, v types.String, valueWOVersion types.Int64) ProjectEnvironmentVariable {
 	var target []attr.Value
 	for _, t := range response.Target {
 		target = append(target, types.StringValue(t))
@@ -382,6 +399,7 @@ func convertResponseToProjectEnvironmentVariable(response client.EnvironmentVari
 		Key:                  types.StringValue(response.Key),
 		Value:                value,
 		ValueWO:              types.StringNull(),
+		ValueWOVersion:       valueWOVersion,
 		TeamID:               toTeamID(response.TeamID),
 		ProjectID:            projectID,
 		ID:                   types.StringValue(response.ID),
@@ -436,7 +454,7 @@ func (r *projectEnvironmentVariableResource) Create(ctx context.Context, req res
 		return
 	}
 
-	result := convertResponseToProjectEnvironmentVariable(response, plan.ProjectID, plan.Value)
+	result := convertResponseToProjectEnvironmentVariable(response, plan.ProjectID, plan.Value, plan.ValueWOVersion)
 
 	tflog.Info(ctx, "created project environment variable", map[string]any{
 		"id":         result.ID.ValueString(),
@@ -479,7 +497,7 @@ func (r *projectEnvironmentVariableResource) Read(ctx context.Context, req resou
 		return
 	}
 
-	result := convertResponseToProjectEnvironmentVariable(out, state.ProjectID, state.Value)
+	result := convertResponseToProjectEnvironmentVariable(out, state.ProjectID, state.Value, state.ValueWOVersion)
 	tflog.Info(ctx, "read project environment variable", map[string]any{
 		"id":         result.ID.ValueString(),
 		"team_id":    result.TeamID.ValueString(),
@@ -495,8 +513,14 @@ func (r *projectEnvironmentVariableResource) Read(ctx context.Context, req resou
 
 // Update updates the project environment variable of a Vercel project state.
 func (r *projectEnvironmentVariableResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var state ProjectEnvironmentVariable
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	var plan ProjectEnvironmentVariable
-	diags := req.Plan.Get(ctx, &plan)
+	diags = req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -508,7 +532,12 @@ func (r *projectEnvironmentVariableResource) Update(ctx context.Context, req res
 		return
 	}
 
-	request, diags := plan.toUpdateEnvironmentVariableRequest(ctx, config.ValueWO)
+	valueWO := types.StringNull()
+	if shouldUpdateProjectEnvironmentVariableValueWO(state, plan) {
+		valueWO = config.ValueWO
+	}
+
+	request, diags := plan.toUpdateEnvironmentVariableRequest(ctx, valueWO)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -522,7 +551,7 @@ func (r *projectEnvironmentVariableResource) Update(ctx context.Context, req res
 		return
 	}
 
-	result := convertResponseToProjectEnvironmentVariable(response, plan.ProjectID, plan.Value)
+	result := convertResponseToProjectEnvironmentVariable(response, plan.ProjectID, plan.Value, plan.ValueWOVersion)
 
 	tflog.Info(ctx, "updated project environment variable", map[string]any{
 		"id":         result.ID.ValueString(),
@@ -600,7 +629,7 @@ func (r *projectEnvironmentVariableResource) ImportState(ctx context.Context, re
 		value = types.StringValue(out.Value)
 	}
 
-	result := convertResponseToProjectEnvironmentVariable(out, types.StringValue(projectID), value)
+	result := convertResponseToProjectEnvironmentVariable(out, types.StringValue(projectID), value, types.Int64Null())
 	tflog.Info(ctx, "imported project environment variable", map[string]any{
 		"team_id":    result.TeamID.ValueString(),
 		"project_id": result.ProjectID.ValueString(),

--- a/vercel/resource_project_environment_variable_test.go
+++ b/vercel/resource_project_environment_variable_test.go
@@ -276,6 +276,7 @@ func TestAcc_ProjectEnvironmentVariable_ValueWO(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_project_environment_variable.example_value_wo", "comment", "value_wo-initial"),
 					resource.TestCheckNoResourceAttr("vercel_project_environment_variable.example_value_wo", "value_wo"),
 					resource.TestCheckNoResourceAttr("vercel_project_environment_variable.example_value_wo", "value"),
+					resource.TestCheckResourceAttr("vercel_project_environment_variable.example_value_wo", "value_wo_version", "1"),
 					resource.TestCheckTypeSetElemAttr("vercel_project_environment_variable.example_value_wo", "target.*", "production"),
 				),
 			},
@@ -284,9 +285,10 @@ func TestAcc_ProjectEnvironmentVariable_ValueWO(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccProjectEnvironmentVariableExists(testClient(t), "vercel_project_environment_variable.example_value_wo", testTeam(t)),
 					resource.TestCheckResourceAttr("vercel_project_environment_variable.example_value_wo", "key", "foo_wo"),
-					resource.TestCheckResourceAttr("vercel_project_environment_variable.example_value_wo", "comment", "value_wo-updated"),
+					resource.TestCheckResourceAttr("vercel_project_environment_variable.example_value_wo", "comment", "value_wo-initial"),
 					resource.TestCheckNoResourceAttr("vercel_project_environment_variable.example_value_wo", "value_wo"),
 					resource.TestCheckNoResourceAttr("vercel_project_environment_variable.example_value_wo", "value"),
+					resource.TestCheckResourceAttr("vercel_project_environment_variable.example_value_wo", "value_wo_version", "2"),
 					resource.TestCheckTypeSetElemAttr("vercel_project_environment_variable.example_value_wo", "target.*", "production"),
 				),
 			},
@@ -347,7 +349,8 @@ resource "vercel_project" "example" {
 resource "vercel_project_environment_variable" "example_value_wo" {
 	project_id = vercel_project.example.id
 	key        = "foo_wo"
-	value_wo   = "bar-wo"
+	value_wo         = "bar-wo"
+	value_wo_version = 1
 	target     = ["production"]
 	sensitive  = true
 	comment    = "value_wo-initial"
@@ -369,10 +372,11 @@ resource "vercel_project" "example" {
 resource "vercel_project_environment_variable" "example_value_wo" {
 	project_id = vercel_project.example.id
 	key        = "foo_wo"
-	value_wo   = "bar-wo-updated"
+	value_wo         = "bar-wo-updated"
+	value_wo_version = 2
 	target     = ["production"]
 	sensitive  = true
-	comment    = "value_wo-updated"
+	comment    = "value_wo-initial"
 }
 `, projectName, githubRepo)
 }

--- a/vercel/resource_project_environment_variable_unit_test.go
+++ b/vercel/resource_project_environment_variable_unit_test.go
@@ -26,6 +26,7 @@ func TestConvertResponseToProjectEnvironmentVariableKeepsWriteOnlyValueNull(t *t
 		},
 		types.StringValue("prj_123"),
 		types.StringNull(),
+		types.Int64Value(2),
 	)
 
 	if !result.Value.IsNull() {
@@ -34,6 +35,10 @@ func TestConvertResponseToProjectEnvironmentVariableKeepsWriteOnlyValueNull(t *t
 
 	if !result.ValueWO.IsNull() {
 		t.Fatalf("ValueWO = %v, want null", result.ValueWO)
+	}
+
+	if got := result.ValueWOVersion.ValueInt64(); got != 2 {
+		t.Fatalf("ValueWOVersion = %d, want 2", got)
 	}
 }
 
@@ -51,6 +56,7 @@ func TestConvertResponseToProjectEnvironmentVariableUsesProvidedSensitiveValueWh
 		},
 		types.StringValue("prj_123"),
 		types.StringValue("bar-new"),
+		types.Int64Null(),
 	)
 
 	if result.Value.IsNull() {
@@ -59,6 +65,102 @@ func TestConvertResponseToProjectEnvironmentVariableUsesProvidedSensitiveValueWh
 
 	if got := result.Value.ValueString(); got != "bar-new" {
 		t.Fatalf("Value = %q, want %q", got, "bar-new")
+	}
+}
+
+func TestProjectEnvironmentVariableUpdateRequestOmitsUnchangedWriteOnlyValue(t *testing.T) {
+	t.Parallel()
+
+	env := ProjectEnvironmentVariable{
+		Target:               stringSet("production"),
+		CustomEnvironmentIDs: types.SetNull(types.StringType),
+		Value:                types.StringNull(),
+		Sensitive:            types.BoolValue(true),
+	}
+
+	request, diags := env.toUpdateEnvironmentVariableRequest(context.Background(), types.StringNull())
+	if diags.HasError() {
+		t.Fatalf("toUpdateEnvironmentVariableRequest() returned diagnostics: %v", diags)
+	}
+
+	if request.Value != nil {
+		t.Fatalf("Value = %q, want nil", *request.Value)
+	}
+}
+
+func TestProjectEnvironmentVariableUpdateRequestIncludesChangedWriteOnlyValue(t *testing.T) {
+	t.Parallel()
+
+	env := ProjectEnvironmentVariable{
+		Target:               stringSet("production"),
+		CustomEnvironmentIDs: types.SetNull(types.StringType),
+		Value:                types.StringNull(),
+		Sensitive:            types.BoolValue(true),
+	}
+
+	request, diags := env.toUpdateEnvironmentVariableRequest(context.Background(), types.StringValue("new-secret"))
+	if diags.HasError() {
+		t.Fatalf("toUpdateEnvironmentVariableRequest() returned diagnostics: %v", diags)
+	}
+
+	if request.Value == nil || *request.Value != "new-secret" {
+		t.Fatalf("Value = %v, want new-secret", request.Value)
+	}
+}
+
+func TestShouldUpdateProjectEnvironmentVariableValueWO(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		state ProjectEnvironmentVariable
+		plan  ProjectEnvironmentVariable
+		want  bool
+	}{
+		{
+			name: "unchanged version",
+			state: ProjectEnvironmentVariable{
+				Value:          types.StringNull(),
+				ValueWOVersion: types.Int64Value(1),
+			},
+			plan: ProjectEnvironmentVariable{
+				Value:          types.StringNull(),
+				ValueWOVersion: types.Int64Value(1),
+			},
+			want: false,
+		},
+		{
+			name: "changed version",
+			state: ProjectEnvironmentVariable{
+				Value:          types.StringNull(),
+				ValueWOVersion: types.Int64Value(1),
+			},
+			plan: ProjectEnvironmentVariable{
+				Value:          types.StringNull(),
+				ValueWOVersion: types.Int64Value(2),
+			},
+			want: true,
+		},
+		{
+			name: "switch from persisted value",
+			state: ProjectEnvironmentVariable{
+				Value:          types.StringValue("old-secret"),
+				ValueWOVersion: types.Int64Null(),
+			},
+			plan: ProjectEnvironmentVariable{
+				Value:          types.StringNull(),
+				ValueWOVersion: types.Int64Null(),
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldUpdateProjectEnvironmentVariableValueWO(tt.state, tt.plan); got != tt.want {
+				t.Fatalf("shouldUpdateProjectEnvironmentVariableValueWO() = %t, want %t", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -187,6 +289,7 @@ func TestProjectEnvironmentVariableModifyPlanSkipsPolicyValidationForExistingRes
 		Key:                  types.StringValue("EXAMPLE"),
 		Value:                types.StringValue("value"),
 		ValueWO:              types.StringNull(),
+		ValueWOVersion:       types.Int64Null(),
 		TeamID:               types.StringNull(),
 		ProjectID:            types.StringValue("prj_123"),
 		ID:                   types.StringNull(),
@@ -241,6 +344,7 @@ func TestProjectEnvironmentVariableModifyPlanUsesPlannedDevelopmentTarget(t *tes
 		Key:                  types.StringValue("EXAMPLE"),
 		Value:                types.StringValue("value"),
 		ValueWO:              types.StringNull(),
+		ValueWOVersion:       types.Int64Null(),
 		TeamID:               types.StringNull(),
 		ProjectID:            types.StringValue("prj_123"),
 		ID:                   types.StringNull(),


### PR DESCRIPTION
Adds value_wo_version to project environment variables as a persisted trigger for rotating ephemeral values. Bumping the version resends value_wo, while unrelated updates omit the secret from the Vercel PATCH request.

Existing value_wo configurations remain compatible, and the generated documentation and example show how to opt into versioned rotation.

Closes #570.