### PR TITLE
Keep project IDs in firewall config state

### DIFF
--- a/client/firewall_config.go
+++ b/client/firewall_config.go
@@ -99,6 +99,7 @@ func (c *Client) GetFirewallConfig(ctx context.Context, projectId string, teamId
 		method: "GET",
 		url:    url,
 	}, &res)
+	res.ProjectID = projectId
 	res.TeamID = teamId
 	return res, err
 }
@@ -124,6 +125,7 @@ func (c *Client) PutFirewallConfig(ctx context.Context, cfg FirewallConfig) (Fir
 		url:    url,
 		body:   string(payload),
 	}, &res)
+	res.Active.ProjectID = cfg.ProjectID
 	res.Active.TeamID = teamId
 	return res.Active, err
 }

--- a/client/firewall_config_test.go
+++ b/client/firewall_config_test.go
@@ -8,6 +8,58 @@ import (
 	vercelclient "github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
+func TestGetFirewallConfigPreservesIdentity(t *testing.T) {
+	t.Parallel()
+
+	client := newFeatureFlagTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, "GET", "/v1/security/firewall/config/active", "team_123", nil)
+		if value := r.URL.Query().Get("projectId"); value != "prj_123" {
+			t.Fatalf("expected projectId %q, got %q", "prj_123", value)
+		}
+		_, _ = w.Write([]byte(`{"firewallEnabled":true}`))
+	})
+
+	config, err := client.GetFirewallConfig(context.Background(), "prj_123", "team_123")
+	if err != nil {
+		t.Fatalf("GetFirewallConfig returned error: %v", err)
+	}
+	if config.ProjectID != "prj_123" {
+		t.Fatalf("expected project ID %q, got %q", "prj_123", config.ProjectID)
+	}
+	if config.TeamID != "team_123" {
+		t.Fatalf("expected team ID %q, got %q", "team_123", config.TeamID)
+	}
+}
+
+func TestPutFirewallConfigPreservesIdentity(t *testing.T) {
+	t.Parallel()
+
+	client := newFeatureFlagTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(t, r, "PUT", "/v1/security/firewall/config", "team_123", map[string]any{
+			"firewallEnabled": true,
+		})
+		if value := r.URL.Query().Get("projectId"); value != "prj_123" {
+			t.Fatalf("expected projectId %q, got %q", "prj_123", value)
+		}
+		_, _ = w.Write([]byte(`{"active":{"firewallEnabled":true}}`))
+	})
+
+	config, err := client.PutFirewallConfig(context.Background(), vercelclient.FirewallConfig{
+		ProjectID: "prj_123",
+		TeamID:    "team_123",
+		Enabled:   true,
+	})
+	if err != nil {
+		t.Fatalf("PutFirewallConfig returned error: %v", err)
+	}
+	if config.ProjectID != "prj_123" {
+		t.Fatalf("expected project ID %q, got %q", "prj_123", config.ProjectID)
+	}
+	if config.TeamID != "team_123" {
+		t.Fatalf("expected team ID %q, got %q", "team_123", config.TeamID)
+	}
+}
+
 func TestUpdateFirewallConfig(t *testing.T) {
 	t.Parallel()
 

--- a/vercel/resource_firewall_config_test.go
+++ b/vercel/resource_firewall_config_test.go
@@ -10,6 +10,59 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
+func TestAcc_FirewallConfigIDIncludesProjectID(t *testing.T) {
+	name := acctest.RandString(16)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(testAccFirewallConfigIDResource(name)),
+				Check: func(state *terraform.State) error {
+					firewall := state.RootModule().Resources["vercel_firewall_config.test"]
+					if firewall == nil {
+						return fmt.Errorf("vercel_firewall_config.test not found in state")
+					}
+
+					want := fmt.Sprintf("%s/%s", firewall.Primary.Attributes["team_id"], firewall.Primary.Attributes["project_id"])
+					if firewall.Primary.ID != want {
+						return fmt.Errorf("expected complete firewall config ID %q, got %q", want, firewall.Primary.ID)
+					}
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func testAccFirewallConfigIDResource(name string) string {
+	return fmt.Sprintf(`
+resource "vercel_project" "test" {
+    name = "test-acc-%[1]s-firewall-id"
+}
+
+resource "vercel_firewall_config" "test" {
+    project_id = vercel_project.test.id
+
+    rules {
+        rule {
+            name = "test-rule"
+            action = {
+                action = "deny"
+            }
+            condition_group = [{
+                conditions = [{
+                    type  = "path"
+                    op    = "re"
+                    value = "^/foo$"
+                }]
+            }]
+        }
+    }
+}
+`, name)
+}
+
 func getFirewallImportID(n string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[n]


### PR DESCRIPTION
`vercel_firewall_config` drops the project ID after API reads and writes because the API response does not include it. This leaves the Terraform resource ID as `team_id/` instead of `team_id/project_id`.

Preserve the project ID from the request on both GET and PUT responses so Terraform state always records the complete resource ID.
