### PR TITLE
Preserve firewall configuration during import and refresh

### DIFF
--- a/vercel/resource_firewall_config.go
+++ b/vercel/resource_firewall_config.go
@@ -679,7 +679,14 @@ func (r *FirewallRule) Mitigate() (client.Mitigate, error) {
 	return mit, nil
 }
 
-func fromFirewallRule(rule client.FirewallRule, ref FirewallRule) (FirewallRule, error) {
+type firewallFlattenMode uint8
+
+const (
+	preserveConfiguredShape firewallFlattenMode = iota
+	canonicalImportShape
+)
+
+func fromFirewallRule(rule client.FirewallRule, ref FirewallRule, mode firewallFlattenMode) (FirewallRule, error) {
 	var err error
 	r := FirewallRule{
 		ID:          types.StringValue(rule.ID),
@@ -687,11 +694,11 @@ func fromFirewallRule(rule client.FirewallRule, ref FirewallRule) (FirewallRule,
 		Description: types.StringValue(rule.Description),
 		Active:      types.BoolValue(rule.Active),
 	}
-	if rule.Active && ref.Active == types.BoolNull() {
+	if mode == preserveConfiguredShape && rule.Active && ref.Active == types.BoolNull() {
 		r.Active = ref.Active
 	}
 
-	r.Action, err = fromMitigate(rule.Action.Mitigate, ref.Action)
+	r.Action, err = fromMitigate(rule.Action.Mitigate, ref.Action, mode)
 	if err != nil {
 		return r, err
 	}
@@ -703,7 +710,7 @@ func fromFirewallRule(rule client.FirewallRule, ref FirewallRule) (FirewallRule,
 			if len(ref.ConditionGroup) > j && len(ref.ConditionGroup[j].Conditions) > k {
 				cond = ref.ConditionGroup[j].Conditions[k]
 			}
-			conditions[k], err = fromCondition(condition, cond)
+			conditions[k], err = fromCondition(condition, cond, mode)
 			if err != nil {
 				return r, err
 			}
@@ -714,11 +721,8 @@ func fromFirewallRule(rule client.FirewallRule, ref FirewallRule) (FirewallRule,
 	}
 	r.ConditionGroup = conditionGroups
 	// Description and active can be optional
-	if rule.Description == "" && ref.Description == types.StringNull() {
-		r.Description = ref.Description
-	}
-	if rule.Active && ref.Active == types.BoolNull() {
-		r.Active = ref.Active
+	if rule.Description == "" && (mode == canonicalImportShape || ref.Description == types.StringNull()) {
+		r.Description = types.StringNull()
 	}
 
 	return r, nil
@@ -750,7 +754,7 @@ type Mitigate struct {
 	ActionDuration types.String `tfsdk:"action_duration"`
 }
 
-func fromMitigate(mitigate client.Mitigate, ref Mitigate) (Mitigate, error) {
+func fromMitigate(mitigate client.Mitigate, ref Mitigate, mode firewallFlattenMode) (Mitigate, error) {
 	m := Mitigate{
 		Action:         types.StringValue(mitigate.Action),
 		ActionDuration: types.StringValue(mitigate.ActionDuration),
@@ -758,8 +762,8 @@ func fromMitigate(mitigate client.Mitigate, ref Mitigate) (Mitigate, error) {
 		RateLimit:      types.ObjectNull(ratelimitType.AttrTypes),
 	}
 
-	if mitigate.ActionDuration == "" && ref.ActionDuration == types.StringNull() {
-		m.ActionDuration = ref.ActionDuration
+	if mitigate.ActionDuration == "" && (mode == canonicalImportShape || ref.ActionDuration == types.StringNull()) {
+		m.ActionDuration = types.StringNull()
 	}
 
 	if mitigate.RateLimit != nil {
@@ -816,7 +820,7 @@ type Condition struct {
 	Values types.List   `tfsdk:"values"`
 }
 
-func fromCondition(condition client.Condition, ref Condition) (Condition, error) {
+func fromCondition(condition client.Condition, ref Condition, mode firewallFlattenMode) (Condition, error) {
 	c := Condition{
 		Type:   types.StringValue(condition.Type),
 		Op:     types.StringValue(condition.Op),
@@ -852,7 +856,11 @@ func fromCondition(condition client.Condition, ref Condition) (Condition, error)
 	}
 
 	// If key is present it's possible for value to be optional.
-	if ref.Key == types.StringNull() {
+	if mode == canonicalImportShape {
+		if condition.Key == "" {
+			c.Key = types.StringNull()
+		}
+	} else if ref.Key == types.StringNull() {
 		c.Key = types.StringNull()
 	} else {
 		if ref.Value == types.StringNull() {
@@ -874,30 +882,37 @@ type IPRule struct {
 	Action   types.String `tfsdk:"action"`
 }
 
-func fromCRS(conf map[string]client.CoreRuleSet, refMr *FirewallManagedRulesets) *CRSRule {
+func fromCRS(conf map[string]client.CoreRuleSet, refMr *FirewallManagedRulesets, mode firewallFlattenMode) *CRSRule {
 	var ref = &CRSRule{}
 	if refMr != nil && refMr.OWASP != nil {
 		ref = refMr.OWASP
 	}
-	if conf == nil || ref == nil || refMr.OWASP == nil {
+	if mode == preserveConfiguredShape && (refMr == nil || refMr.OWASP == nil) {
 		return nil
 	}
-	return &CRSRule{
-		XSS:  fromCoreRuleset(conf["xss"], ref.XSS),
-		SQLI: fromCoreRuleset(conf["sqli"], ref.SQLI),
-		SF:   fromCoreRuleset(conf["sf"], ref.SF),
-		LFI:  fromCoreRuleset(conf["lfi"], ref.LFI),
-		RFI:  fromCoreRuleset(conf["rfi"], ref.RFI),
-		RCE:  fromCoreRuleset(conf["rce"], ref.RCE),
-		SD:   fromCoreRuleset(conf["sd"], ref.SD),
-		MA:   fromCoreRuleset(conf["ma"], ref.MA),
-		PHP:  fromCoreRuleset(conf["php"], ref.PHP),
-		GEN:  fromCoreRuleset(conf["gen"], ref.GEN),
-		JAVA: fromCoreRuleset(conf["java"], ref.JAVA),
+	rules := &CRSRule{}
+	set := func(key string, ref *CRSRuleConfig, target **CRSRuleConfig) {
+		crsRule, ok := conf[key]
+		if !ok {
+			return
+		}
+		*target = fromCoreRuleset(crsRule, ref, mode)
 	}
+	set("xss", ref.XSS, &rules.XSS)
+	set("sqli", ref.SQLI, &rules.SQLI)
+	set("sf", ref.SF, &rules.SF)
+	set("lfi", ref.LFI, &rules.LFI)
+	set("rfi", ref.RFI, &rules.RFI)
+	set("rce", ref.RCE, &rules.RCE)
+	set("sd", ref.SD, &rules.SD)
+	set("ma", ref.MA, &rules.MA)
+	set("php", ref.PHP, &rules.PHP)
+	set("gen", ref.GEN, &rules.GEN)
+	set("java", ref.JAVA, &rules.JAVA)
+	return rules
 }
 
-func fromCoreRuleset(crsRule client.CoreRuleSet, ref *CRSRuleConfig) *CRSRuleConfig {
+func fromCoreRuleset(crsRule client.CoreRuleSet, ref *CRSRuleConfig, mode firewallFlattenMode) *CRSRuleConfig {
 	if ref == nil && !crsRule.Active && crsRule.Action == "log" {
 		return nil
 	}
@@ -905,38 +920,33 @@ func fromCoreRuleset(crsRule client.CoreRuleSet, ref *CRSRuleConfig) *CRSRuleCon
 		Active: types.BoolValue(crsRule.Active),
 		Action: types.StringValue(crsRule.Action),
 	}
-	if (ref == nil && crsRule.Active) ||
-		ref != nil && ref.Active == types.BoolNull() {
+	if mode == preserveConfiguredShape && ((ref == nil && crsRule.Active) ||
+		ref != nil && ref.Active == types.BoolNull()) {
 		c.Active = types.BoolNull()
 	}
 	return c
 }
 
-func fromClient(conf client.FirewallConfig, state FirewallConfig) (FirewallConfig, error) {
+func fromClient(conf client.FirewallConfig, state FirewallConfig, mode firewallFlattenMode) (FirewallConfig, error) {
 	var err error
 	cfg := FirewallConfig{
 		ID:        types.StringValue(conf.TeamID + "/" + conf.ProjectID),
 		ProjectID: state.ProjectID,
-		// Take the teamID from the response/provider if it wasn't provided in resource
-		TeamID:  types.StringValue(conf.TeamID),
-		Enabled: state.Enabled,
+		TeamID:    types.StringValue(conf.TeamID),
+		Enabled:   types.BoolValue(conf.Enabled),
 	}
-	// Enabled can be null
-	if conf.Enabled && state.Enabled.IsNull() {
+	if mode == preserveConfiguredShape && conf.Enabled && state.Enabled.IsNull() {
 		cfg.Enabled = state.Enabled
 	}
 
 	if len(conf.Rules) > 0 {
 		rules := make([]FirewallRule, len(conf.Rules))
 		for i, rule := range conf.Rules {
-			// Set empty optional types
-			var stateRule = FirewallRule{
-				Active: types.BoolNull(),
-			}
+			stateRule := FirewallRule{Active: types.BoolNull()}
 			if state.Rules != nil && len(state.Rules.Rules) > i {
 				stateRule = state.Rules.Rules[i]
 			}
-			rules[i], err = fromFirewallRule(rule, stateRule)
+			rules[i], err = fromFirewallRule(rule, stateRule, mode)
 			if err != nil {
 				return cfg, err
 			}
@@ -954,47 +964,49 @@ func fromClient(conf client.FirewallConfig, state FirewallConfig) (FirewallConfi
 				Notes:    types.StringValue(iprule.Notes),
 				Action:   types.StringValue(iprule.Action),
 			}
-			// notes don't have to be set
-			if iprule.Notes == "" && state.IPRules != nil && len(state.IPRules.Rules) > i && state.IPRules.Rules[i].Notes.IsNull() {
-				ipRules[i].Notes = state.IPRules.Rules[i].Notes
+			if iprule.Notes == "" && (mode == canonicalImportShape || state.IPRules != nil && len(state.IPRules.Rules) > i && state.IPRules.Rules[i].Notes.IsNull()) {
+				ipRules[i].Notes = types.StringNull()
 			}
 		}
-
 		cfg.IPRules = &IPRules{Rules: ipRules}
 	}
 
-	if len(conf.ManagedRulesets) > 0 {
+	if mode == canonicalImportShape {
 		managedRulesets := &FirewallManagedRulesets{}
-		cfg.ManagedRulesets = managedRulesets
-		if conf.CRS != nil && state.ManagedRulesets != nil {
-			cfg.ManagedRulesets.OWASP = fromCRS(conf.CRS, state.ManagedRulesets)
+		if rule, ok := conf.ManagedRulesets["bot_protection"]; ok {
+			managedRulesets.BotProtection = &BotProtectionConfig{Active: types.BoolValue(rule.Active), Action: types.StringValue(rule.Action)}
 		}
-
+		if rule, ok := conf.ManagedRulesets["ai_bots"]; ok {
+			managedRulesets.AiBots = &AiBotsConfig{Active: types.BoolValue(rule.Active), Action: types.StringValue(rule.Action)}
+		}
+		// CRS categories also exist when OWASP is disabled; only its marker enables them.
+		if owasp, ok := conf.ManagedRulesets["owasp"]; ok && owasp.Active {
+			managedRulesets.OWASP = fromCRS(conf.CRS, nil, mode)
+		}
+		if managedRulesets.BotProtection != nil || managedRulesets.AiBots != nil || managedRulesets.OWASP != nil {
+			cfg.ManagedRulesets = managedRulesets
+		}
+	} else if len(conf.ManagedRulesets) > 0 || state.ManagedRulesets != nil {
+		cfg.ManagedRulesets = &FirewallManagedRulesets{}
+		if state.ManagedRulesets != nil && state.ManagedRulesets.OWASP != nil {
+			if owasp, ok := conf.ManagedRulesets["owasp"]; ok && owasp.Active {
+				cfg.ManagedRulesets.OWASP = fromCRS(conf.CRS, state.ManagedRulesets, mode)
+			}
+		}
 		if state.ManagedRulesets != nil && state.ManagedRulesets.BotProtection != nil {
-			botFilter, botFilterExist := conf.ManagedRulesets["bot_protection"]
-			if botFilterExist {
-				cfg.ManagedRulesets.BotProtection = &BotProtectionConfig{
-					Active: types.BoolValue(botFilter.Active),
-					Action: types.StringValue(botFilter.Action),
-				}
+			if rule, ok := conf.ManagedRulesets["bot_protection"]; ok {
+				cfg.ManagedRulesets.BotProtection = &BotProtectionConfig{Active: types.BoolValue(rule.Active), Action: types.StringValue(rule.Action)}
 			}
 		} else if state.ManagedRulesets != nil && state.ManagedRulesets.BotFilter != nil {
-			botFilter, botFilterExist := conf.ManagedRulesets["bot_protection"]
-			if botFilterExist {
-				cfg.ManagedRulesets.BotFilter = &BotFilterConfig{
-					Active: types.BoolValue(botFilter.Active),
-					Action: types.StringValue(botFilter.Action),
-				}
+			if rule, ok := conf.ManagedRulesets["bot_protection"]; ok {
+				cfg.ManagedRulesets.BotFilter = &BotFilterConfig{Active: types.BoolValue(rule.Active), Action: types.StringValue(rule.Action)}
 			}
 		}
-
-		aiBots, aiBotsExist := conf.ManagedRulesets["ai_bots"]
-		if aiBotsExist {
-			aiBotsConf := &AiBotsConfig{
-				Active: types.BoolValue(aiBots.Active),
-				Action: types.StringValue(aiBots.Action),
-			}
-			cfg.ManagedRulesets.AiBots = aiBotsConf
+		if rule, ok := conf.ManagedRulesets["ai_bots"]; ok {
+			cfg.ManagedRulesets.AiBots = &AiBotsConfig{Active: types.BoolValue(rule.Active), Action: types.StringValue(rule.Action)}
+		}
+		if state.ManagedRulesets == nil && cfg.ManagedRulesets.OWASP == nil && cfg.ManagedRulesets.BotProtection == nil && cfg.ManagedRulesets.BotFilter == nil && cfg.ManagedRulesets.AiBots == nil {
+			cfg.ManagedRulesets = nil
 		}
 	}
 
@@ -1602,7 +1614,7 @@ func (r *firewallConfigResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	cfg, err := fromClient(out, plan)
+	cfg, err := fromClient(out, plan, preserveConfiguredShape)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to read created firewall config", err.Error())
 		return
@@ -1628,7 +1640,7 @@ func (r *firewallConfigResource) Read(ctx context.Context, req resource.ReadRequ
 		resp.Diagnostics.AddError("failed to read firewall config", err.Error())
 		return
 	}
-	cfg, err := fromClient(out, state)
+	cfg, err := fromClient(out, state, preserveConfiguredShape)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to read firewall config", err.Error())
 		return
@@ -1671,7 +1683,7 @@ func (r *firewallConfigResource) Update(ctx context.Context, req resource.Update
 			return
 		}
 
-		cfg, err := fromClient(out, plan)
+		cfg, err := fromClient(out, plan, preserveConfiguredShape)
 		if err != nil {
 			diags.AddError("failed to read updated firewall config", err.Error())
 			resp.Diagnostics.Append(diags...)
@@ -1695,7 +1707,7 @@ func (r *firewallConfigResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	cfg, err := fromClient(out, plan)
+	cfg, err := fromClient(out, plan, preserveConfiguredShape)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to read updated firewall config", err.Error())
 		return
@@ -1744,8 +1756,8 @@ func (r *firewallConfigResource) ImportState(ctx context.Context, req resource.I
 	}
 	conf, err := fromClient(out, FirewallConfig{
 		ProjectID: types.StringValue(projectID),
-		TeamID:    types.StringValue(out.TeamID), // use output teamID if not provided on import
-	})
+		TeamID:    types.StringValue(out.TeamID),
+	}, canonicalImportShape)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to read firewall config", err.Error())
 		return

--- a/vercel/resource_firewall_config_import_test.go
+++ b/vercel/resource_firewall_config_import_test.go
@@ -1,0 +1,184 @@
+package vercel
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+
+	"github.com/vercel/terraform-provider-vercel/v5/client"
+)
+
+func TestFirewallImportStateLifecycle(t *testing.T) {
+	apiDefaults := defaultCRSMap()
+	for _, category := range []string{"rce", "gen", "xss", "sqli"} {
+		apiDefaults[category] = client.CoreRuleSet{Active: true, Action: "log"}
+	}
+	full := client.FirewallConfig{
+		Enabled: false,
+		ManagedRulesets: map[string]client.ManagedRule{
+			"owasp": {Active: true}, "bot_protection": {Active: true, Action: "challenge"}, "ai_bots": {Active: false, Action: "deny"},
+		},
+		CRS: map[string]client.CoreRuleSet{"sf": {Active: false, Action: "deny"}, "xss": {Active: true, Action: "log"}},
+		Rules: []client.FirewallRule{
+			{ID: "rule_redirect", Name: "redirect", Active: true, Description: "keep description", Action: client.Action{Mitigate: client.Mitigate{Action: "redirect", Redirect: &client.Redirect{Location: "https://example.com", Permanent: true}, ActionDuration: "1h"}}, ConditionGroup: []client.ConditionGroup{{Conditions: []client.Condition{
+				{Type: "query", Op: "eq", Key: "campaign", Value: "spring", Neg: true},
+				{Type: "path", Op: "inc", Value: []any{"/a", "/b"}},
+				{Type: "header", Op: "ex", Key: "x-test", Value: ""},
+			}}}},
+			{ID: "rule_rate", Name: "rate", Active: false, Action: client.Action{Mitigate: client.Mitigate{Action: "rate_limit", RateLimit: &client.RateLimit{Algo: "fixed_window", Window: 60, Limit: 100, Keys: []string{"ip"}, Action: "deny"}}}, ConditionGroup: []client.ConditionGroup{{Conditions: []client.Condition{
+				{Type: "query", Op: "eq", Key: "empty", Value: ""},
+				{Type: "query", Op: "ninc", Key: "campaign", Value: []any{"summer", "winter"}},
+				{Type: "path", Op: "eq", Value: "/api"},
+			}}}},
+		},
+		IPRules: []client.IPRule{{ID: "ip_one", Hostname: "*", IP: "192.0.2.1", Action: "deny"}, {ID: "ip_two", Hostname: "example.com", IP: "192.0.2.2", Action: "log", Notes: "keep notes"}},
+	}
+	for _, tc := range []struct {
+		name      string
+		config    client.FirewallConfig
+		wantOWASP bool
+	}{
+		{name: "full", config: full, wantOWASP: true},
+		{name: "partial CRS", config: client.FirewallConfig{Enabled: true, ManagedRulesets: map[string]client.ManagedRule{"owasp": {Active: true}}, CRS: map[string]client.CoreRuleSet{"sf": {Active: false, Action: "deny"}}}, wantOWASP: true},
+		{name: "CRS only", config: client.FirewallConfig{Enabled: true, CRS: map[string]client.CoreRuleSet{"sf": {Active: false, Action: "deny"}, "xss": {Active: true, Action: "log"}}}},
+		{name: "disabled OWASP with active category", config: client.FirewallConfig{Enabled: true, ManagedRulesets: map[string]client.ManagedRule{"owasp": {Active: false}}, CRS: map[string]client.CoreRuleSet{"xss": {Active: true, Action: "log"}}}},
+		{name: "OWASP marker without CRS", config: client.FirewallConfig{Enabled: true, ManagedRulesets: map[string]client.ManagedRule{"owasp": {Active: true}}}, wantOWASP: true},
+		{name: "unknown managed rule", config: client.FirewallConfig{Enabled: true, ManagedRulesets: map[string]client.ManagedRule{"future": {Active: true, Action: "deny"}}}},
+		{
+			name:      "API default CRS with active marker",
+			config:    client.FirewallConfig{Enabled: true, CRS: apiDefaults, ManagedRulesets: map[string]client.ManagedRule{"owasp": {Active: true}}},
+			wantOWASP: true,
+		},
+		{
+			name:   "API default CRS without marker",
+			config: client.FirewallConfig{Enabled: true, CRS: apiDefaults},
+		},
+		{
+			name:   "API default CRS with inactive marker",
+			config: client.FirewallConfig{Enabled: true, CRS: apiDefaults, ManagedRulesets: map[string]client.ManagedRule{"owasp": {Active: false}}},
+		},
+	} {
+		for _, importID := range []string{"team_123/prj_123", "prj_123"} {
+			t.Run(tc.name+"/"+importID, func(t *testing.T) {
+				requests := 0
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					requests++
+					if r.Method != http.MethodGet || r.URL.Path != "/v1/security/firewall/config/active" || r.URL.Query().Get("teamId") != "team_123" || r.URL.Query().Get("projectId") != "prj_123" {
+						t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+						w.WriteHeader(http.StatusBadRequest)
+						return
+					}
+					_ = json.NewEncoder(w).Encode(tc.config)
+				}))
+				defer server.Close()
+				team := "team_123"
+				if importID != "prj_123" {
+					team = "team_ignored"
+				}
+				r, imported := firewallImportResponse(t, server.URL, team)
+				r.ImportState(context.Background(), resource.ImportStateRequest{ID: importID}, imported)
+				if imported.Diagnostics.HasError() {
+					t.Fatalf("import: %v", imported.Diagnostics)
+				}
+				var model FirewallConfig
+				if diags := imported.State.Get(context.Background(), &model); diags.HasError() {
+					t.Fatalf("decode imported state: %v", diags)
+				}
+				if model.ID.ValueString() != "team_123/prj_123" || model.TeamID.ValueString() != "team_123" || model.ProjectID.ValueString() != "prj_123" || model.Enabled.IsNull() || model.Enabled.ValueBool() != tc.config.Enabled {
+					t.Fatalf("incorrect imported identifiers or enabled: %+v", model)
+				}
+				hasOWASP := model.ManagedRulesets != nil && model.ManagedRulesets.OWASP != nil
+				if hasOWASP != tc.wantOWASP {
+					t.Fatalf("OWASP present = %t, want %t", hasOWASP, tc.wantOWASP)
+				}
+				roundTrip, err := model.toClient()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if roundTrip.ManagedRulesets["owasp"].Active != tc.wantOWASP {
+					t.Fatalf("round trip changed OWASP activation: %+v", roundTrip.ManagedRulesets)
+				}
+				if tc.wantOWASP {
+					for category, want := range tc.config.CRS {
+						got, ok := roundTrip.CRS[category]
+						// Omitted categories are disabled with action log on a full update.
+						if !ok {
+							got = client.CoreRuleSet{Active: false, Action: "log"}
+						}
+						if got != want {
+							t.Fatalf("round trip changed CRS %s: got %+v, want %+v", category, got, want)
+						}
+					}
+				} else if len(roundTrip.CRS) != 0 {
+					t.Fatalf("disabled OWASP emitted CRS: %+v", roundTrip.CRS)
+				}
+				if tc.name == "full" {
+					if !model.IPRules.Rules[0].Notes.IsNull() || !model.Rules.Rules[1].Description.IsNull() || !model.Rules.Rules[1].Action.ActionDuration.IsNull() {
+						t.Fatal("empty optional strings must import as null")
+					}
+					got, err := model.toClient()
+					if err != nil {
+						t.Fatal(err)
+					}
+					wantJSON, _ := json.Marshal(full)
+					gotJSON, _ := json.Marshal(got)
+					if string(gotJSON) != string(wantJSON) {
+						t.Fatalf("import changed API semantics:\ngot  %s\nwant %s", gotJSON, wantJSON)
+					}
+				}
+				state := imported.State
+				for refresh := 0; refresh < 2; refresh++ {
+					read := &resource.ReadResponse{State: state}
+					r.Read(context.Background(), resource.ReadRequest{State: state}, read)
+					if read.Diagnostics.HasError() {
+						t.Fatalf("refresh %d: %v", refresh, read.Diagnostics)
+					}
+					if !read.State.Raw.Equal(imported.State.Raw) {
+						t.Fatalf("refresh %d changed imported state", refresh)
+					}
+					state = read.State
+				}
+				if requests != 3 {
+					t.Fatalf("requests = %d, want import and two refreshes", requests)
+				}
+			})
+		}
+	}
+}
+
+func TestFirewallImportStateAPIErrors(t *testing.T) {
+	for _, status := range []int{http.StatusNotFound, http.StatusForbidden, http.StatusInternalServerError} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+				_, _ = fmt.Fprint(w, `{"error":{"code":"test_error","message":"test error"}}`)
+			}))
+			defer server.Close()
+			r, resp := firewallImportResponse(t, server.URL, "team_123")
+			r.ImportState(context.Background(), resource.ImportStateRequest{ID: "prj_123"}, resp)
+			if !resp.Diagnostics.HasError() {
+				t.Fatal("expected import error diagnostic")
+			}
+			if !resp.State.Raw.IsNull() {
+				t.Fatalf("failed import populated state: %s", resp.State.Raw)
+			}
+		})
+	}
+}
+
+func firewallImportResponse(t *testing.T, baseURL, teamID string) (*firewallConfigResource, *resource.ImportStateResponse) {
+	t.Helper()
+	r := &firewallConfigResource{client: client.New("token").WithBaseURL(baseURL).WithTeam(client.Team{ID: teamID})}
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema: %v", schemaResp.Diagnostics)
+	}
+	return r, &resource.ImportStateResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+}

--- a/vercel/resource_firewall_config_unit_test.go
+++ b/vercel/resource_firewall_config_unit_test.go
@@ -53,7 +53,7 @@ func TestFromConditionPreservesNegFromAPI(t *testing.T) {
 			}, Condition{
 				Neg: types.BoolNull(),
 				Key: types.StringValue("x-origin-verify"),
-			})
+			}, preserveConfiguredShape)
 			if err != nil {
 				t.Fatalf("unexpected error converting condition: %v", err)
 			}
@@ -167,7 +167,7 @@ func TestFromCRSIncludesSessionFixationRule(t *testing.T) {
 				Action: types.StringValue("deny"),
 			},
 		},
-	})
+	}, preserveConfiguredShape)
 
 	if crs == nil {
 		t.Fatalf("expected CRS value")
@@ -183,6 +183,222 @@ func TestFromCRSIncludesSessionFixationRule(t *testing.T) {
 
 	if crs.SF.Active.ValueBool() {
 		t.Fatalf("expected sf active to be false")
+	}
+}
+
+func importFirewallConfig(t *testing.T, apiConfig client.FirewallConfig) FirewallConfig {
+	t.Helper()
+	got, err := fromClient(apiConfig, FirewallConfig{
+		ProjectID: types.StringValue(apiConfig.ProjectID),
+		TeamID:    types.StringValue(apiConfig.TeamID),
+	}, canonicalImportShape)
+	if err != nil {
+		t.Fatalf("unexpected error converting imported config: %v", err)
+	}
+	return got
+}
+
+func TestCanonicalImportEnabled(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("enabled_%t", enabled), func(t *testing.T) {
+			got := importFirewallConfig(t, client.FirewallConfig{ProjectID: "prj_123", TeamID: "team_123", Enabled: enabled})
+			if got.Enabled.IsNull() || got.Enabled.ValueBool() != enabled {
+				t.Fatalf("enabled = %s, want %t", got.Enabled, enabled)
+			}
+		})
+	}
+}
+
+func TestCanonicalImportRuleOptionalStringsAndActive(t *testing.T) {
+	tests := []struct {
+		name, description, duration           string
+		active                                bool
+		wantDescriptionNull, wantDurationNull bool
+	}{
+		{name: "empty enabled", active: true, wantDescriptionNull: true, wantDurationNull: true},
+		{name: "nonempty disabled", description: "description", duration: "1h", active: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := importFirewallConfig(t, client.FirewallConfig{Rules: []client.FirewallRule{{
+				Active: tc.active, Description: tc.description,
+				Action: client.Action{Mitigate: client.Mitigate{Action: "deny", ActionDuration: tc.duration}},
+			}}})
+			rule := got.Rules.Rules[0]
+			if rule.Active.IsNull() || rule.Active.ValueBool() != tc.active {
+				t.Fatalf("active = %s, want %t", rule.Active, tc.active)
+			}
+			if rule.Description.IsNull() != tc.wantDescriptionNull || !rule.Description.IsNull() && rule.Description.ValueString() != tc.description {
+				t.Fatalf("description = %s", rule.Description)
+			}
+			if rule.Action.ActionDuration.IsNull() != tc.wantDurationNull || !rule.Action.ActionDuration.IsNull() && rule.Action.ActionDuration.ValueString() != tc.duration {
+				t.Fatalf("action_duration = %s", rule.Action.ActionDuration)
+			}
+		})
+	}
+}
+
+func TestCanonicalImportConditions(t *testing.T) {
+	tests := []struct {
+		name                       string
+		condition                  client.Condition
+		wantKeyNull, wantValueNull bool
+		wantValue                  string
+		wantValues                 []string
+	}{
+		{name: "keyed scalar", condition: client.Condition{Type: "query", Op: "eq", Key: "campaign", Value: "spring"}, wantValue: "spring"},
+		{name: "keyed empty scalar", condition: client.Condition{Type: "query", Op: "eq", Key: "campaign", Value: ""}, wantValue: ""},
+		{name: "keyless scalar", condition: client.Condition{Type: "path", Op: "eq", Value: "/sale"}, wantKeyNull: true, wantValue: "/sale"},
+		{name: "keyed list", condition: client.Condition{Type: "query", Op: "inc", Key: "campaign", Value: []any{"spring", "summer"}}, wantValues: []string{"spring", "summer"}, wantValueNull: true},
+		{name: "keyless list", condition: client.Condition{Type: "path", Op: "inc", Value: []any{"/a", "/b"}}, wantKeyNull: true, wantValues: []string{"/a", "/b"}, wantValueNull: true},
+		{name: "keyed existence", condition: client.Condition{Type: "header", Op: "ex", Key: "x-test", Value: ""}, wantValueNull: true},
+		{name: "keyless existence", condition: client.Condition{Type: "path", Op: "nex", Value: nil}, wantKeyNull: true, wantValueNull: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := fromCondition(tc.condition, Condition{}, canonicalImportShape)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Key.IsNull() != tc.wantKeyNull {
+				t.Fatalf("key = %s", got.Key)
+			}
+			if !got.Key.IsNull() && got.Key.ValueString() != tc.condition.Key {
+				t.Fatalf("key = %q", got.Key.ValueString())
+			}
+			if got.Value.IsNull() != tc.wantValueNull {
+				t.Fatalf("value = %s", got.Value)
+			}
+			if !got.Value.IsNull() && got.Value.ValueString() != tc.wantValue {
+				t.Fatalf("value = %q", got.Value.ValueString())
+			}
+			if tc.wantValues != nil {
+				var values []string
+				diags := got.Values.ElementsAs(context.Background(), &values, false)
+				if diags.HasError() || fmt.Sprint(values) != fmt.Sprint(tc.wantValues) {
+					t.Fatalf("values = %v, diagnostics = %v", values, diags)
+				}
+			}
+		})
+	}
+}
+
+func TestCanonicalImportManagedRulesets(t *testing.T) {
+	got := importFirewallConfig(t, client.FirewallConfig{ManagedRulesets: map[string]client.ManagedRule{
+		"bot_protection": {Active: true, Action: "challenge"},
+		"ai_bots":        {Active: false, Action: "deny"},
+		"future_rule":    {Active: true, Action: "deny"},
+	}})
+	if got.ManagedRulesets == nil || got.ManagedRulesets.BotProtection == nil || got.ManagedRulesets.AiBots == nil {
+		t.Fatalf("recognized managed rules missing: %+v", got.ManagedRulesets)
+	}
+	if got.ManagedRulesets.BotFilter != nil {
+		t.Fatal("import invented deprecated bot_filter")
+	}
+	if !got.ManagedRulesets.BotProtection.Active.ValueBool() || got.ManagedRulesets.BotProtection.Action.ValueString() != "challenge" {
+		t.Fatalf("bot protection = %+v", got.ManagedRulesets.BotProtection)
+	}
+	if got.ManagedRulesets.AiBots.Active.ValueBool() || got.ManagedRulesets.AiBots.Action.ValueString() != "deny" {
+		t.Fatalf("ai bots = %+v", got.ManagedRulesets.AiBots)
+	}
+
+	unknownOnly := importFirewallConfig(t, client.FirewallConfig{ManagedRulesets: map[string]client.ManagedRule{"future_rule": {Active: true, Action: "deny"}}})
+	if unknownOnly.ManagedRulesets != nil {
+		t.Fatalf("unknown managed rule materialized state: %+v", unknownOnly.ManagedRulesets)
+	}
+}
+
+func TestCanonicalImportCRS(t *testing.T) {
+	tests := []struct {
+		name                       string
+		managed                    map[string]client.ManagedRule
+		crs                        map[string]client.CoreRuleSet
+		wantOWASP, wantSF, wantXSS bool
+	}{
+		{name: "default only", crs: defaultCRSMap()},
+		{name: "partial", managed: map[string]client.ManagedRule{"owasp": {Active: true}}, crs: map[string]client.CoreRuleSet{"sf": {Active: false, Action: "deny"}}, wantOWASP: true, wantSF: true},
+		{name: "partial active", managed: map[string]client.ManagedRule{"owasp": {Active: true}}, crs: map[string]client.CoreRuleSet{"xss": {Active: true, Action: "log"}}, wantOWASP: true, wantXSS: true},
+		{name: "unknown only", crs: map[string]client.CoreRuleSet{"future": {Active: true, Action: "deny"}}},
+		{name: "active marker without details", managed: map[string]client.ManagedRule{"owasp": {Active: true}}, wantOWASP: true},
+		{name: "active marker with defaults", managed: map[string]client.ManagedRule{"owasp": {Active: true}}, crs: defaultCRSMap(), wantOWASP: true},
+		{name: "active marker with unknown category", managed: map[string]client.ManagedRule{"owasp": {Active: true}}, crs: map[string]client.CoreRuleSet{"future": {Active: true, Action: "deny"}}, wantOWASP: true},
+		{name: "active marker with partial category", managed: map[string]client.ManagedRule{"owasp": {Active: true}}, crs: map[string]client.CoreRuleSet{"sf": {Active: false, Action: "deny"}}, wantOWASP: true, wantSF: true},
+		{name: "inactive marker overrides category", managed: map[string]client.ManagedRule{"owasp": {Active: false}}, crs: map[string]client.CoreRuleSet{"sf": {Active: false, Action: "deny"}}},
+		{name: "crs only response", crs: map[string]client.CoreRuleSet{"sf": {Active: false, Action: "deny"}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := importFirewallConfig(t, client.FirewallConfig{ManagedRulesets: tc.managed, CRS: tc.crs})
+			owasp := (*CRSRule)(nil)
+			if got.ManagedRulesets != nil {
+				owasp = got.ManagedRulesets.OWASP
+			}
+			if (owasp != nil) != tc.wantOWASP {
+				t.Fatalf("OWASP = %+v", owasp)
+			}
+			if owasp != nil && (owasp.SF != nil) != tc.wantSF {
+				t.Fatalf("SF = %+v", owasp.SF)
+			}
+			if owasp != nil && (owasp.XSS != nil) != tc.wantXSS {
+				t.Fatalf("XSS = %+v", owasp.XSS)
+			}
+			if owasp != nil && owasp.SF != nil && (owasp.SF.Active.IsNull() || owasp.SF.Action.ValueString() != "deny") {
+				t.Fatalf("SF = %+v", owasp.SF)
+			}
+			roundTrip, err := got.toClient()
+			if err != nil {
+				t.Fatalf("round trip failed: %v", err)
+			}
+			_, hasOWASPMarker := roundTrip.ManagedRulesets["owasp"]
+			if hasOWASPMarker != tc.wantOWASP {
+				t.Fatalf("round-trip OWASP marker = %t", hasOWASPMarker)
+			}
+		})
+	}
+}
+
+func TestCanonicalImportIPRuleNotes(t *testing.T) {
+	got := importFirewallConfig(t, client.FirewallConfig{IPRules: []client.IPRule{
+		{ID: "empty", Notes: "", Action: "deny"},
+		{ID: "noted", Notes: "keep me", Action: "deny"},
+	}})
+	if !got.IPRules.Rules[0].Notes.IsNull() {
+		t.Fatalf("empty notes = %s", got.IPRules.Rules[0].Notes)
+	}
+	if got.IPRules.Rules[1].Notes.IsNull() || got.IPRules.Rules[1].Notes.ValueString() != "keep me" {
+		t.Fatalf("nonempty notes = %s", got.IPRules.Rules[1].Notes)
+	}
+}
+
+func TestPreserveConfiguredShapeMode(t *testing.T) {
+	apiConfig := client.FirewallConfig{
+		Enabled:         true,
+		Rules:           []client.FirewallRule{{Active: true, Description: "", Action: client.Action{Mitigate: client.Mitigate{Action: "deny"}}, ConditionGroup: []client.ConditionGroup{{Conditions: []client.Condition{{Type: "query", Op: "eq", Key: "api-key", Value: "api-value"}}}}}},
+		IPRules:         []client.IPRule{{Notes: "", Action: "deny"}},
+		ManagedRulesets: map[string]client.ManagedRule{"bot_protection": {Active: true, Action: "challenge"}, "ai_bots": {Active: true, Action: "deny"}},
+	}
+	state := FirewallConfig{
+		Enabled:         types.BoolNull(),
+		Rules:           &FirewallRules{Rules: []FirewallRule{{Active: types.BoolNull(), Description: types.StringNull(), Action: Mitigate{ActionDuration: types.StringNull()}, ConditionGroup: []ConditionGroup{{Conditions: []Condition{{Key: types.StringNull(), Value: types.StringNull()}}}}}}},
+		IPRules:         &IPRules{Rules: []IPRule{{Notes: types.StringNull()}}},
+		ManagedRulesets: &FirewallManagedRulesets{BotFilter: &BotFilterConfig{}, AiBots: &AiBotsConfig{}},
+	}
+	got, err := fromClient(apiConfig, state, preserveConfiguredShape)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Enabled.IsNull() || !got.Rules.Rules[0].Active.IsNull() || !got.Rules.Rules[0].Description.IsNull() || !got.Rules.Rules[0].Action.ActionDuration.IsNull() {
+		t.Fatalf("optional configured shape changed: %+v", got.Rules.Rules[0])
+	}
+	condition := got.Rules.Rules[0].ConditionGroup[0].Conditions[0]
+	if !condition.Key.IsNull() || condition.Value.IsNull() || condition.Value.ValueString() != "api-value" {
+		t.Fatalf("condition shape changed: %+v", condition)
+	}
+	if !got.IPRules.Rules[0].Notes.IsNull() {
+		t.Fatalf("notes shape changed: %s", got.IPRules.Rules[0].Notes)
+	}
+	if got.ManagedRulesets.BotFilter == nil || got.ManagedRulesets.BotProtection != nil || got.ManagedRulesets.AiBots == nil {
+		t.Fatalf("managed rules shape changed: %+v", got.ManagedRulesets)
 	}
 }
 
@@ -468,5 +684,38 @@ func testResourceFirewallRule(id, name, path, action string) FirewallRule {
 			Redirect:       types.ObjectNull(redirectType.AttrTypes),
 			ActionDuration: types.StringNull(),
 		},
+	}
+}
+
+func TestFirewallReadEnabledDrift(t *testing.T) {
+	for _, prior := range []types.Bool{types.BoolNull(), types.BoolValue(false), types.BoolValue(true)} {
+		for _, enabled := range []bool{false, true} {
+			got, err := fromClient(client.FirewallConfig{Enabled: enabled}, FirewallConfig{Enabled: prior}, preserveConfiguredShape)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := types.BoolValue(enabled)
+			if enabled && prior.IsNull() {
+				want = types.BoolNull()
+			}
+			if !got.Enabled.Equal(want) {
+				t.Fatalf("prior=%s API=%t: enabled=%s, want %s", prior, enabled, got.Enabled, want)
+			}
+		}
+	}
+}
+
+func TestFirewallReadOWASPDisabled(t *testing.T) {
+	for _, managed := range []map[string]client.ManagedRule{nil, {"owasp": {Active: false}}} {
+		got, err := fromClient(client.FirewallConfig{
+			ManagedRulesets: managed,
+			CRS:             map[string]client.CoreRuleSet{"xss": {Active: true, Action: "deny"}},
+		}, FirewallConfig{ManagedRulesets: &FirewallManagedRulesets{OWASP: &CRSRule{}}}, preserveConfiguredShape)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.ManagedRulesets != nil && got.ManagedRulesets.OWASP != nil {
+			t.Fatal("refresh retained disabled OWASP")
+		}
 	}
 }


### PR DESCRIPTION
Preserve API-returned firewall settings when importing `vercel_firewall_config`, including enabled flags, custom-rule conditions and actions, Bot Protection, AI Bots, and OWASP categories. Imports use API-derived values while ordinary operations retain configured optional-field shapes and deprecated `bot_filter` compatibility.

Only import OWASP as enabled when its API activation flag is set: CRS defaults can contain active categories even when OWASP is disabled. Keep imported state stable across refreshes, omit missing CRS categories, and reflect changes to firewall and OWASP activation.

Supersedes #593.
