### PR TITLE
Fix project domain readiness checks

### DIFF
--- a/client/domain_config.go
+++ b/client/domain_config.go
@@ -20,11 +20,13 @@ type recommendedCNAMEValue struct {
 type domainConfigAPIResponse struct {
 	RecommendedCNAME []recommendedCNAMEValue `json:"recommendedCNAME"`
 	RecommendedIPv4  []recommendedValue      `json:"recommendedIPv4"`
+	Misconfigured    bool                    `json:"misconfigured"`
 }
 
 type DomainConfigResponse struct {
 	RecommendedCNAME string
 	RecommendedIPv4s []string
+	Misconfigured    bool
 }
 
 func (c *Client) GetDomainConfig(ctx context.Context, domain, projectIdOrName, teamID string) (DomainConfigResponse, error) {
@@ -49,7 +51,9 @@ func (c *Client) GetDomainConfig(ctx context.Context, domain, projectIdOrName, t
 		return DomainConfigResponse{}, fmt.Errorf("unable to get domain config: %w", err)
 	}
 
-	response := DomainConfigResponse{}
+	response := DomainConfigResponse{
+		Misconfigured: apiResponse.Misconfigured,
+	}
 
 	for _, reccomendation := range apiResponse.RecommendedCNAME {
 		if reccomendation.Rank == 1 {

--- a/client/domain_config_test.go
+++ b/client/domain_config_test.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestGetDomainConfigIncludesMisconfigured(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if got, want := r.URL.Path, "/v6/domains/www.example.com/config"; got != want {
+			t.Fatalf("request path = %q, want %q", got, want)
+		}
+		if got, want := r.URL.Query().Get("projectIdOrName"), "prj_123"; got != want {
+			t.Fatalf("projectIdOrName = %q, want %q", got, want)
+		}
+		if got, want := r.URL.Query().Get("teamId"), "team_123"; got != want {
+			t.Fatalf("teamId = %q, want %q", got, want)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(`{
+			"misconfigured": true,
+			"recommendedCNAME": [{"rank": 1, "value": "example.vercel-dns-017.com"}],
+			"recommendedIPv4": [{"rank": 1, "value": ["76.76.21.21"]}]
+		}`)),
+		}, nil
+	})}
+
+	testClient := New("INVALID").WithBaseURL("https://api.vercel.test")
+	testClient.client = httpClient
+	got, err := testClient.GetDomainConfig(
+		context.Background(),
+		"www.example.com",
+		"prj_123",
+		"team_123",
+	)
+	if err != nil {
+		t.Fatalf("GetDomainConfig() error = %v", err)
+	}
+	if !got.Misconfigured {
+		t.Fatal("GetDomainConfig().Misconfigured = false, want true")
+	}
+	if got.RecommendedCNAME != "example.vercel-dns-017.com" {
+		t.Fatalf("GetDomainConfig().RecommendedCNAME = %q, want %q", got.RecommendedCNAME, "example.vercel-dns-017.com")
+	}
+	if len(got.RecommendedIPv4s) != 1 || got.RecommendedIPv4s[0] != "76.76.21.21" {
+		t.Fatalf("GetDomainConfig().RecommendedIPv4s = %v, want [76.76.21.21]", got.RecommendedIPv4s)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}

--- a/docs/data-sources/domain_config.md
+++ b/docs/data-sources/domain_config.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Provides domain configuration information for a Vercel project.
   This data source returns configuration details for a domain associated with a specific project,
-  including recommended CNAME and IPv4 values.
+  including its DNS configuration status and recommended CNAME and IPv4 values.
 ---
 
 # vercel_domain_config (Data Source)
@@ -13,7 +13,7 @@ description: |-
 Provides domain configuration information for a Vercel project.
 
 This data source returns configuration details for a domain associated with a specific project,
-including recommended CNAME and IPv4 values.
+including its DNS configuration status and recommended CNAME and IPv4 values.
 
 ## Example Usage
 
@@ -69,5 +69,6 @@ resource "aws_route53_record" "www_example_com_cname" {
 
 ### Read-Only
 
+- `misconfigured` (Boolean) Whether the domain has an invalid DNS configuration or Vercel cannot automatically generate a TLS certificate for it.
 - `recommended_cname` (String) The recommended CNAME value for the domain.
 - `recommended_ipv4s` (List of String) The recommended IPv4 values for the domain.

--- a/docs/resources/project_domain.md
+++ b/docs/resources/project_domain.md
@@ -63,13 +63,14 @@ resource "vercel_project_domain" "example_redirect" {
 - `redirect` (String) The domain name that serves as a target destination for redirects.
 - `redirect_status_code` (Number) The HTTP status code to use when serving as a redirect.
 - `team_id` (String) The ID of the team the project exists under. Required when configuring a team resource if a default team has not been set in the provider.
-- `wait_for_ready` (Boolean) Wait until the project domain is verified before considering it created. This is useful when another resource, such as an alias, depends on the domain being ready immediately.
+- `wait_for_ready` (Boolean) Wait until the project domain is verified and has a valid DNS configuration before considering it created. DNS records must be configured independently before enabling this option because dependent resources are not created until the wait completes.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `verification` (Attributes List) A list of verification challenges, one of which must be completed to verify the domain for use on the project. Once the challenge is satisfied, the domain will be verified automatically on the next refresh. Typically used to configure DNS records (e.g. a `TXT` record) for domains hosted with an external DNS provider. (see [below for nested schema](#nestedatt--verification))
-- `verified` (Boolean) Whether the domain is verified for use with the project. If `false`, the challenges in `verification` must be completed before the domain will serve traffic for the project.
+- `misconfigured` (Boolean) Whether the domain has an invalid DNS configuration or Vercel cannot automatically generate a TLS certificate for it.
+- `verification` (Attributes List) A list of ownership verification challenges, one of which must be completed to verify the domain for use with the project. These are typically `TXT` records and do not describe the `A` or `CNAME` records needed to route traffic to Vercel. (see [below for nested schema](#nestedatt--verification))
+- `verified` (Boolean) Whether ownership of the domain is verified for use with the project. This does not indicate whether the domain's DNS records point to Vercel; use `misconfigured` for that status.
 
 <a id="nestedatt--verification"></a>
 ### Nested Schema for `verification`

--- a/vercel/data_source_domain_config.go
+++ b/vercel/data_source_domain_config.go
@@ -55,7 +55,7 @@ func (d *domainConfigDataSource) Schema(_ context.Context, req datasource.Schema
 Provides domain configuration information for a Vercel project.
 
 This data source returns configuration details for a domain associated with a specific project,
-including recommended CNAME and IPv4 values.
+including its DNS configuration status and recommended CNAME and IPv4 values.
 		`,
 		Attributes: map[string]schema.Attribute{
 			"domain": schema.StringAttribute{
@@ -80,6 +80,10 @@ including recommended CNAME and IPv4 values.
 				Computed:    true,
 				Description: "The recommended IPv4 values for the domain.",
 			},
+			"misconfigured": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Whether the domain has an invalid DNS configuration or Vercel cannot automatically generate a TLS certificate for it.",
+			},
 		},
 	}
 }
@@ -91,6 +95,7 @@ type DomainConfigDataSource struct {
 	TeamID           types.String `tfsdk:"team_id"`
 	RecommendedCNAME types.String `tfsdk:"recommended_cname"`
 	RecommendedIPv4s types.List   `tfsdk:"recommended_ipv4s"`
+	Misconfigured    types.Bool   `tfsdk:"misconfigured"`
 }
 
 // Read will read domain config information by requesting it from the Vercel API, and will update terraform
@@ -128,6 +133,7 @@ func (d *domainConfigDataSource) Read(ctx context.Context, req datasource.ReadRe
 		TeamID:           config.TeamID,
 		RecommendedCNAME: types.StringValue(out.RecommendedCNAME),
 		RecommendedIPv4s: types.ListValueMust(types.StringType, ipv4Values),
+		Misconfigured:    types.BoolValue(out.Misconfigured),
 	}
 
 	tflog.Info(ctx, "read domain config", map[string]any{
@@ -136,6 +142,7 @@ func (d *domainConfigDataSource) Read(ctx context.Context, req datasource.ReadRe
 		"teamId":           result.TeamID.ValueString(),
 		"recommendedCNAME": result.RecommendedCNAME.ValueString(),
 		"recommendedIPv4s": result.RecommendedIPv4s.Elements(),
+		"misconfigured":    result.Misconfigured.ValueBool(),
 	})
 
 	diags = resp.State.Set(ctx, result)

--- a/vercel/data_source_domain_config_test.go
+++ b/vercel/data_source_domain_config_test.go
@@ -23,6 +23,7 @@ func TestAcc_DomainConfigDataSource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.vercel_domain_config.test", "project_id_or_name"),
 					resource.TestCheckResourceAttrSet("data.vercel_domain_config.test", "recommended_cname"),
 					resource.TestCheckResourceAttrSet("data.vercel_domain_config.test", "recommended_ipv4s.#"),
+					resource.TestCheckResourceAttrSet("data.vercel_domain_config.test", "misconfigured"),
 				),
 			},
 		},

--- a/vercel/resource_project_domain.go
+++ b/vercel/resource_project_domain.go
@@ -3,6 +3,7 @@ package vercel
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -121,15 +122,15 @@ By default, Project Domains will be automatically applied to any ` + "`productio
 				},
 			},
 			"wait_for_ready": schema.BoolAttribute{
-				Description: "Wait until the project domain is verified before considering it created. This is useful when another resource, such as an alias, depends on the domain being ready immediately.",
+				Description: "Wait until the project domain is verified and has a valid DNS configuration before considering it created. DNS records must be configured independently before enabling this option because dependent resources are not created until the wait completes.",
 				Optional:    true,
 			},
 			"verified": schema.BoolAttribute{
-				Description: "Whether the domain is verified for use with the project. If `false`, the challenges in `verification` must be completed before the domain will serve traffic for the project.",
+				Description: "Whether ownership of the domain is verified for use with the project. This does not indicate whether the domain's DNS records point to Vercel; use `misconfigured` for that status.",
 				Computed:    true,
 			},
 			"verification": schema.ListNestedAttribute{
-				Description: "A list of verification challenges, one of which must be completed to verify the domain for use on the project. Once the challenge is satisfied, the domain will be verified automatically on the next refresh. Typically used to configure DNS records (e.g. a `TXT` record) for domains hosted with an external DNS provider.",
+				Description: "A list of ownership verification challenges, one of which must be completed to verify the domain for use with the project. These are typically `TXT` records and do not describe the `A` or `CNAME` records needed to route traffic to Vercel.",
 				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -151,6 +152,10 @@ By default, Project Domains will be automatically applied to any ` + "`productio
 						},
 					},
 				},
+			},
+			"misconfigured": schema.BoolAttribute{
+				Description: "Whether the domain has an invalid DNS configuration or Vercel cannot automatically generate a TLS certificate for it.",
+				Computed:    true,
 			},
 		},
 	}
@@ -186,9 +191,10 @@ type ProjectDomain struct {
 	WaitForReady        types.Bool   `tfsdk:"wait_for_ready"`
 	Verified            types.Bool   `tfsdk:"verified"`
 	Verification        types.List   `tfsdk:"verification"`
+	Misconfigured       types.Bool   `tfsdk:"misconfigured"`
 }
 
-func convertResponseToProjectDomain(response client.ProjectDomainResponse) ProjectDomain {
+func convertResponseToProjectDomain(response client.ProjectDomainResponse, domainConfig client.DomainConfigResponse) ProjectDomain {
 	verification := make([]attr.Value, 0, len(response.Verification))
 	for _, v := range response.Verification {
 		verification = append(verification, projectDomainVerificationAttrValue(v))
@@ -205,6 +211,7 @@ func convertResponseToProjectDomain(response client.ProjectDomainResponse) Proje
 		TeamID:              toTeamID(response.TeamID),
 		Verified:            types.BoolValue(response.Verified),
 		Verification:        types.ListValueMust(projectDomainVerificationAttrType, verification),
+		Misconfigured:       types.BoolValue(domainConfig.Misconfigured),
 	}
 }
 
@@ -282,12 +289,26 @@ func (r *projectDomainResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	var domainConfig client.DomainConfigResponse
 	if plan.WaitForReady.ValueBool() {
-		out, err = r.waitForProjectDomainReady(ctx, plan.ProjectID.ValueString(), plan.Domain.ValueString(), plan.TeamID.ValueString())
+		out, domainConfig, err = r.waitForProjectDomainReady(ctx, plan.ProjectID.ValueString(), plan.Domain.ValueString(), plan.TeamID.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error waiting for project domain",
-				fmt.Sprintf("Could not wait for domain %s for project %s to become verified: %s",
+				fmt.Sprintf("Could not wait for domain %s for project %s to become ready: %s",
+					plan.Domain.ValueString(),
+					plan.ProjectID.ValueString(),
+					err,
+				),
+			)
+			return
+		}
+	} else {
+		domainConfig, err = r.client.GetDomainConfig(ctx, plan.Domain.ValueString(), plan.ProjectID.ValueString(), plan.TeamID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error reading project domain configuration",
+				fmt.Sprintf("Could not get DNS configuration for domain %s and project %s, unexpected error: %s",
 					plan.Domain.ValueString(),
 					plan.ProjectID.ValueString(),
 					err,
@@ -297,7 +318,7 @@ func (r *projectDomainResource) Create(ctx context.Context, req resource.CreateR
 		}
 	}
 
-	result := convertResponseToProjectDomain(out)
+	result := convertResponseToProjectDomain(out, domainConfig)
 	result.WaitForReady = plan.WaitForReady
 	tflog.Info(ctx, "added domain to project", map[string]any{
 		"project_id": result.ProjectID.ValueString(),
@@ -339,7 +360,20 @@ func (r *projectDomainResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	result := convertResponseToProjectDomain(out)
+	domainConfig, err := r.client.GetDomainConfig(ctx, state.Domain.ValueString(), state.ProjectID.ValueString(), state.TeamID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading project domain configuration",
+			fmt.Sprintf("Could not get DNS configuration for domain %s and project %s, unexpected error: %s",
+				state.Domain.ValueString(),
+				state.ProjectID.ValueString(),
+				err,
+			),
+		)
+		return
+	}
+
+	result := convertResponseToProjectDomain(out, domainConfig)
 	result.WaitForReady = state.WaitForReady
 	tflog.Info(ctx, "read project domain", map[string]any{
 		"project_id": result.ProjectID.ValueString(),
@@ -382,12 +416,26 @@ func (r *projectDomainResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
+	var domainConfig client.DomainConfigResponse
 	if plan.WaitForReady.ValueBool() {
-		out, err = r.waitForProjectDomainReady(ctx, plan.ProjectID.ValueString(), plan.Domain.ValueString(), plan.TeamID.ValueString())
+		out, domainConfig, err = r.waitForProjectDomainReady(ctx, plan.ProjectID.ValueString(), plan.Domain.ValueString(), plan.TeamID.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error waiting for project domain",
-				fmt.Sprintf("Could not wait for domain %s for project %s to become verified: %s",
+				fmt.Sprintf("Could not wait for domain %s for project %s to become ready: %s",
+					plan.Domain.ValueString(),
+					plan.ProjectID.ValueString(),
+					err,
+				),
+			)
+			return
+		}
+	} else {
+		domainConfig, err = r.client.GetDomainConfig(ctx, plan.Domain.ValueString(), plan.ProjectID.ValueString(), plan.TeamID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error reading project domain configuration",
+				fmt.Sprintf("Could not get DNS configuration for domain %s and project %s, unexpected error: %s",
 					plan.Domain.ValueString(),
 					plan.ProjectID.ValueString(),
 					err,
@@ -397,7 +445,7 @@ func (r *projectDomainResource) Update(ctx context.Context, req resource.UpdateR
 		}
 	}
 
-	result := convertResponseToProjectDomain(out)
+	result := convertResponseToProjectDomain(out, domainConfig)
 	result.WaitForReady = plan.WaitForReady
 	tflog.Info(ctx, "update project domain", map[string]any{
 		"project_id": result.ProjectID.ValueString(),
@@ -472,7 +520,20 @@ func (r *projectDomainResource) ImportState(ctx context.Context, req resource.Im
 		return
 	}
 
-	result := convertResponseToProjectDomain(out)
+	domainConfig, err := r.client.GetDomainConfig(ctx, domain, projectID, teamID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading project domain configuration",
+			fmt.Sprintf("Could not get DNS configuration for domain %s and project %s, unexpected error: %s",
+				domain,
+				projectID,
+				err,
+			),
+		)
+		return
+	}
+
+	result := convertResponseToProjectDomain(out, domainConfig)
 	tflog.Info(ctx, "imported project domain", map[string]any{
 		"project_id": result.ProjectID.ValueString(),
 		"domain":     result.Domain.ValueString(),
@@ -486,7 +547,7 @@ func (r *projectDomainResource) ImportState(ctx context.Context, req resource.Im
 	}
 }
 
-func (r *projectDomainResource) waitForProjectDomainReady(ctx context.Context, projectID, domain, teamID string) (client.ProjectDomainResponse, error) {
+func (r *projectDomainResource) waitForProjectDomainReady(ctx context.Context, projectID, domain, teamID string) (client.ProjectDomainResponse, client.DomainConfigResponse, error) {
 	ctx, cancel := context.WithTimeout(ctx, projectDomainReadyTimeout)
 	defer cancel()
 
@@ -496,22 +557,55 @@ func (r *projectDomainResource) waitForProjectDomainReady(ctx context.Context, p
 	for {
 		out, err := r.client.GetProjectDomain(ctx, projectID, domain, teamID)
 		if err != nil {
-			return out, err
-		}
-		if out.Verified {
-			return out, nil
+			return out, client.DomainConfigResponse{}, err
 		}
 
-		tflog.Info(ctx, "project domain is not verified yet", map[string]any{
-			"project_id": projectID,
-			"domain":     domain,
-			"team_id":    teamID,
+		domainConfig, err := r.client.GetDomainConfig(ctx, domain, projectID, teamID)
+		if err != nil {
+			return out, domainConfig, err
+		}
+		if projectDomainReady(out, domainConfig) {
+			return out, domainConfig, nil
+		}
+
+		tflog.Info(ctx, "project domain is not ready yet", map[string]any{
+			"project_id":    projectID,
+			"domain":        domain,
+			"team_id":       teamID,
+			"verified":      out.Verified,
+			"misconfigured": domainConfig.Misconfigured,
 		})
 
 		select {
 		case <-ctx.Done():
-			return out, ctx.Err()
+			return out, domainConfig, fmt.Errorf("%w: %s", ctx.Err(), projectDomainNotReadyReason(out, domainConfig))
 		case <-ticker.C:
 		}
 	}
+}
+
+func projectDomainReady(projectDomain client.ProjectDomainResponse, domainConfig client.DomainConfigResponse) bool {
+	return projectDomain.Verified && !domainConfig.Misconfigured
+}
+
+func projectDomainNotReadyReason(projectDomain client.ProjectDomainResponse, domainConfig client.DomainConfigResponse) string {
+	reasons := make([]string, 0, 2)
+	if !projectDomain.Verified {
+		reasons = append(reasons, "domain ownership verification is still pending")
+	}
+	if domainConfig.Misconfigured {
+		reason := "DNS configuration is still invalid"
+		recommendations := make([]string, 0, 2)
+		if domainConfig.RecommendedCNAME != "" {
+			recommendations = append(recommendations, fmt.Sprintf("CNAME %q", domainConfig.RecommendedCNAME))
+		}
+		if len(domainConfig.RecommendedIPv4s) > 0 {
+			recommendations = append(recommendations, fmt.Sprintf("IPv4 addresses %s", strings.Join(domainConfig.RecommendedIPv4s, ", ")))
+		}
+		if len(recommendations) > 0 {
+			reason += "; recommended values: " + strings.Join(recommendations, ", ")
+		}
+		reasons = append(reasons, reason)
+	}
+	return strings.Join(reasons, "; ")
 }

--- a/vercel/resource_project_domain_test.go
+++ b/vercel/resource_project_domain_test.go
@@ -42,6 +42,7 @@ func TestAcc_ProjectDomain(t *testing.T) {
 					resource.TestCheckResourceAttr("vercel_project_domain.test", "domain", "2"+domain),
 					resource.TestCheckResourceAttrSet("vercel_project_domain.test", "verified"),
 					resource.TestCheckResourceAttrSet("vercel_project_domain.test", "verification.#"),
+					resource.TestCheckResourceAttrSet("vercel_project_domain.test", "misconfigured"),
 				),
 			},
 			// Update testing
@@ -102,6 +103,7 @@ func TestAcc_ProjectDomainWaitForReady(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("vercel_project_domain.test", "wait_for_ready", "true"),
 					resource.TestCheckResourceAttrSet("vercel_project_domain.test", "custom_environment_id"),
+					resource.TestCheckResourceAttr("vercel_project_domain.test", "misconfigured", "false"),
 				),
 			},
 		},

--- a/vercel/resource_project_domain_unit_test.go
+++ b/vercel/resource_project_domain_unit_test.go
@@ -2,7 +2,12 @@ package vercel
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
@@ -30,10 +35,13 @@ func TestConvertResponseToProjectDomainIncludesVerification(t *testing.T) {
 				Reason: "pending_domain_verification",
 			},
 		},
-	})
+	}, client.DomainConfigResponse{Misconfigured: true})
 
 	if got := result.Verified.ValueBool(); got {
 		t.Fatalf("Verified = %t, want false", got)
+	}
+	if got := result.Misconfigured.ValueBool(); !got {
+		t.Fatalf("Misconfigured = %t, want true", got)
 	}
 
 	var verification []ProjectDomainVerification
@@ -57,5 +65,80 @@ func TestConvertResponseToProjectDomainIncludesVerification(t *testing.T) {
 	}
 	if got := first.Reason.ValueString(); got != "pending_domain_verification" {
 		t.Fatalf("Verification[0].Reason = %q, want pending_domain_verification", got)
+	}
+}
+
+func TestProjectDomainReady(t *testing.T) {
+	tests := []struct {
+		name          string
+		verified      bool
+		misconfigured bool
+		want          bool
+	}{
+		{name: "ready", verified: true, misconfigured: false, want: true},
+		{name: "ownership pending", verified: false, misconfigured: false, want: false},
+		{name: "DNS misconfigured", verified: true, misconfigured: true, want: false},
+		{name: "both pending", verified: false, misconfigured: true, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := projectDomainReady(
+				client.ProjectDomainResponse{Verified: tt.verified},
+				client.DomainConfigResponse{Misconfigured: tt.misconfigured},
+			)
+			if got != tt.want {
+				t.Fatalf("projectDomainReady() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectDomainNotReadyReasonIncludesDNSRecommendations(t *testing.T) {
+	got := projectDomainNotReadyReason(
+		client.ProjectDomainResponse{Verified: true},
+		client.DomainConfigResponse{
+			Misconfigured:    true,
+			RecommendedCNAME: "example.vercel-dns-017.com",
+			RecommendedIPv4s: []string{"76.76.21.21"},
+		},
+	)
+	want := `DNS configuration is still invalid; recommended values: CNAME "example.vercel-dns-017.com", IPv4 addresses 76.76.21.21`
+	if got != want {
+		t.Fatalf("projectDomainNotReadyReason() = %q, want %q", got, want)
+	}
+}
+
+func TestWaitForProjectDomainReadyChecksDNSConfiguration(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v9/projects/prj_123/domains/www.example.com":
+			fmt.Fprintln(w, `{"name":"www.example.com","projectId":"prj_123","verified":true}`)
+		case "/v6/domains/www.example.com/config":
+			fmt.Fprintln(w, `{
+				"misconfigured": true,
+				"recommendedCNAME": [{"rank": 1, "value": "example.vercel-dns-017.com"}],
+				"recommendedIPv4": []
+			}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	testResource := &projectDomainResource{client: client.New("INVALID").WithBaseURL(server.URL)}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, _, err := testResource.waitForProjectDomainReady(ctx, "prj_123", "www.example.com", "team_123")
+	if err == nil {
+		t.Fatal("waitForProjectDomainReady() error = nil, want DNS misconfiguration error")
+	}
+	if !strings.Contains(err.Error(), "DNS configuration is still invalid") {
+		t.Fatalf("waitForProjectDomainReady() error = %q, want DNS misconfiguration details", err)
+	}
+	if !strings.Contains(err.Error(), `CNAME "example.vercel-dns-017.com"`) {
+		t.Fatalf("waitForProjectDomainReady() error = %q, want recommended CNAME", err)
 	}
 }


### PR DESCRIPTION
- Require both project ownership verification and valid DNS configuration before `wait_for_ready` completes.
- Expose `misconfigured` on project domains and domain configuration data, with actionable DNS recommendations on timeout.
- Clarify the distinction between ownership verification and DNS readiness.

Closes #569 
