### PR TITLE
Add import support for Vercel webhooks

### DIFF
--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -56,3 +56,21 @@ resource "vercel_webhook" "without_project_ids" {
 
 - `id` (String) The ID of the Webhook.
 - `secret` (String, Sensitive) A secret value which will be provided in the `x-vercel-signature` header and can be used to verify the authenticity of the webhook. See https://vercel.com/docs/observability/webhooks-overview/webhooks-api#securing-webhooks for further details.
+
+## Import
+
+Import is supported using the following syntax:
+
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
+```shell
+# If importing into a personal account, or with a team configured on the
+# provider, use the webhook ID.
+terraform import vercel_webhook.example hook_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Alternatively, import using the team ID and webhook ID.
+terraform import vercel_webhook.example team_xxxxxxxxxxxxxxxxxxxxxxxx/hook_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Vercel does not return an existing webhook's signing secret, so the imported
+# secret value will be null.
+```

--- a/examples/resources/vercel_webhook/import.sh
+++ b/examples/resources/vercel_webhook/import.sh
@@ -1,0 +1,9 @@
+# If importing into a personal account, or with a team configured on the
+# provider, use the webhook ID.
+terraform import vercel_webhook.example hook_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Alternatively, import using the team ID and webhook ID.
+terraform import vercel_webhook.example team_xxxxxxxxxxxxxxxxxxxxxxxx/hook_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Vercel does not return an existing webhook's signing secret, so the imported
+# secret value will be null.

--- a/vercel/import_state_unit_test.go
+++ b/vercel/import_state_unit_test.go
@@ -50,6 +50,7 @@ func TestImportStateInvalidIDReturnsBeforeClientCall(t *testing.T) {
 		}},
 		{name: "team member", run: func(resp *resource.ImportStateResponse) { (&teamMemberResource{}).ImportState(ctx, req, resp) }},
 		{name: "trace drain", run: func(resp *resource.ImportStateResponse) { (&traceDrainResource{}).ImportState(ctx, req, resp) }},
+		{name: "webhook", run: func(resp *resource.ImportStateResponse) { (&webhookResource{}).ImportState(ctx, req, resp) }},
 	}
 
 	for _, tt := range tests {

--- a/vercel/resource_webhook.go
+++ b/vercel/resource_webhook.go
@@ -20,8 +20,9 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource              = &webhookResource{}
-	_ resource.ResourceWithConfigure = &webhookResource{}
+	_ resource.Resource                = &webhookResource{}
+	_ resource.ResourceWithConfigure   = &webhookResource{}
+	_ resource.ResourceWithImportState = &webhookResource{}
 )
 
 func newWebhookResource() resource.Resource {
@@ -171,7 +172,7 @@ type Webhook struct {
 	Events     types.Set    `tfsdk:"events"`
 }
 
-func responseToWebhook(ctx context.Context, out client.Webhook) (Webhook, diag.Diagnostics) {
+func responseToWebhook(ctx context.Context, out client.Webhook, secret types.String) (Webhook, diag.Diagnostics) {
 	projectIDs, diags := types.SetValueFrom(ctx, types.StringType, out.ProjectIDs)
 	if diags.HasError() {
 		return Webhook{}, diags
@@ -185,7 +186,7 @@ func responseToWebhook(ctx context.Context, out client.Webhook) (Webhook, diag.D
 		ID:         types.StringValue(out.ID),
 		TeamID:     types.StringValue(out.TeamID),
 		Endpoint:   types.StringValue(out.Endpoint),
-		Secret:     types.StringValue(out.Secret),
+		Secret:     secret,
 		ProjectIDs: projectIDs,
 		Events:     events,
 	}, diags
@@ -226,7 +227,7 @@ func (r *webhookResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	result, diags := responseToWebhook(ctx, out)
+	result, diags := responseToWebhook(ctx, out, types.StringValue(out.Secret))
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -270,9 +271,8 @@ func (r *webhookResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	// Override the secret with state as this is not returned by the 'GET' endpoint.
-	out.Secret = state.Secret.ValueString()
-	result, diags := responseToWebhook(ctx, out)
+	// Preserve the secret from state as this is not returned by the 'GET' endpoint.
+	result, diags := responseToWebhook(ctx, out, state.Secret)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -287,6 +287,43 @@ func (r *webhookResource) Read(ctx context.Context, req resource.ReadRequest, re
 	if resp.Diagnostics.HasError() {
 		return
 	}
+}
+
+func (r *webhookResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	teamID, id, ok := splitInto1Or2(req.ID)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Error importing Webhook",
+			fmt.Sprintf("Invalid id '%s' specified. should be in format \"team_id/webhook_id\" or \"webhook_id\"", req.ID),
+		)
+		return
+	}
+
+	out, err := r.client.GetWebhook(ctx, id, teamID)
+	if client.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error importing Webhook",
+			fmt.Sprintf("Could not get Webhook %s %s, unexpected error: %s", teamID, id, err),
+		)
+		return
+	}
+
+	result, diags := responseToWebhook(ctx, out, types.StringNull())
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	tflog.Info(ctx, "import webhook", map[string]any{
+		"team_id":    result.TeamID.ValueString(),
+		"webhook_id": result.ID.ValueString(),
+	})
+
+	diags = resp.State.Set(ctx, result)
+	resp.Diagnostics.Append(diags...)
 }
 
 // Update does nothing.

--- a/vercel/resource_webhook.go
+++ b/vercel/resource_webhook.go
@@ -3,6 +3,7 @@ package vercel
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -291,7 +292,7 @@ func (r *webhookResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 func (r *webhookResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	teamID, id, ok := splitInto1Or2(req.ID)
-	if !ok {
+	if !ok || id == "" || (strings.Contains(req.ID, "/") && teamID == "") {
 		resp.Diagnostics.AddError(
 			"Error importing Webhook",
 			fmt.Sprintf("Invalid id '%s' specified. should be in format \"team_id/webhook_id\" or \"webhook_id\"", req.ID),

--- a/vercel/resource_webhook_test.go
+++ b/vercel/resource_webhook_test.go
@@ -74,8 +74,38 @@ func TestAcc_WebhookResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("vercel_webhook.without_project_ids", "secret"),
 				),
 			},
+			{
+				ResourceName:            "vercel_webhook.with_project_ids",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"secret"},
+				ImportStateIdFunc:       getWebhookImportID("vercel_webhook.with_project_ids", true),
+			},
+			{
+				ResourceName:            "vercel_webhook.without_project_ids",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"secret"},
+				ImportStateIdFunc:       getWebhookImportID("vercel_webhook.without_project_ids", false),
+			},
 		},
 	})
+}
+
+func getWebhookImportID(n string, includeTeamID bool) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return "", fmt.Errorf("no ID is set")
+		}
+		if includeTeamID {
+			return fmt.Sprintf("%s/%s", rs.Primary.Attributes["team_id"], rs.Primary.ID), nil
+		}
+		return rs.Primary.ID, nil
+	}
 }
 
 func testAccResourceWebhook(name string) string {

--- a/vercel/resource_webhook_unit_test.go
+++ b/vercel/resource_webhook_unit_test.go
@@ -122,6 +122,33 @@ func TestWebhookImportStateAPIErrors(t *testing.T) {
 	}
 }
 
+func TestWebhookImportStateRejectsMalformedIDs(t *testing.T) {
+	t.Parallel()
+
+	for _, importID := range []string{
+		"",
+		"/",
+		"/hook_123",
+		"team_123/",
+		"team_123/hook_123/extra",
+	} {
+		t.Run(importID, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &resource.ImportStateResponse{}
+			(&webhookResource{}).ImportState(
+				context.Background(),
+				resource.ImportStateRequest{ID: importID},
+				resp,
+			)
+
+			if !resp.Diagnostics.HasError() {
+				t.Fatal("ImportState() returned no diagnostics for malformed ID")
+			}
+		})
+	}
+}
+
 func importWebhookState(t *testing.T, baseURL string, team client.Team, importID string) Webhook {
 	t.Helper()
 

--- a/vercel/resource_webhook_unit_test.go
+++ b/vercel/resource_webhook_unit_test.go
@@ -1,0 +1,157 @@
+package vercel
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
+)
+
+func TestWebhookImportState(t *testing.T) {
+	t.Parallel()
+
+	const (
+		webhookID = "hook_123"
+		teamID    = "team_123"
+	)
+
+	for _, tt := range []struct {
+		name           string
+		importID       string
+		configuredTeam client.Team
+	}{
+		{
+			name:     "team and webhook ID",
+			importID: teamID + "/" + webhookID,
+		},
+		{
+			name:           "webhook ID with provider team",
+			importID:       webhookID,
+			configuredTeam: client.Team{ID: teamID},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Fatalf("method = %s, want GET", r.Method)
+				}
+				if r.URL.Path != "/v1/webhooks/"+webhookID {
+					t.Fatalf("path = %s, want /v1/webhooks/%s", r.URL.Path, webhookID)
+				}
+				if got := r.URL.Query().Get("teamId"); got != teamID {
+					t.Fatalf("teamId = %q, want %q", got, teamID)
+				}
+
+				_, _ = fmt.Fprint(w, `{
+					"id": "hook_123",
+					"ownerId": "team_123",
+					"url": "https://example.com/webhook",
+					"events": ["deployment.succeeded", "deployment.promoted"],
+					"projectIds": ["prj_123"]
+				}`)
+			}))
+			defer server.Close()
+
+			imported := importWebhookState(t, server.URL, tt.configuredTeam, tt.importID)
+			if imported.ID.ValueString() != webhookID {
+				t.Fatalf("id = %q, want %q", imported.ID.ValueString(), webhookID)
+			}
+			if imported.TeamID.ValueString() != teamID {
+				t.Fatalf("team_id = %q, want %q", imported.TeamID.ValueString(), teamID)
+			}
+			if imported.Endpoint.ValueString() != "https://example.com/webhook" {
+				t.Fatalf("endpoint = %q, want https://example.com/webhook", imported.Endpoint.ValueString())
+			}
+			if !imported.Secret.IsNull() {
+				t.Fatalf("secret = %s, want null", imported.Secret)
+			}
+
+			var projectIDs []string
+			diags := imported.ProjectIDs.ElementsAs(context.Background(), &projectIDs, false)
+			if diags.HasError() || len(projectIDs) != 1 || projectIDs[0] != "prj_123" {
+				t.Fatalf("project_ids = %v, diagnostics = %v", projectIDs, diags)
+			}
+			var events []string
+			diags = imported.Events.ElementsAs(context.Background(), &events, false)
+			slices.Sort(events)
+			if diags.HasError() || !slices.Equal(events, []string{"deployment.promoted", "deployment.succeeded"}) {
+				t.Fatalf("events = %v, diagnostics = %v", events, diags)
+			}
+		})
+	}
+}
+
+func TestWebhookImportStateAPIErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name             string
+		status           int
+		expectDiagnostic bool
+	}{
+		{name: "not found removes resource", status: http.StatusNotFound},
+		{name: "API error returns diagnostic", status: http.StatusInternalServerError, expectDiagnostic: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = fmt.Fprint(w, `{"error":{"code":"test_error","message":"test error"}}`)
+			}))
+			defer server.Close()
+
+			res, resp := webhookImportResponse(t, server.URL, client.Team{})
+			res.ImportState(context.Background(), resource.ImportStateRequest{ID: "team_123/hook_123"}, resp)
+
+			if resp.Diagnostics.HasError() != tt.expectDiagnostic {
+				t.Fatalf("diagnostics error = %v, want %v: %v", resp.Diagnostics.HasError(), tt.expectDiagnostic, resp.Diagnostics)
+			}
+			if !tt.expectDiagnostic && !resp.State.Raw.IsNull() {
+				t.Fatalf("state = %s, want null", resp.State.Raw)
+			}
+		})
+	}
+}
+
+func importWebhookState(t *testing.T, baseURL string, team client.Team, importID string) Webhook {
+	t.Helper()
+
+	res, resp := webhookImportResponse(t, baseURL, team)
+	res.ImportState(context.Background(), resource.ImportStateRequest{ID: importID}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("import diagnostics: %v", resp.Diagnostics)
+	}
+
+	var state Webhook
+	diags := resp.State.Get(context.Background(), &state)
+	if diags.HasError() {
+		t.Fatalf("get state diagnostics: %v", diags)
+	}
+	return state
+}
+
+func webhookImportResponse(t *testing.T, baseURL string, team client.Team) (*webhookResource, *resource.ImportStateResponse) {
+	t.Helper()
+
+	res := &webhookResource{
+		client: client.New("token").WithBaseURL(baseURL).WithTeam(team),
+	}
+	schemaResp := &resource.SchemaResponse{}
+	res.Schema(context.Background(), resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", schemaResp.Diagnostics)
+	}
+
+	return res, &resource.ImportStateResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema},
+	}
+}


### PR DESCRIPTION
I'm in the process of importing our Vercel setup into Terraform as much as possible, and I got stuck. I'd just made a bunch of replacement webhooks, and I didn't want to do it again. So I patched the provider locally! But there's no reason everyone else shouldn't get it too.

`vercel_webhook` cannot import an existing webhook, which prevents Terraform from adopting an existing signed webhook without recreating it.

This adds import support for `team_id/webhook_id`, or `webhook_id` when the provider has a default team. Import reads the existing endpoint, events, project IDs, team, and webhook ID.

Vercel does not return an existing webhook signing secret. Imported state therefore records `secret` as null; this does not change how Terraform-created webhooks behave.

Includes unit coverage for valid and malformed import identifiers, missing webhooks, and API failures, plus acceptance import coverage, generated documentation, and an import example.

I might be a little slow to see any feedback. I'm 100% fine if any changes are required that you're happy to make if it means after it will be merged.