### PR TITLE
Update edited firewall rules in place

### DIFF
--- a/vercel/resource_firewall_config.go
+++ b/vercel/resource_firewall_config.go
@@ -27,6 +27,7 @@ var (
 	_ resource.Resource                = &firewallConfigResource{}
 	_ resource.ResourceWithConfigure   = &firewallConfigResource{}
 	_ resource.ResourceWithImportState = &firewallConfigResource{}
+	_ resource.ResourceWithModifyPlan  = &firewallConfigResource{}
 )
 
 func newFirewallConfigResource() resource.Resource { return &firewallConfigResource{} }
@@ -473,6 +474,28 @@ Define Custom Rules to shape the way your traffic is handled by the Vercel Edge 
 			},
 		},
 	}
+}
+
+func (r *firewallConfigResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return
+	}
+
+	var plan, state FirewallConfig
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := propagateFirewallRuleIDs(state.Rules, plan.Rules); err != nil {
+		// Unknown nested values can make rule comparison impossible during planning.
+		// Terraform will plan again once dependencies resolve.
+		tflog.Debug(ctx, "Unable to correlate firewall rule IDs in the current plan", map[string]any{"error": err.Error()})
+		return
+	}
+
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
 }
 
 func (r *firewallConfigResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -1317,6 +1340,39 @@ func matchFirewallRules(current, desired []client.FirewallRule) ([]firewallRuleM
 	}
 
 	return matches, removals, inserts, nil
+}
+
+func propagateFirewallRuleIDs(state, plan *FirewallRules) error {
+	current, err := firewallRulesToClient(state)
+	if err != nil {
+		return err
+	}
+	desired, err := firewallRulesToClient(plan)
+	if err != nil {
+		return err
+	}
+
+	matches, remainingCurrent, remainingDesired, err := matchFirewallRules(current, desired)
+	if err != nil {
+		return err
+	}
+
+	// When both the name and body changed, there is no configured identity left to
+	// match. Preserve list order for the remaining rules so edits remain updates.
+	for i := 0; i < min(len(remainingCurrent), len(remainingDesired)); i++ {
+		matches = append(matches, firewallRuleMatch{
+			currentIndex: remainingCurrent[i],
+			desiredIndex: remainingDesired[i],
+		})
+	}
+
+	for _, match := range matches {
+		if current[match.currentIndex].ID != "" {
+			plan.Rules[match.desiredIndex].ID = types.StringValue(current[match.currentIndex].ID)
+		}
+	}
+
+	return nil
 }
 
 func onlyFirewallRulesChanged(state, plan FirewallConfig) (bool, error) {

--- a/vercel/resource_firewall_config_test.go
+++ b/vercel/resource_firewall_config_test.go
@@ -1,13 +1,16 @@
 package vercel_test
 
 import (
+	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
 )
 
 func getFirewallImportID(n string) resource.ImportStateIdFunc {
@@ -67,6 +70,80 @@ func checkResourceAttrEquals(n, key string, expected *string) resource.TestCheck
 
 		return nil
 	}
+}
+
+func testAccCheckFirewallRuleUnchanged(t *testing.T, apiClient *client.Client, projectID, ruleID *string) func() {
+	return func() {
+		config, err := apiClient.GetFirewallConfig(context.Background(), *projectID, testTeam(t))
+		if err != nil {
+			t.Fatalf("failed to read firewall config: %v", err)
+		}
+		if len(config.Rules) != 1 {
+			t.Fatalf("firewall has %d custom rules after rejected update, want 1", len(config.Rules))
+		}
+		if config.Rules[0].ID != *ruleID {
+			t.Fatalf("firewall rule ID after rejected update = %q, want %q", config.Rules[0].ID, *ruleID)
+		}
+		if config.Rules[0].Name != "valid-rule" {
+			t.Fatalf("firewall rule name after rejected update = %q, want valid-rule", config.Rules[0].Name)
+		}
+	}
+}
+
+func TestAcc_FirewallConfigRuleIDPreservedInPlan(t *testing.T) {
+	name := acctest.RandString(16)
+	var projectID, ruleID string
+	apiClient := testClient(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(testAccFirewallRuleIdentityConfig(name, "valid-rule", "^/foo$")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					captureResourceAttr("vercel_firewall_config.test", "project_id", &projectID),
+					captureResourceAttr("vercel_firewall_config.test", "rules.rule.0.id", &ruleID),
+				),
+			},
+			{
+				Config:      cfg(testAccFirewallRuleIdentityConfig(name, "invalid-rule", "(?i)^/bar$")),
+				ExpectError: regexp.MustCompile("Invalid rule"),
+			},
+			{
+				PreConfig: testAccCheckFirewallRuleUnchanged(t, apiClient, &projectID, &ruleID),
+				Config:    cfg(testAccFirewallRuleIdentityConfig(name, "valid-rule", "^/foo$")),
+				PlanOnly:  true,
+			},
+		},
+	})
+}
+
+func testAccFirewallRuleIdentityConfig(name, ruleName, regex string) string {
+	return fmt.Sprintf(`
+resource "vercel_project" "test" {
+  name = "test-acc-%[1]s-rule-identity"
+}
+
+resource "vercel_firewall_config" "test" {
+  project_id = vercel_project.test.id
+
+  rules {
+    rule {
+      name = %[2]q
+      action = {
+        action = "deny"
+      }
+      condition_group = [{
+        conditions = [{
+          type  = "path"
+          op    = "re"
+          value = %[3]q
+        }]
+      }]
+    }
+  }
+}
+`, name, ruleName, regex)
 }
 
 func TestAcc_FirewallConfigResource(t *testing.T) {

--- a/vercel/resource_firewall_config_unit_test.go
+++ b/vercel/resource_firewall_config_unit_test.go
@@ -108,6 +108,13 @@ func TestFirewallConfigResourceSchemaIncludesSessionFixationRule(t *testing.T) {
 	}
 }
 
+func TestFirewallConfigUsesModifyPlanForRuleIdentityCorrelation(t *testing.T) {
+	res := newFirewallConfigResource()
+	if _, ok := res.(resource.ResourceWithModifyPlan); !ok {
+		t.Fatal("firewall config must implement ResourceWithModifyPlan to preserve rule IDs before apply")
+	}
+}
+
 func TestFirewallConfigToClientIncludesSessionFixationRule(t *testing.T) {
 	cfg := FirewallConfig{
 		ProjectID: types.StringValue("prj_123"),
@@ -292,6 +299,51 @@ func TestMatchFirewallRulesMatchesByNameWhenRuleBodyChanges(t *testing.T) {
 	}
 	if len(inserts) != 0 {
 		t.Fatalf("expected no inserts, got %v", inserts)
+	}
+}
+
+func TestPropagateFirewallRuleIDsTreatsCompleteEditAsUpdate(t *testing.T) {
+	state := &FirewallRules{Rules: []FirewallRule{
+		testResourceFirewallRule("rule_a", "alpha", "/alpha", "deny"),
+	}}
+	plan := &FirewallRules{Rules: []FirewallRule{
+		testResourceFirewallRule("", "renamed", "/changed", "challenge"),
+	}}
+	plan.Rules[0].ID = types.StringUnknown()
+
+	if err := propagateFirewallRuleIDs(state, plan); err != nil {
+		t.Fatalf("propagateFirewallRuleIDs() returned an error: %v", err)
+	}
+	if got := plan.Rules[0].ID.ValueString(); got != "rule_a" {
+		t.Fatalf("planned rule ID = %q, want rule_a", got)
+	}
+}
+
+func TestPropagateFirewallRuleIDsFollowsRulesAcrossReorderAndInsertion(t *testing.T) {
+	state := &FirewallRules{Rules: []FirewallRule{
+		testResourceFirewallRule("rule_a", "alpha", "/alpha", "deny"),
+		testResourceFirewallRule("rule_b", "beta", "/beta", "deny"),
+	}}
+	plan := &FirewallRules{Rules: []FirewallRule{
+		testResourceFirewallRule("", "new-rule", "/new", "deny"),
+		testResourceFirewallRule("", "beta", "/beta", "deny"),
+		testResourceFirewallRule("", "alpha", "/alpha", "deny"),
+	}}
+	for i := range plan.Rules {
+		plan.Rules[i].ID = types.StringUnknown()
+	}
+
+	if err := propagateFirewallRuleIDs(state, plan); err != nil {
+		t.Fatalf("propagateFirewallRuleIDs() returned an error: %v", err)
+	}
+	if !plan.Rules[0].ID.IsUnknown() {
+		t.Fatalf("new planned rule ID = %v, want unknown", plan.Rules[0].ID)
+	}
+	if got := plan.Rules[1].ID.ValueString(); got != "rule_b" {
+		t.Fatalf("beta planned rule ID = %q, want rule_b", got)
+	}
+	if got := plan.Rules[2].ID.ValueString(); got != "rule_a" {
+		t.Fatalf("alpha planned rule ID = %q, want rule_a", got)
 	}
 }
 


### PR DESCRIPTION
When a firewall rule's name and body change together, its computed ID is unknown in the proposed plan. The provider can mistake the edit for a removal plus insertion, delete the existing rule, then fail to insert the replacement if API validation rejects it.

Carry IDs from state into the proposed plan by matching stable rule details first and list order only as a final fallback. Existing rules are then updated in place, so a rejected edit leaves the active rule unchanged; genuinely new rules still receive IDs after creation.
