### PR TITLE
docs: fix teh typo in edge config item import

### DIFF
--- a/docs/resources/edge_config_item.md
+++ b/docs/resources/edge_config_item.md
@@ -61,7 +61,7 @@ The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/c
 # If importing into a personal account, or with a team configured on
 # the provider, simply use the edge config id and the key of the item to import.
 # - edge_config_id can be found by navigating to the Edge Config in the Vercel UI. It should begin with `ecfg_`.
-# - key is the key of teh item to import.
+# - key is the key of the item to import.
 terraform import vercel_edge_config.example ecfg_xxxxxxxxxxxxxxxxxxxxxxxxxxxx/example_key
 
 # Alternatively, you can import via the team_id, edge_config_id and the key of the item to import.

--- a/examples/resources/vercel_edge_config_item/import.sh
+++ b/examples/resources/vercel_edge_config_item/import.sh
@@ -1,7 +1,7 @@
 # If importing into a personal account, or with a team configured on
 # the provider, simply use the edge config id and the key of the item to import.
 # - edge_config_id can be found by navigating to the Edge Config in the Vercel UI. It should begin with `ecfg_`.
-# - key is the key of teh item to import.
+# - key is the key of the item to import.
 terraform import vercel_edge_config.example ecfg_xxxxxxxxxxxxxxxxxxxxxxxxxxxx/example_key
 
 # Alternatively, you can import via the team_id, edge_config_id and the key of the item to import.


### PR DESCRIPTION
Fixes `teh` to `the` in the Edge Config Item import docs and example. Docs-only change.