### PR TITLE
Preserve team ownership across resource imports

### DIFF
--- a/client/access_group.go
+++ b/client/access_group.go
@@ -36,7 +36,9 @@ func (c *Client) GetAccessGroup(ctx context.Context, req GetAccessGroupRequest) 
 		return r, fmt.Errorf("unable to get access group: %w", err)
 	}
 
-	r.TeamID = c.TeamID(req.TeamID)
+	if r.TeamID == "" {
+		r.TeamID = c.TeamID(req.TeamID)
+	}
 	return r, err
 }
 
@@ -70,7 +72,9 @@ func (c *Client) CreateAccessGroup(ctx context.Context, req CreateAccessGroupReq
 	if err != nil {
 		return r, err
 	}
-	r.TeamID = c.TeamID(req.TeamID)
+	if r.TeamID == "" {
+		r.TeamID = c.TeamID(req.TeamID)
+	}
 	return r, err
 }
 
@@ -105,7 +109,9 @@ func (c *Client) UpdateAccessGroup(ctx context.Context, req UpdateAccessGroupReq
 	if err != nil {
 		return r, err
 	}
-	r.TeamID = c.TeamID(req.TeamID)
+	if r.TeamID == "" {
+		r.TeamID = c.TeamID(req.TeamID)
+	}
 	return r, err
 }
 

--- a/client/access_group_member.go
+++ b/client/access_group_member.go
@@ -78,6 +78,17 @@ type accessGroupMembersResponse struct {
 // members endpoint searching for the requested user. A 404 APIError is returned
 // when the user is not a member, so callers can use NotFound to detect removal.
 func (c *Client) GetAccessGroupMember(ctx context.Context, req GetAccessGroupMemberRequest) (r AccessGroupMember, err error) {
+	if c.TeamID(req.TeamID) == "" {
+		group, err := c.GetAccessGroup(ctx, GetAccessGroupRequest{AccessGroupID: req.AccessGroupID})
+		if err != nil {
+			return r, fmt.Errorf("unable to determine access group ownership: %w", err)
+		}
+		if group.TeamID == "" {
+			return r, fmt.Errorf("unable to determine access group ownership; include team_id in the import ID or configure team on the provider")
+		}
+		req.TeamID = group.TeamID
+	}
+
 	next := ""
 	for {
 		query := url.Values{}

--- a/client/access_group_project.go
+++ b/client/access_group_project.go
@@ -48,7 +48,9 @@ func (c *Client) CreateAccessGroupProject(ctx context.Context, req CreateAccessG
 	if err != nil {
 		return r, err
 	}
-	r.TeamID = c.TeamID(req.TeamID)
+	if r.TeamID == "" {
+		r.TeamID = c.TeamID(req.TeamID)
+	}
 	return r, err
 }
 
@@ -111,7 +113,9 @@ func (c *Client) UpdateAccessGroupProject(ctx context.Context, req UpdateAccessG
 	if err != nil {
 		return r, err
 	}
-	r.TeamID = c.TeamID(req.TeamID)
+	if r.TeamID == "" {
+		r.TeamID = c.TeamID(req.TeamID)
+	}
 	return r, err
 }
 

--- a/client/attack_challenge_mode.go
+++ b/client/attack_challenge_mode.go
@@ -25,7 +25,7 @@ func (c *Client) GetAttackChallengeMode(ctx context.Context, projectID, teamID s
 	}
 	return AttackChallengeMode{
 		ProjectID:             projectID,
-		TeamID:                teamID,
+		TeamID:                project.TeamID,
 		Enabled:               enabled,
 		AttackModeActiveUntil: activeUntil,
 	}, err

--- a/client/dns_record.go
+++ b/client/dns_record.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -93,6 +94,10 @@ func (c *Client) GetDNSRecord(ctx context.Context, recordID, teamID string) (r D
 		body:   "",
 	}, &r)
 	r.TeamID = c.TeamID(teamID)
+	if err == nil && r.TeamID == "" {
+		r.TeamID, err = c.dnsDomainTeamID(ctx, r.Domain)
+	}
+
 	return r, err
 }
 
@@ -159,4 +164,21 @@ func (c *Client) UpdateDNSRecord(ctx context.Context, teamID, recordID string, r
 	}, &r)
 	r.TeamID = c.TeamID(teamID)
 	return r, err
+}
+
+func (c *Client) dnsDomainTeamID(ctx context.Context, domain string) (string, error) {
+	var response struct {
+		Domain struct {
+			TeamID string `json:"teamId"`
+			UserID string `json:"userId"`
+		} `json:"domain"`
+	}
+	err := c.doRequest(clientRequest{ctx: ctx, method: "GET", url: fmt.Sprintf("%s/v5/domains/%s", c.baseURL, url.PathEscape(domain))}, &response)
+	if err != nil {
+		return "", fmt.Errorf("unable to determine DNS domain ownership: %w", err)
+	}
+	if response.Domain.TeamID == "" && response.Domain.UserID == "" {
+		return "", fmt.Errorf("unable to determine DNS domain ownership; include team_id in the import ID or configure team on the provider")
+	}
+	return response.Domain.TeamID, nil
 }

--- a/client/edge_config.go
+++ b/client/edge_config.go
@@ -110,3 +110,17 @@ func (c *Client) ListEdgeConfigs(ctx context.Context, teamID string) (e []EdgeCo
 	}, &e)
 	return e, err
 }
+
+func (c *Client) edgeConfigTeamID(ctx context.Context, id, teamID string) (string, error) {
+	if teamID = c.TeamID(teamID); teamID != "" {
+		return teamID, nil
+	}
+	parent, err := c.GetEdgeConfig(ctx, id, "")
+	if err != nil {
+		return "", fmt.Errorf("unable to determine Edge Config ownership: %w", err)
+	}
+	if parent.TeamID == "" {
+		return "", fmt.Errorf("unable to determine Edge Config ownership; include team_id in the import ID or configure team on the provider")
+	}
+	return parent.TeamID, nil
+}

--- a/client/edge_config_item.go
+++ b/client/edge_config_item.go
@@ -108,6 +108,11 @@ func (c *Client) DeleteEdgeConfigItem(ctx context.Context, request EdgeConfigIte
 }
 
 func (c *Client) GetEdgeConfigItem(ctx context.Context, request EdgeConfigItemRequest) (e EdgeConfigItem, err error) {
+	request.TeamID, err = c.edgeConfigTeamID(ctx, request.EdgeConfigID, request.TeamID)
+	if err != nil {
+		return e, err
+	}
+
 	url := fmt.Sprintf("%s/v1/edge-config/%s/item/%s", c.baseURL, request.EdgeConfigID, request.Key)
 	if c.TeamID(request.TeamID) != "" {
 		url = fmt.Sprintf("%s?teamId=%s", url, c.TeamID(request.TeamID))

--- a/client/edge_config_schema.go
+++ b/client/edge_config_schema.go
@@ -35,6 +35,11 @@ func (c *Client) UpsertEdgeConfigSchema(ctx context.Context, request EdgeConfigS
 }
 
 func (c *Client) GetEdgeConfigSchema(ctx context.Context, id, teamID string) (e EdgeConfigSchema, err error) {
+	teamID, err = c.edgeConfigTeamID(ctx, id, teamID)
+	if err != nil {
+		return e, err
+	}
+
 	url := fmt.Sprintf("%s/v1/edge-config/%s/schema", c.baseURL, id)
 	if c.TeamID(teamID) != "" {
 		url = fmt.Sprintf("%s?teamId=%s", url, c.TeamID(teamID))

--- a/client/edge_config_token.go
+++ b/client/edge_config_token.go
@@ -83,6 +83,11 @@ func (c *Client) DeleteEdgeConfigToken(ctx context.Context, request EdgeConfigTo
 }
 
 func (c *Client) GetEdgeConfigToken(ctx context.Context, request EdgeConfigTokenRequest) (e EdgeConfigToken, err error) {
+	request.TeamID, err = c.edgeConfigTeamID(ctx, request.EdgeConfigID, request.TeamID)
+	if err != nil {
+		return e, err
+	}
+
 	url := fmt.Sprintf("%s/v1/edge-config/%s/token/%s", c.baseURL, request.EdgeConfigID, request.Token)
 	if c.TeamID(request.TeamID) != "" {
 		url = fmt.Sprintf("%s?teamId=%s", url, c.TeamID(request.TeamID))

--- a/client/import_owner_test.go
+++ b/client/import_owner_test.go
@@ -1,0 +1,145 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestChildReadDiscoversImportOwner(t *testing.T) {
+	for _, op := range []struct {
+		name, parentPath, parentJSON, childPath, childJSON string
+		read                                               func(*Client, string) (string, error)
+	}{
+		{"edge config item", "/v1/edge-config/ec_1", `{"ownerId":"team_owner"}`, "/v1/edge-config/ec_1/item/key", `{"value":"test"}`, func(c *Client, team string) (string, error) {
+			r, e := c.GetEdgeConfigItem(context.Background(), EdgeConfigItemRequest{EdgeConfigID: "ec_1", Key: "key", TeamID: team})
+			return r.TeamID, e
+		}},
+		{"edge config schema", "/v1/edge-config/ec_1", `{"ownerId":"team_owner"}`, "/v1/edge-config/ec_1/schema", `{"definition":{}}`, func(c *Client, team string) (string, error) {
+			r, e := c.GetEdgeConfigSchema(context.Background(), "ec_1", team)
+			return r.TeamID, e
+		}},
+		{"edge config token", "/v1/edge-config/ec_1", `{"ownerId":"team_owner"}`, "/v1/edge-config/ec_1/token/token", `{"id":"tok_1"}`, func(c *Client, team string) (string, error) {
+			r, e := c.GetEdgeConfigToken(context.Background(), EdgeConfigTokenRequest{EdgeConfigID: "ec_1", Token: "token", TeamID: team})
+			return r.TeamID, e
+		}},
+		{"access group member", "/v1/access-groups/ag_1", `{"teamId":"team_owner"}`, "/v1/access-groups/ag_1/members", `{"members":[{"uid":"user_1"}]}`, func(c *Client, team string) (string, error) {
+			r, e := c.GetAccessGroupMember(context.Background(), GetAccessGroupMemberRequest{AccessGroupID: "ag_1", UserID: "user_1", TeamID: team})
+			return r.TeamID, e
+		}},
+		{"DNS record", "/v5/domains/example.com", `{"domain":{"teamId":"team_owner","userId":"user_1"}}`, "/domains/records/rec_1", `{"id":"rec_1","domain":"example.com"}`, func(c *Client, team string) (string, error) {
+			r, e := c.GetDNSRecord(context.Background(), "rec_1", team)
+			return r.TeamID, e
+		}},
+	} {
+		t.Run(op.name, func(t *testing.T) {
+			for _, tc := range []struct {
+				name, request, provider string
+				parentStatus            int
+				parentJSON              string
+				want                    string
+				wantError               bool
+			}{
+				{name: "unscoped import", parentJSON: op.parentJSON, want: "team_owner"},
+				{name: "explicit team", request: "team_explicit", want: "team_explicit"},
+				{name: "provider team", provider: "team_provider", want: "team_provider"},
+				{name: "parent lookup fails", parentStatus: 403, wantError: true},
+				{name: "parent owner omitted", parentJSON: `{}`, wantError: true},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					parentCalls := 0
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if r.Method != "GET" {
+							t.Errorf("unexpected method %s", r.Method)
+						}
+						switch r.URL.Path {
+						case op.parentPath:
+							parentCalls++
+							if tc.parentStatus != 0 {
+								w.WriteHeader(tc.parentStatus)
+								fmt.Fprint(w, `{"error":{"code":"forbidden","message":"forbidden"}}`)
+								return
+							}
+							fmt.Fprint(w, tc.parentJSON)
+						case op.childPath:
+							expected := tc.request
+							if expected == "" {
+								expected = tc.provider
+							}
+							if expected == "" && op.name != "DNS record" {
+								expected = "team_owner"
+							}
+							if got := r.URL.Query().Get("teamId"); got != expected {
+								t.Errorf("team query=%q, want %q", got, expected)
+							}
+							fmt.Fprint(w, op.childJSON)
+						default:
+							t.Errorf("unexpected path %s", r.URL.Path)
+							w.WriteHeader(404)
+						}
+					}))
+					defer server.Close()
+					c := New("test").WithBaseURL(server.URL).WithTeam(Team{ID: tc.provider})
+					got, err := op.read(c, tc.request)
+					if tc.wantError {
+						if err == nil {
+							t.Fatal("expected ownership error")
+						}
+						if !strings.Contains(err.Error(), "ownership") {
+							t.Errorf("missing ownership error context: %v", err)
+						}
+						return
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+					if got != tc.want {
+						t.Errorf("team=%q, want %q", got, tc.want)
+					}
+					expectedCalls := 1
+					if tc.request != "" || tc.provider != "" {
+						expectedCalls = 0
+					}
+					if parentCalls != expectedCalls {
+						t.Errorf("parent calls=%d, want %d", parentCalls, expectedCalls)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestDNSRecordPersonalOwner(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/domains/records/rec_1" {
+			fmt.Fprint(w, `{"domain":"example.com"}`)
+			return
+		}
+		fmt.Fprint(w, `{"domain":{"teamId":null,"userId":"user_1"}}`)
+	}))
+	defer server.Close()
+	r, err := New("test").WithBaseURL(server.URL).GetDNSRecord(context.Background(), "rec_1", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.TeamID != "" {
+		t.Errorf("personal record TeamID=%q, want empty", r.TeamID)
+	}
+}
+
+func TestKMSIssuerResponseOwner(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"id":"issuer_1","ownerId":"team_owner"}`)
+	}))
+	defer server.Close()
+	r, err := New("test").WithBaseURL(server.URL).GetKMSIssuer(context.Background(), "issuer_1", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.TeamID != "team_owner" {
+		t.Errorf("TeamID=%q, want team_owner", r.TeamID)
+	}
+}

--- a/client/kms.go
+++ b/client/kms.go
@@ -104,7 +104,10 @@ func (c *Client) CreateKMSIssuer(ctx context.Context, request CreateKMSIssuerReq
 	if err != nil {
 		return i, err
 	}
-	i.TeamID = c.TeamID(request.TeamID)
+	i.TeamID = i.OwnerID
+	if i.TeamID == "" {
+		i.TeamID = c.TeamID(request.TeamID)
+	}
 	return i, nil
 }
 
@@ -121,7 +124,10 @@ func (c *Client) GetKMSIssuer(ctx context.Context, issuerID, teamID string) (i K
 	if err != nil {
 		return i, err
 	}
-	i.TeamID = c.TeamID(teamID)
+	i.TeamID = i.OwnerID
+	if i.TeamID == "" {
+		i.TeamID = c.TeamID(teamID)
+	}
 	return i, nil
 }
 
@@ -150,7 +156,10 @@ func (c *Client) ListKMSIssuers(ctx context.Context, teamID string) (issuers []K
 		return nil, err
 	}
 	for i := range response.Issuers {
-		response.Issuers[i].TeamID = c.TeamID(teamID)
+		response.Issuers[i].TeamID = response.Issuers[i].OwnerID
+		if response.Issuers[i].TeamID == "" {
+			response.Issuers[i].TeamID = c.TeamID(teamID)
+		}
 	}
 	return response.Issuers, nil
 }
@@ -179,7 +188,10 @@ func (c *Client) UpdateKMSIssuer(ctx context.Context, request UpdateKMSIssuerReq
 	if err != nil {
 		return i, err
 	}
-	i.TeamID = c.TeamID(request.TeamID)
+	i.TeamID = i.OwnerID
+	if i.TeamID == "" {
+		i.TeamID = c.TeamID(request.TeamID)
+	}
 	return i, nil
 }
 

--- a/client/microfrontend_group.go
+++ b/client/microfrontend_group.go
@@ -124,7 +124,7 @@ func (c *Client) DeleteMicrofrontendGroup(ctx context.Context, request Microfron
 
 func (c *Client) GetMicrofrontendGroup(ctx context.Context, microfrontendGroupID string, teamID string) (r MicrofrontendGroup, err error) {
 	if c.TeamID(teamID) == "" {
-		return r, fmt.Errorf("team_id is required")
+		return r, fmt.Errorf("team_id is required: include it in the import ID or configure the provider team")
 	}
 	url := fmt.Sprintf("%s/v1/microfrontends/groups", c.baseURL)
 	if c.TeamID(teamID) != "" {

--- a/client/project.go
+++ b/client/project.go
@@ -85,7 +85,7 @@ func (c *Client) CreateProject(ctx context.Context, teamID string, request Creat
 	if err != nil {
 		return r, err
 	}
-	r.TeamID = c.TeamID(teamID)
+	r.resolveTeamID(c.TeamID(teamID))
 	r.normalizeBuildMachineType()
 	return r, err
 }
@@ -160,6 +160,7 @@ func (r *ProjectResponse) Repository() *Repository {
 
 // ProjectResponse defines the information Vercel returns about a project.
 type ProjectResponse struct {
+	AccountID                   string  `json:"accountId"`
 	BuildCommand                *string `json:"buildCommand"`
 	CommandForIgnoringBuildStep *string `json:"commandForIgnoringBuildStep"`
 	DevCommand                  *string `json:"devCommand"`
@@ -274,6 +275,19 @@ type ResourceConfig struct {
 	BuildMachineSelection     *string  `json:"buildMachineSelection,omitempty"`
 }
 
+// The API owner is authoritative: an unscoped request can return a team project.
+// Personal account IDs must not be used as team IDs in subsequent requests.
+func (r *ProjectResponse) resolveTeamID(fallback string) {
+	switch {
+	case strings.HasPrefix(r.AccountID, "team_"):
+		r.TeamID = r.AccountID
+	case r.AccountID != "":
+		r.TeamID = ""
+	default:
+		r.TeamID = fallback
+	}
+}
+
 // normalizeBuildMachineType collapses the API's (buildMachineType, buildMachineSelection)
 // pair into a single value for the provider: when selection is "elastic", the effective
 // type is "elastic" regardless of the concrete buildMachineType returned by the API (which
@@ -307,7 +321,7 @@ func (c *Client) GetProject(ctx context.Context, projectID, teamID string) (r Pr
 		return r, fmt.Errorf("unable to get project: %w", err)
 	}
 
-	r.TeamID = c.TeamID(teamID)
+	r.resolveTeamID(c.TeamID(teamID))
 	r.normalizeBuildMachineType()
 	return r, err
 }
@@ -332,7 +346,7 @@ func (c *Client) ListProjects(ctx context.Context, teamID string) (r []ProjectRe
 		body:   "",
 	}, &pr)
 	for i := range pr.Projects {
-		pr.Projects[i].TeamID = c.TeamID(teamID)
+		pr.Projects[i].resolveTeamID(c.TeamID(teamID))
 		pr.Projects[i].normalizeBuildMachineType()
 	}
 	return pr.Projects, err
@@ -401,7 +415,7 @@ func (c *Client) UpdateProject(ctx context.Context, projectID, teamID string, re
 		return r, err
 	}
 
-	r.TeamID = c.TeamID(teamID)
+	r.resolveTeamID(c.TeamID(teamID))
 	r.normalizeBuildMachineType()
 	return r, err
 }
@@ -431,7 +445,7 @@ func (c *Client) UpdateProductionBranch(ctx context.Context, request UpdateProdu
 	if err != nil {
 		return r, err
 	}
-	r.TeamID = c.TeamID(c.TeamID(request.TeamID))
+	r.resolveTeamID(c.TeamID(request.TeamID))
 	r.normalizeBuildMachineType()
 	return r, err
 }
@@ -452,7 +466,7 @@ func (c *Client) UnlinkGitRepoFromProject(ctx context.Context, projectID, teamID
 	if err != nil {
 		return r, fmt.Errorf("error unlinking git repo: %w", err)
 	}
-	r.TeamID = c.TeamID(teamID)
+	r.resolveTeamID(c.TeamID(teamID))
 	r.normalizeBuildMachineType()
 	return r, err
 }
@@ -482,7 +496,7 @@ func (c *Client) LinkGitRepoToProject(ctx context.Context, request LinkGitRepoTo
 	if err != nil {
 		return r, fmt.Errorf("error linking git repo: %w", err)
 	}
-	r.TeamID = c.TeamID(c.TeamID(request.TeamID))
+	r.resolveTeamID(c.TeamID(request.TeamID))
 	r.normalizeBuildMachineType()
 	return r, err
 }

--- a/client/project_crons.go
+++ b/client/project_crons.go
@@ -20,7 +20,7 @@ func (c *Client) GetProjectCrons(ctx context.Context, projectID, teamID string) 
 
 	return ProjectCrons{
 		ProjectID: projectID,
-		TeamID:    teamID,
+		TeamID:    r.TeamID,
 		Enabled:   r.Crons == nil || r.Crons.DisabledAt == nil,
 	}, err
 }
@@ -43,9 +43,10 @@ func (c *Client) UpdateProjectCrons(ctx context.Context, request ProjectCrons) (
 		body:   string(mustMarshal(request)),
 	}, &r)
 
+	r.resolveTeamID(c.TeamID(request.TeamID))
 	return ProjectCrons{
 		ProjectID: request.ProjectID,
-		TeamID:    request.TeamID,
+		TeamID:    r.TeamID,
 		Enabled:   r.Crons == nil || r.Crons.DisabledAt == nil,
 	}, err
 }

--- a/client/project_crons_test.go
+++ b/client/project_crons_test.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProjectCronsTeamOwnership(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodPatch} {
+		for _, tc := range []struct {
+			name, response, providerTeam, wantTeam string
+		}{
+			{"bare ID", `{"accountId":"team_owner","crons":{"disabledAt":123}}`, "", "team_owner"},
+			{"provider fallback", `{"crons":{"disabledAt":123}}`, "team_default", "team_default"},
+			{"personal owner", `{"accountId":"user_owner","crons":{"disabledAt":123}}`, "", ""},
+		} {
+			t.Run(method+"/"+tc.name, func(t *testing.T) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != method || r.URL.Query().Get("teamId") != tc.providerTeam {
+						t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(tc.response))
+				}))
+				t.Cleanup(server.Close)
+				c := New("TOKEN").WithBaseURL(server.URL).WithTeam(Team{ID: tc.providerTeam})
+				var out ProjectCrons
+				var err error
+				if method == http.MethodGet {
+					out, err = c.GetProjectCrons(context.Background(), "prj_123", "")
+				} else {
+					out, err = c.UpdateProjectCrons(context.Background(), ProjectCrons{ProjectID: "prj_123", Enabled: false})
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				if out.TeamID != tc.wantTeam || out.ProjectID != "prj_123" || out.Enabled {
+					t.Fatalf("unexpected crons: %#v; want team %q and disabled", out, tc.wantTeam)
+				}
+			})
+		}
+	}
+}

--- a/client/project_deployment_retention.go
+++ b/client/project_deployment_retention.go
@@ -111,6 +111,10 @@ func (c *Client) GetDeploymentRetention(ctx context.Context, projectID, teamID s
 		url:    url,
 		body:   "",
 	}, &p)
+	if err != nil {
+		return DeploymentExpirationResponse{}, err
+	}
+	p.resolveTeamID(c.TeamID(teamID))
 	if p.DeploymentExpiration == nil {
 		return DeploymentExpirationResponse{
 			DeploymentExpiration: DeploymentExpiration{
@@ -119,11 +123,11 @@ func (c *Client) GetDeploymentRetention(ctx context.Context, projectID, teamID s
 				ExpirationCanceled:   36500,
 				ExpirationErrored:    36500,
 			},
-			TeamID: c.TeamID(teamID),
+			TeamID: p.TeamID,
 		}, nil
 	}
 	return DeploymentExpirationResponse{
 		DeploymentExpiration: *p.DeploymentExpiration,
-		TeamID:               c.TeamID(teamID),
+		TeamID:               p.TeamID,
 	}, err
 }

--- a/client/project_deployment_retention_test.go
+++ b/client/project_deployment_retention_test.go
@@ -1,0 +1,50 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetDeploymentRetentionTeamOwnership(t *testing.T) {
+	for _, tc := range []struct {
+		name, response, wantTeam string
+		wantPreview              int
+	}{
+		{"team with retention", `{"accountId":"team_owner","deploymentExpiration":{"expirationDays":30}}`, "team_owner", 30},
+		{"team with defaults", `{"accountId":"team_owner"}`, "team_owner", 36500},
+		{"personal with defaults", `{"accountId":"user_owner"}`, "", 36500},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || r.URL.Path != "/v2/projects/prj_123" || r.URL.RawQuery != "" {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.response))
+			}))
+			t.Cleanup(server.Close)
+			out, err := New("TOKEN").WithBaseURL(server.URL).GetDeploymentRetention(context.Background(), "prj_123", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if out.TeamID != tc.wantTeam || out.ExpirationPreview != tc.wantPreview {
+				t.Fatalf("unexpected retention: %#v; want team %q, preview %d", out, tc.wantTeam, tc.wantPreview)
+			}
+		})
+	}
+}
+
+func TestGetDeploymentRetentionReturnsReadError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":"not_found","message":"Project not found"}}`))
+	}))
+	t.Cleanup(server.Close)
+	_, err := New("TOKEN").WithBaseURL(server.URL).GetDeploymentRetention(context.Background(), "prj_missing", "")
+	if !NotFound(err) {
+		t.Fatalf("error = %v, want not found", err)
+	}
+}

--- a/client/project_ownership_test.go
+++ b/client/project_ownership_test.go
@@ -1,0 +1,83 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProjectResponseOwnership(t *testing.T) {
+	for _, operation := range []struct {
+		name string
+		run  func(*Client, string) (ProjectResponse, error)
+	}{
+		{"get", func(c *Client, team string) (ProjectResponse, error) {
+			return c.GetProject(context.Background(), "prj_test", team)
+		}},
+		{"create", func(c *Client, team string) (ProjectResponse, error) {
+			return c.CreateProject(context.Background(), team, CreateProjectRequest{})
+		}},
+		{"update", func(c *Client, team string) (ProjectResponse, error) {
+			return c.UpdateProject(context.Background(), "prj_test", team, UpdateProjectRequest{})
+		}},
+		{"branch", func(c *Client, team string) (ProjectResponse, error) {
+			return c.UpdateProductionBranch(context.Background(), UpdateProductionBranchRequest{ProjectID: "prj_test", TeamID: team})
+		}},
+		{"link", func(c *Client, team string) (ProjectResponse, error) {
+			return c.LinkGitRepoToProject(context.Background(), LinkGitRepoToProjectRequest{ProjectID: "prj_test", TeamID: team})
+		}},
+		{"unlink", func(c *Client, team string) (ProjectResponse, error) {
+			return c.UnlinkGitRepoFromProject(context.Background(), "prj_test", team)
+		}},
+		{"list", func(c *Client, team string) (ProjectResponse, error) {
+			p, err := c.ListProjects(context.Background(), team)
+			if err != nil {
+				return ProjectResponse{}, err
+			}
+			if len(p) != 1 {
+				return ProjectResponse{}, fmt.Errorf("got %d projects", len(p))
+			}
+			return p[0], nil
+		}},
+	} {
+		t.Run(operation.name, func(t *testing.T) {
+			for _, tc := range []struct{ name, account, explicit, provider, want string }{
+				{name: "unscoped team", account: "team_owner", want: "team_owner"},
+				{name: "personal", account: "user_owner"},
+				{name: "response overrides scope", account: "team_owner", explicit: "team_scope", provider: "team_default", want: "team_owner"},
+				{name: "personal overrides scope", account: "user_owner", provider: "team_default"},
+				{name: "missing owner explicit fallback", explicit: "team_scope", provider: "team_default", want: "team_scope"},
+				{name: "missing owner provider fallback", provider: "team_default", want: "team_default"},
+				{name: "missing owner no scope"},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					h := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						scope := tc.explicit
+						if scope == "" {
+							scope = tc.provider
+						}
+						if got := r.URL.Query().Get("teamId"); got != scope {
+							t.Errorf("request team = %q, want %q", got, scope)
+						}
+						body := fmt.Sprintf(`{"id":"prj_test","accountId":%q}`, tc.account)
+						if operation.name == "list" {
+							body = `{"projects":[` + body + `]}`
+						}
+						fmt.Fprintln(w, body)
+					}))
+					defer h.Close()
+					c := New("test").WithBaseURL(h.URL).WithTeam(Team{ID: tc.provider})
+					p, err := operation.run(c, tc.explicit)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if p.TeamID != tc.want {
+						t.Fatalf("team = %q, want %q", p.TeamID, tc.want)
+					}
+				})
+			}
+		})
+	}
+}

--- a/client/response_team_test.go
+++ b/client/response_team_test.go
@@ -1,0 +1,100 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResponseTeamOwnership(t *testing.T) {
+	operations := []struct {
+		name       string
+		method     string
+		path       string
+		ownerField string
+		list       bool
+		call       func(*Client, string) (string, error)
+	}{
+		{"get attack challenge mode", "GET", "/v10/projects/prj_1", "accountId", false, func(c *Client, team string) (string, error) {
+			r, err := c.GetAttackChallengeMode(context.Background(), "prj_1", team)
+			return r.TeamID, err
+		}},
+		{"get shared environment variable", "GET", "/v1/env/env_1", "ownerId", false, func(c *Client, team string) (string, error) {
+			r, err := c.GetSharedEnvironmentVariable(context.Background(), team, "env_1")
+			return r.TeamID, err
+		}},
+		{"list shared environment variables", "GET", "/v1/env/all", "ownerId", true, func(c *Client, team string) (string, error) {
+			r, err := c.ListSharedEnvironmentVariablesPage(context.Background(), ListSharedEnvironmentVariablesRequest{TeamID: team})
+			if err != nil {
+				return "", err
+			}
+			if len(r.EnvironmentVariables) != 1 {
+				return "", fmt.Errorf("expected one environment variable, got %d", len(r.EnvironmentVariables))
+			}
+			return r.EnvironmentVariables[0].TeamID, nil
+		}},
+		{"get access group", "GET", "/v1/access-groups/ag_1", "teamId", false, func(c *Client, team string) (string, error) {
+			r, err := c.GetAccessGroup(context.Background(), GetAccessGroupRequest{TeamID: team, AccessGroupID: "ag_1"})
+			return r.TeamID, err
+		}},
+		{"create access group", "POST", "/v1/access-groups", "teamId", false, func(c *Client, team string) (string, error) {
+			r, err := c.CreateAccessGroup(context.Background(), CreateAccessGroupRequest{TeamID: team, Name: "test"})
+			return r.TeamID, err
+		}},
+		{"update access group", "POST", "/v1/access-groups/ag_1", "teamId", false, func(c *Client, team string) (string, error) {
+			r, err := c.UpdateAccessGroup(context.Background(), UpdateAccessGroupRequest{TeamID: team, AccessGroupID: "ag_1", Name: "test"})
+			return r.TeamID, err
+		}},
+		{"create access group project", "POST", "/v1/access-groups/ag_1/projects", "teamId", false, func(c *Client, team string) (string, error) {
+			r, err := c.CreateAccessGroupProject(context.Background(), CreateAccessGroupProjectRequest{TeamID: team, AccessGroupID: "ag_1", ProjectID: "prj_1", Role: "ADMIN"})
+			return r.TeamID, err
+		}},
+		{"update access group project", "PATCH", "/v1/access-groups/ag_1/projects/prj_1", "teamId", false, func(c *Client, team string) (string, error) {
+			r, err := c.UpdateAccessGroupProject(context.Background(), UpdateAccessGroupProjectRequest{TeamID: team, AccessGroupID: "ag_1", ProjectID: "prj_1", Role: "ADMIN"})
+			return r.TeamID, err
+		}},
+	}
+	for _, op := range operations {
+		t.Run(op.name, func(t *testing.T) {
+			for _, tc := range []struct{ name, owner, requestTeam, providerTeam, want string }{
+				{"bare ID discovers owner", "team_owner", "", "", "team_owner"},
+				{"response owner preserved", "team_owner", "team_request", "team_provider", "team_owner"},
+				{"missing owner uses request", "", "team_request", "team_provider", "team_request"},
+				{"missing owner uses provider", "", "", "team_provider", "team_provider"},
+				{"missing owner and fallback", "", "", "", ""},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if r.Method != op.method || r.URL.Path != op.path {
+							t.Errorf("request = %s %s, want %s %s", r.Method, r.URL.Path, op.method, op.path)
+						}
+						wantQuery := tc.requestTeam
+						if wantQuery == "" {
+							wantQuery = tc.providerTeam
+						}
+						if r.URL.Query().Get("teamId") != wantQuery {
+							t.Errorf("teamId query = %q, want %q", r.URL.Query().Get("teamId"), wantQuery)
+						}
+						response := map[string]any{op.ownerField: tc.owner}
+						if op.list {
+							response = map[string]any{"data": []any{response}}
+						}
+						_ = json.NewEncoder(w).Encode(response)
+					}))
+					defer server.Close()
+					c := New("test").WithBaseURL(server.URL).WithTeam(Team{ID: tc.providerTeam})
+					got, err := op.call(c, tc.requestTeam)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if got != tc.want {
+						t.Errorf("TeamID = %q, want %q", got, tc.want)
+					}
+				})
+			}
+		})
+	}
+}

--- a/client/shared_environment_variable.go
+++ b/client/shared_environment_variable.go
@@ -137,7 +137,9 @@ func (c *Client) GetSharedEnvironmentVariable(ctx context.Context, teamID, envID
 		url:    url,
 		body:   "",
 	}, &e)
-	e.TeamID = c.TeamID(teamID)
+	if e.TeamID == "" {
+		e.TeamID = c.TeamID(teamID)
+	}
 	return e, err
 }
 
@@ -175,7 +177,9 @@ func (c *Client) ListSharedEnvironmentVariablesPage(ctx context.Context, request
 		body:   "",
 	}, &res)
 	for i := 0; i < len(res.Data); i++ {
-		res.Data[i].TeamID = c.TeamID(request.TeamID)
+		if res.Data[i].TeamID == "" {
+			res.Data[i].TeamID = c.TeamID(request.TeamID)
+		}
 	}
 	return ListSharedEnvironmentVariablesResponse{
 		EnvironmentVariables: res.Data,

--- a/docs/guides/importing.md
+++ b/docs/guides/importing.md
@@ -1,0 +1,53 @@
+---
+page_title: "Importing existing resources"
+subcategory: ""
+description: |-
+  Import existing Vercel resources with the correct team ownership.
+---
+
+# Importing existing resources
+
+Use the import format documented for the resource. Most resources accept an optional team ID prefix. For example:
+
+```shell
+terraform import vercel_project.example team_xxxxxxxxxxxxxxxxxxxxxxxx/prj_xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+terraform import vercel_project_domain.example team_xxxxxxxxxxxxxxxxxxxxxxxx/prj_xxxxxxxxxxxxxxxxxxxxxxxxxxxx/example.com
+```
+
+You can also configure the default team on the provider and omit the team prefix where the resource's import format allows it:
+
+```terraform
+provider "vercel" {
+  team = "team_xxxxxxxxxxxxxxxxxxxxxxxx"
+}
+```
+
+The resource's `team_id` configuration is not an import scope. Supply the team in the import ID or provider configuration if the API requires a scoped request.
+
+## Ownership discovery
+
+An explicit import team takes precedence over the provider's default team for requests. The provider preserves ownership returned by the resource API. When neither import nor provider specifies a team and the child API does not return ownership, the provider reads the parent before importing:
+
+| Resource | Ownership source |
+| --- | --- |
+| Project settings, domains, environment variables, custom environments, feature flags, firewall settings, deployment protection exceptions, routes, tracing, and VCR repositories/permissions | Project |
+| Edge Config items, schemas, and tokens | Edge Config store |
+| Access group members | Access group |
+| Blob project connections | Blob store |
+| KMS signing keys and project grants | KMS issuer |
+| DNS records | Domain |
+| Microfrontend group memberships | Project scope, then microfrontend group |
+
+These lookups require permission to read the parent. If ownership cannot be determined, the import fails; supply the team explicitly or configure the provider team and retry. Ownership discovery does not bypass API access controls, and endpoints that require a team may reject an unscoped request.
+
+Personal-account ownership remains null for resources that support it, including personal projects and DNS records. A user token without a team scope also legitimately has a null `team_id`.
+
+## Resources with required scope
+
+Some resources require an explicit team in their documented import format, such as team members and firewall bypass entries. Microfrontend groups require either an import team or a provider team because their API lists groups within a team. Team configuration uses the team itself as its import ID.
+
+Empty identifiers, including an empty team prefix such as `/project_id`, are rejected. Use the documented form without the optional prefix instead.
+
+## Existing imported state
+
+Review the next plan after upgrading. Reads that already retrieve ownership can correct older state. Child resources whose ownership lookup runs only during import may need to be re-imported with the correct team to repair older null state. Do not apply an unexpected replacement solely to correct an imported `team_id`.

--- a/vercel/import_project_team.go
+++ b/vercel/import_project_team.go
@@ -1,0 +1,27 @@
+package vercel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
+)
+
+// importProjectTeam resolves ownership before reading project settings whose APIs
+// do not return their owner. Explicit import and provider team scopes take priority.
+func importProjectTeam(ctx context.Context, c *client.Client, projectID, teamID string, resp *resource.ImportStateResponse) (string, bool) {
+	if teamID = c.TeamID(teamID); teamID != "" {
+		return teamID, true
+	}
+	project, err := c.GetProject(ctx, projectID, "")
+	if err != nil {
+		resp.Diagnostics.AddError("Error resolving project ownership", fmt.Sprintf("Could not read project %s to determine its team: %s", projectID, err))
+		return "", false
+	}
+	if project.AccountID == "" && project.TeamID == "" {
+		resp.Diagnostics.AddError("Error resolving project ownership", fmt.Sprintf("Project %s did not return its owner. Include team_id in the import ID or configure a provider team.", projectID))
+		return "", false
+	}
+	return project.TeamID, true
+}

--- a/vercel/import_project_team_test.go
+++ b/vercel/import_project_team_test.go
@@ -1,0 +1,142 @@
+package vercel
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
+)
+
+func TestProjectTracingImportTeamOwnership(t *testing.T) {
+	for _, tc := range []struct {
+		name, importID, providerTeam, owner, wantTeam string
+		wantLookups                                   int
+	}{
+		{"bare team project", "prj_123", "", "team_owner", "team_owner", 1},
+		{"personal project", "prj_123", "", "user_owner", "", 1},
+		{"explicit team", "team_explicit/prj_123", "team_default", "", "team_explicit", 0},
+		{"provider team", "prj_123", "team_default", "", "team_default", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lookups, settingsReads := 0, 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if req.URL.Path == "/v10/projects/prj_123" {
+					lookups++
+					if req.URL.Query().Get("teamId") != "" {
+						t.Error("ownership lookup should be unscoped")
+					}
+					_, _ = fmt.Fprintf(w, `{"id":"prj_123","accountId":%q}`, tc.owner)
+					return
+				}
+				settingsReads++
+				if req.URL.Path != "/v1/drains/tracing/config" || req.URL.Query().Get("teamId") != tc.wantTeam {
+					t.Errorf("unexpected settings request: %s", req.URL)
+				}
+				_, _ = fmt.Fprint(w, `{"enabled":true,"sampling":[]}`)
+			}))
+			t.Cleanup(server.Close)
+			r := &projectTracingResource{client: client.New("token").WithBaseURL(server.URL).WithTeam(client.Team{ID: tc.providerTeam})}
+			ctx := context.Background()
+			var schema resource.SchemaResponse
+			r.Schema(ctx, resource.SchemaRequest{}, &schema)
+			resp := resource.ImportStateResponse{State: tfsdk.State{Schema: schema.Schema}}
+			r.ImportState(ctx, resource.ImportStateRequest{ID: tc.importID}, &resp)
+			if resp.Diagnostics.HasError() {
+				t.Fatal(resp.Diagnostics)
+			}
+			var team types.String
+			if diags := resp.State.GetAttribute(ctx, path.Root("team_id"), &team); diags.HasError() {
+				t.Fatal(diags)
+			}
+			if !team.Equal(toTeamID(tc.wantTeam)) {
+				t.Fatalf("team = %s, want %s", team, toTeamID(tc.wantTeam))
+			}
+			read := resource.ReadResponse{State: resp.State}
+			r.Read(ctx, resource.ReadRequest{State: resp.State}, &read)
+			if read.Diagnostics.HasError() {
+				t.Fatal(read.Diagnostics)
+			}
+			if !resp.State.Raw.Equal(read.State.Raw) {
+				t.Fatal("refresh changed imported state")
+			}
+			if lookups != tc.wantLookups || settingsReads != 2 {
+				t.Fatalf("lookups=%d reads=%d", lookups, settingsReads)
+			}
+		})
+	}
+}
+
+func TestProjectChildImportsRejectOwnershipLookupFailure(t *testing.T) {
+	c := client.New("token")
+	for _, tc := range []struct {
+		name, importID string
+		r              resource.ResourceWithImportState
+	}{
+		{"bulk redirects", "prj_123", &bulkRedirectsResource{client: c}},
+		{"custom environment", "prj_123/staging", &customEnvironmentResource{client: c}},
+		{"deployment protection exception", "prj_123/example.com", &deploymentProtectionExceptionResource{client: c}},
+		{"flag definition", "prj_123/flag", &featureFlagDefinitionResource{client: c}},
+		{"flag config", "prj_123/flag", &featureFlagConfigResource{client: c}},
+		{"flag segment", "prj_123/segment", &featureFlagSegmentResource{client: c}},
+		{"flag SDK key", "prj_123/key", &featureFlagSDKKeyResource{client: c}},
+		{"firewall config", "prj_123", &firewallConfigResource{client: c}},
+		{"protection bypass", "prj_123/secret", &projectProtectionBypassResource{client: c}},
+		{"environment variable", "prj_123/env", &projectEnvironmentVariableResource{client: c}},
+		{"route", "prj_123/route", &projectRouteResource{client: c}},
+		{"rolling release", "prj_123", &projectRollingReleaseResource{client: c}},
+		{"domain", "prj_123/example.com", &projectDomainResource{client: c}},
+		{"tracing", "prj_123", &projectTracingResource{client: c}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				requests++
+				if req.URL.Path != "/v10/projects/prj_123" {
+					t.Errorf("unexpected request: %s", req.URL)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = fmt.Fprint(w, `{"error":{"code":"forbidden","message":"Forbidden"}}`)
+			}))
+			t.Cleanup(server.Close)
+			c.WithBaseURL(server.URL)
+			ctx := context.Background()
+			var schema resource.SchemaResponse
+			tc.r.Schema(ctx, resource.SchemaRequest{}, &schema)
+			resp := resource.ImportStateResponse{State: tfsdk.State{Schema: schema.Schema}}
+			tc.r.ImportState(ctx, resource.ImportStateRequest{ID: tc.importID}, &resp)
+			if !resp.Diagnostics.HasError() || !resp.State.Raw.IsNull() || requests != 1 {
+				t.Fatalf("failed lookup must stop import: requests=%d, diagnostics=%v, state=%v", requests, resp.Diagnostics, resp.State.Raw)
+			}
+		})
+	}
+}
+
+func TestProjectImportRejectsMissingOwner(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"prj_123"}`)
+	}))
+	t.Cleanup(server.Close)
+	resp := &resource.ImportStateResponse{}
+	_, ok := importProjectTeam(context.Background(), client.New("token").WithBaseURL(server.URL), "prj_123", "", resp)
+	if ok || !resp.Diagnostics.HasError() {
+		t.Fatalf("missing owner must fail: ok=%v diagnostics=%v", ok, resp.Diagnostics)
+	}
+}
+
+func TestSplitBypassIDRejectsEmptyComponents(t *testing.T) {
+	for _, id := range []string{"/prj#example.com#1.2.3.4", "team/#example.com#1.2.3.4", "team/prj##1.2.3.4", "team/prj#example.com#", "team/prj#"} {
+		if _, _, _, _, ok := splitBypassID(id); ok {
+			t.Errorf("accepted malformed ID %q", id)
+		}
+	}
+}

--- a/vercel/import_registry_team_unit_test.go
+++ b/vercel/import_registry_team_unit_test.go
@@ -1,0 +1,115 @@
+package vercel
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/vercel/terraform-provider-vercel/v5/client"
+)
+
+func TestRegistryAndMembershipImportOwnership(t *testing.T) {
+	for _, tc := range []struct {
+		name, id string
+		make     func(*client.Client) resource.ResourceWithImportState
+	}{
+		{"repository", "prj_123/example", func(c *client.Client) resource.ResourceWithImportState { return &vcrRepositoryResource{client: c} }},
+		{"permission", "prj_123/example/team_grantee", func(c *client.Client) resource.ResourceWithImportState {
+			return &vcrRepositoryPermissionResource{client: c}
+		}},
+		{"microfrontend membership", "mfe_123/prj_123", func(c *client.Client) resource.ResourceWithImportState {
+			return &microfrontendGroupMembershipResource{client: c}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, scope := range []string{"discovered", "provider", "explicit", "lookup failure"} {
+				t.Run(scope, func(t *testing.T) {
+					discovery := 0
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.Header().Set("Content-Type", "application/json")
+						if r.URL.Path == "/v10/projects/prj_123" && r.URL.Query().Get("teamId") == "" {
+							discovery++
+							if scope == "lookup failure" {
+								w.WriteHeader(403)
+								fmt.Fprint(w, `{"error":{"code":"forbidden","message":"Forbidden"}}`)
+								return
+							}
+						} else if r.URL.Path != "/v2/teams/team_owner" && r.URL.Query().Get("teamId") != "team_owner" {
+							t.Errorf("unscoped child request: %s", r.URL)
+						}
+						switch r.URL.Path {
+						case "/v10/projects/prj_123":
+							fmt.Fprint(w, `{"id":"prj_123","name":"project","accountId":"team_owner"}`)
+						case "/v2/teams/team_owner":
+							fmt.Fprint(w, `{"id":"team_owner","slug":"owner"}`)
+						case "/v1/vcr/repository/example":
+							fmt.Fprint(w, `{"repository":{"id":"repo_123","name":"example","projectId":"prj_123"}}`)
+						case "/v1/vcr/repository/example/permissions":
+							fmt.Fprint(w, `{"permissions":[{"repositoryId":"repo_123","teamId":"team_grantee","teamSlug":"grantee"}]}`)
+						case "/v1/microfrontends/groups":
+							fmt.Fprint(w, `{"groups":[{"group":{"id":"mfe_123","name":"group","slug":"group"},"projects":[{"id":"prj_123","microfrontends":{"enabled":true,"isDefaultApp":true}}]}]}`)
+						default:
+							t.Errorf("unexpected URL %s", r.URL)
+							http.NotFound(w, r)
+						}
+					}))
+					defer server.Close()
+					c := client.New("token").WithBaseURL(server.URL)
+					id := tc.id
+					if scope == "provider" {
+						c.WithTeam(client.Team{ID: "team_owner", Slug: "owner"})
+					}
+					if scope == "explicit" {
+						id = "team_owner/" + id
+					}
+					res := tc.make(c)
+					ctx := context.Background()
+					sr := resource.SchemaResponse{}
+					res.Schema(ctx, resource.SchemaRequest{}, &sr)
+					resp := resource.ImportStateResponse{State: tfsdk.State{Schema: sr.Schema}}
+					res.ImportState(ctx, resource.ImportStateRequest{ID: id}, &resp)
+					if scope == "lookup failure" {
+						if !resp.Diagnostics.HasError() {
+							t.Fatal("expected ownership error")
+						}
+						return
+					}
+					if resp.Diagnostics.HasError() {
+						t.Fatal(resp.Diagnostics)
+					}
+					var team types.String
+					if d := resp.State.GetAttribute(ctx, path.Root("team_id"), &team); d.HasError() {
+						t.Fatal(d)
+					}
+					if team.ValueString() != "team_owner" {
+						t.Fatalf("team = %s", team)
+					}
+					wantDiscovery := 0
+					if scope == "discovered" {
+						wantDiscovery = 1
+					}
+					if discovery != wantDiscovery {
+						t.Errorf("discovery reads = %d, want %d", discovery, wantDiscovery)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestMicrofrontendGroupImportRequiresTeam(t *testing.T) {
+	ctx := context.Background()
+	res := microfrontendGroupResource{client: client.New("token")}
+	resp := resource.ImportStateResponse{}
+	res.ImportState(ctx, resource.ImportStateRequest{ID: "mfe_123"}, &resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected missing team error")
+	}
+}

--- a/vercel/resource_ai_gateway_api_key.go
+++ b/vercel/resource_ai_gateway_api_key.go
@@ -524,7 +524,7 @@ func (r *aiGatewayAPIKeyResource) ImportState(ctx context.Context, req resource.
 		return
 	}
 
-	quota, err := r.client.GetAIGatewayAPIKeyQuota(ctx, keyID, teamID)
+	quota, err := r.client.GetAIGatewayAPIKeyQuota(ctx, keyID, out.TeamID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error importing AI Gateway API Key",

--- a/vercel/resource_blob_project_connection.go
+++ b/vercel/resource_blob_project_connection.go
@@ -277,6 +277,20 @@ func (r *blobProjectConnectionResource) ImportState(ctx context.Context, req res
 		return
 	}
 
+	teamID = r.client.TeamID(teamID)
+	if teamID == "" {
+		store, err := r.client.GetBlobStore(ctx, storeID, "")
+		if err != nil {
+			resp.Diagnostics.AddError("Error importing Blob store project connection", fmt.Sprintf("Could not determine Blob store ownership: %s", err))
+			return
+		}
+		teamID = store.TeamID
+		if teamID == "" {
+			resp.Diagnostics.AddError("Error importing Blob store project connection", "Could not determine Blob store ownership. Include team_id in the import ID or configure team on the provider.")
+			return
+		}
+	}
+
 	connection, err := r.client.GetBlobStoreConnection(ctx, storeID, connectionID, teamID)
 	if client.NotFound(err) {
 		resp.State.RemoveResource(ctx)

--- a/vercel/resource_bulk_redirects.go
+++ b/vercel/resource_bulk_redirects.go
@@ -333,6 +333,11 @@ func (r *bulkRedirectsResource) ImportState(ctx context.Context, req resource.Im
 		return
 	}
 
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
+		return
+	}
+
 	out, live, err := readLiveBulkRedirects(ctx, r.client, projectID, teamID)
 	if client.NotFound(err) {
 		resp.State.RemoveResource(ctx)

--- a/vercel/resource_child_import_team_unit_test.go
+++ b/vercel/resource_child_import_team_unit_test.go
@@ -1,0 +1,80 @@
+package vercel
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
+)
+
+func TestChildImportTeamOwnership(t *testing.T) {
+	for _, op := range []struct {
+		name, importID, parentPath, parentJSON, childPath, childJSON string
+		resource                                                     func(*client.Client) resource.ResourceWithImportState
+	}{
+		{"edge config item", "ec_1/key", "/v1/edge-config/ec_1", `{"ownerId":"team_owner"}`, "/v1/edge-config/ec_1/item/key", `{"edgeConfigId":"ec_1","key":"key","value":"hello"}`, func(c *client.Client) resource.ResourceWithImportState { return &edgeConfigItemResource{client: c} }},
+		{"blob connection", "store_1/conn_1", "/v1/storage/stores/store_1", `{"store":{"ownerId":"team_owner"}}`, "/v1/storage/stores/store_1/connections", `{"connections":[{"id":"conn_1","projectId":"prj_1","envVarEnvironments":["production"]}]}`, func(c *client.Client) resource.ResourceWithImportState {
+			return &blobProjectConnectionResource{client: c}
+		}},
+	} {
+		t.Run(op.name, func(t *testing.T) {
+			for _, fail := range []bool{false, true} {
+				t.Run(fmt.Sprintf("owner_missing_%t", fail), func(t *testing.T) {
+					childCalled := false
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						switch r.URL.Path {
+						case op.parentPath:
+							if fail {
+								fmt.Fprint(w, `{}`)
+							} else {
+								fmt.Fprint(w, op.parentJSON)
+							}
+						case op.childPath:
+							childCalled = true
+							if r.URL.Query().Get("teamId") != "team_owner" {
+								t.Errorf("child request lacks recovered team: %s", r.URL)
+							}
+							fmt.Fprint(w, op.childJSON)
+						default:
+							t.Errorf("unexpected path %s", r.URL.Path)
+							w.WriteHeader(404)
+						}
+					}))
+					defer server.Close()
+					res := op.resource(client.New("test").WithBaseURL(server.URL))
+					schema := resource.SchemaResponse{}
+					res.Schema(context.Background(), resource.SchemaRequest{}, &schema)
+					resp := resource.ImportStateResponse{State: tfsdk.State{Schema: schema.Schema}}
+					res.ImportState(context.Background(), resource.ImportStateRequest{ID: op.importID}, &resp)
+					if fail {
+						if !resp.Diagnostics.HasError() {
+							t.Fatal("expected ownership diagnostic")
+						}
+						if childCalled {
+							t.Fatal("child queried after ownership could not be established")
+						}
+						return
+					}
+					if resp.Diagnostics.HasError() {
+						t.Fatal(resp.Diagnostics)
+					}
+					var team types.String
+					diags := resp.State.GetAttribute(context.Background(), path.Root("team_id"), &team)
+					if diags.HasError() {
+						t.Fatal(diags)
+					}
+					if team.ValueString() != "team_owner" {
+						t.Errorf("imported team=%s", team)
+					}
+				})
+			}
+		})
+	}
+}

--- a/vercel/resource_custom_environment.go
+++ b/vercel/resource_custom_environment.go
@@ -212,7 +212,7 @@ func convertResponseToModel(res client.CustomEnvironmentResponse) CustomEnvironm
 	}
 	return CustomEnvironment{
 		ID:             types.StringValue(res.ID),
-		TeamID:         types.StringValue(res.TeamID),
+		TeamID:         toTeamID(res.TeamID),
 		ProjectID:      types.StringValue(res.ProjectID),
 		Name:           types.StringValue(res.Slug),
 		Description:    types.StringValue(res.Description),
@@ -354,6 +354,11 @@ func (r *customEnvironmentResource) ImportState(ctx context.Context, req resourc
 			"Error importing Custom Environment",
 			fmt.Sprintf("Invalid id '%s' specified. should be in format \"team_id/project_id/custom_environment_name\" or \"project_id/custom_environment_name\"", req.ID),
 		)
+		return
+	}
+
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
 		return
 	}
 	res, err := r.client.GetCustomEnvironment(ctx, client.GetCustomEnvironmentRequest{

--- a/vercel/resource_deployment_protection_exception.go
+++ b/vercel/resource_deployment_protection_exception.go
@@ -311,6 +311,11 @@ func (r *deploymentProtectionExceptionResource) ImportState(ctx context.Context,
 		return
 	}
 
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
+		return
+	}
+
 	out, err := r.client.GetAlias(ctx, alias, teamID)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/vercel/resource_feature_flag_config.go
+++ b/vercel/resource_feature_flag_config.go
@@ -237,6 +237,11 @@ func (r *featureFlagConfigResource) ImportState(ctx context.Context, req resourc
 		return
 	}
 
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
+		return
+	}
+
 	out, err := r.client.GetFeatureFlag(ctx, client.GetFeatureFlagRequest{
 		ProjectID: projectID,
 		TeamID:    teamID,
@@ -256,7 +261,7 @@ func (r *featureFlagConfigResource) ImportState(ctx context.Context, req resourc
 
 	result, diags := featureFlagConfigFromClient(out, featureFlagConfigModel{
 		ProjectID: types.StringValue(projectID),
-		TeamID:    types.StringValue(r.client.TeamID(teamID)),
+		TeamID:    toTeamID(teamID),
 		FlagID:    types.StringValue(flagID),
 		ID:        types.StringValue(flagID),
 	})

--- a/vercel/resource_feature_flag_definition.go
+++ b/vercel/resource_feature_flag_definition.go
@@ -386,6 +386,11 @@ func (r *featureFlagDefinitionResource) ImportState(ctx context.Context, req res
 		return
 	}
 
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
+		return
+	}
+
 	out, err := r.client.GetFeatureFlag(ctx, client.GetFeatureFlagRequest{
 		ProjectID: projectID,
 		TeamID:    teamID,
@@ -405,7 +410,7 @@ func (r *featureFlagDefinitionResource) ImportState(ctx context.Context, req res
 
 	result, diags := featureFlagDefinitionFromClient(out, featureFlagDefinitionModel{
 		ProjectID: types.StringValue(projectID),
-		TeamID:    types.StringValue(r.client.TeamID(teamID)),
+		TeamID:    toTeamID(teamID),
 	})
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/vercel/resource_feature_flag_sdk_key.go
+++ b/vercel/resource_feature_flag_sdk_key.go
@@ -252,6 +252,11 @@ func (r *featureFlagSDKKeyResource) ImportState(ctx context.Context, req resourc
 		return
 	}
 
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
+		return
+	}
+
 	keys, err := r.client.ListFeatureFlagSDKKeys(ctx, client.ListFeatureFlagSDKKeysRequest{
 		ProjectID: projectID,
 		TeamID:    teamID,
@@ -271,7 +276,7 @@ func (r *featureFlagSDKKeyResource) ImportState(ctx context.Context, req resourc
 
 		result := featureFlagSDKKeyFromClient(key, featureFlagSDKKeyModel{
 			ProjectID: types.StringValue(projectID),
-			TeamID:    types.StringValue(r.client.TeamID(teamID)),
+			TeamID:    toTeamID(teamID),
 		})
 		diags := resp.State.Set(ctx, result)
 		resp.Diagnostics.Append(diags...)

--- a/vercel/resource_feature_flag_segment.go
+++ b/vercel/resource_feature_flag_segment.go
@@ -335,6 +335,11 @@ func (r *featureFlagSegmentResource) ImportState(ctx context.Context, req resour
 		return
 	}
 
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
+		return
+	}
+
 	out, err := r.client.GetFeatureFlagSegment(ctx, client.GetFeatureFlagSegmentRequest{
 		ProjectID: projectID,
 		TeamID:    teamID,
@@ -354,7 +359,7 @@ func (r *featureFlagSegmentResource) ImportState(ctx context.Context, req resour
 
 	result, diags := featureFlagSegmentFromClient(ctx, out, featureFlagSegmentModel{
 		ProjectID: types.StringValue(projectID),
-		TeamID:    types.StringValue(r.client.TeamID(teamID)),
+		TeamID:    toTeamID(teamID),
 	})
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/vercel/resource_firewall_bypass.go
+++ b/vercel/resource_firewall_bypass.go
@@ -254,12 +254,17 @@ func (r *firewallBypassResource) Delete(ctx context.Context, req resource.Delete
 
 func splitBypassID(id string) (string, string, string, string, bool) {
 	split := strings.SplitN(id, "/", 2)
-	if len(split) != 2 {
+	if len(split) != 2 || split[0] == "" {
 		return "", "", "", "", false
 	}
 	teamId := split[0]
 
 	idParts := strings.Split(split[1], "#")
+	for _, part := range idParts {
+		if part == "" {
+			return "", "", "", "", false
+		}
+	}
 	switch len(idParts) {
 	case 2:
 		return teamId, idParts[0], "*", idParts[1], true

--- a/vercel/resource_firewall_config.go
+++ b/vercel/resource_firewall_config.go
@@ -932,7 +932,7 @@ func fromClient(conf client.FirewallConfig, state FirewallConfig, mode firewallF
 	cfg := FirewallConfig{
 		ID:        types.StringValue(conf.TeamID + "/" + conf.ProjectID),
 		ProjectID: state.ProjectID,
-		TeamID:    types.StringValue(conf.TeamID),
+		TeamID:    toTeamID(conf.TeamID),
 		Enabled:   types.BoolValue(conf.Enabled),
 	}
 	if mode == preserveConfiguredShape && conf.Enabled && state.Enabled.IsNull() {
@@ -1749,6 +1749,11 @@ func (r *firewallConfigResource) ImportState(ctx context.Context, req resource.I
 		)
 		return
 	}
+
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
+		return
+	}
 	out, err := r.client.GetFirewallConfig(ctx, projectID, teamID)
 	if err != nil {
 		resp.Diagnostics.AddError("Error importing Firewall Config", err.Error())
@@ -1756,7 +1761,7 @@ func (r *firewallConfigResource) ImportState(ctx context.Context, req resource.I
 	}
 	conf, err := fromClient(out, FirewallConfig{
 		ProjectID: types.StringValue(projectID),
-		TeamID:    types.StringValue(out.TeamID),
+		TeamID:    toTeamID(out.TeamID),
 	}, canonicalImportShape)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to read firewall config", err.Error())

--- a/vercel/resource_kms_project_grant.go
+++ b/vercel/resource_kms_project_grant.go
@@ -230,7 +230,7 @@ func (r *kmsProjectGrantResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	result, diags := r.modelFromResponse(ctx, state.IssuerID.ValueString(), state.ProjectID.ValueString(), toTeamID(r.client.TeamID(state.TeamID.ValueString())), policy, state)
+	result, diags := r.modelFromResponse(ctx, state.IssuerID.ValueString(), state.ProjectID.ValueString(), toTeamID(out.TeamID), policy, state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -343,7 +343,7 @@ func (r *kmsProjectGrantResource) ImportState(ctx context.Context, req resource.
 		return
 	}
 
-	result, diags := r.modelFromResponse(ctx, issuerID, projectID, toTeamID(r.client.TeamID(teamID)), policy, kmsProjectGrantResourceModel{})
+	result, diags := r.modelFromResponse(ctx, issuerID, projectID, toTeamID(out.TeamID), policy, kmsProjectGrantResourceModel{})
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/vercel/resource_kms_signing_key.go
+++ b/vercel/resource_kms_signing_key.go
@@ -242,7 +242,7 @@ func (r *kmsSigningKeyResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	teamID := toTeamID(r.client.TeamID(state.TeamID.ValueString()))
+	teamID := toTeamID(out.TeamID)
 	result := r.modelFromResponse(key, teamID, state.IssuerID, state.Keepers, state.ImportKey, state.ImportKeyID, state.RevokePreviousAt)
 	diags = resp.State.Set(ctx, result)
 	resp.Diagnostics.Append(diags...)
@@ -326,7 +326,7 @@ func (r *kmsSigningKeyResource) ImportState(ctx context.Context, req resource.Im
 		return
 	}
 
-	result := r.modelFromResponse(key, toTeamID(r.client.TeamID(teamID)), types.StringValue(issuerID), types.MapNull(types.StringType), types.StringNull(), types.StringNull(), types.StringNull())
+	result := r.modelFromResponse(key, toTeamID(out.TeamID), types.StringValue(issuerID), types.MapNull(types.StringType), types.StringNull(), types.StringNull(), types.StringNull())
 	diags := resp.State.Set(ctx, result)
 	resp.Diagnostics.Append(diags...)
 }

--- a/vercel/resource_microfrontend_group_membership.go
+++ b/vercel/resource_microfrontend_group_membership.go
@@ -324,6 +324,11 @@ func (r *microfrontendGroupMembershipResource) ImportState(ctx context.Context, 
 		)
 		return
 	}
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
+		return
+	}
+
 	out, err := r.client.GetMicrofrontendGroupMembership(ctx, teamID, microfrontendID, projectID)
 	if client.NotFound(err) {
 		resp.State.RemoveResource(ctx)

--- a/vercel/resource_project_deployment_retention.go
+++ b/vercel/resource_project_deployment_retention.go
@@ -154,7 +154,7 @@ func convertResponseToProjectDeploymentRetention(response client.DeploymentExpir
 		ExpirationProduction: types.StringValue(client.DeploymentRetentionDaysToString[response.ExpirationProduction]),
 		ExpirationCanceled:   types.StringValue(client.DeploymentRetentionDaysToString[response.ExpirationCanceled]),
 		ExpirationErrored:    types.StringValue(client.DeploymentRetentionDaysToString[response.ExpirationErrored]),
-		TeamID:               types.StringValue(response.TeamID),
+		TeamID:               toTeamID(response.TeamID),
 		ProjectID:            projectID,
 	}
 }

--- a/vercel/resource_project_domain.go
+++ b/vercel/resource_project_domain.go
@@ -507,6 +507,11 @@ func (r *projectDomainResource) ImportState(ctx context.Context, req resource.Im
 		return
 	}
 
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
+		return
+	}
+
 	out, err := r.client.GetProjectDomain(ctx, projectID, domain, teamID)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/vercel/resource_project_environment_variable.go
+++ b/vercel/resource_project_environment_variable.go
@@ -572,6 +572,11 @@ func (r *projectEnvironmentVariableResource) ImportState(ctx context.Context, re
 		return
 	}
 
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
+		return
+	}
+
 	out, err := r.client.GetEnvironmentVariable(ctx, projectID, teamID, envID)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/vercel/resource_project_import_unit_test.go
+++ b/vercel/resource_project_import_unit_test.go
@@ -1,0 +1,129 @@
+package vercel
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/vercel/terraform-provider-vercel/v5/client"
+)
+
+func TestProjectImportAndReadOwnership(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name           string
+		importID       string
+		configuredTeam client.Team
+		accountID      string
+		requestTeam    string
+		wantTeam       string
+	}{
+		{
+			name:      "bare ID discovers team owner",
+			importID:  "prj_123",
+			accountID: "team_123",
+			wantTeam:  "team_123",
+		},
+		{
+			name:        "explicit team",
+			importID:    "team_123/prj_123",
+			accountID:   "team_123",
+			requestTeam: "team_123",
+			wantTeam:    "team_123",
+		},
+		{
+			name:           "provider team",
+			importID:       "prj_123",
+			configuredTeam: client.Team{ID: "team_123"},
+			accountID:      "team_123",
+			requestTeam:    "team_123",
+			wantTeam:       "team_123",
+		},
+		{
+			name:      "personal owner remains null",
+			importID:  "prj_123",
+			accountID: "user_123",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("method = %s, want GET", r.Method)
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				switch r.URL.Path {
+				case "/v10/projects/prj_123":
+					if got := r.URL.Query().Get("teamId"); got != tt.requestTeam {
+						t.Errorf("project request teamId = %q, want %q", got, tt.requestTeam)
+					}
+					_, _ = fmt.Fprintf(w, `{"id":"prj_123","name":"test-project","accountId":%q}`, tt.accountID)
+				case "/v8/projects/prj_123/env":
+					if got := r.URL.Query().Get("teamId"); got != tt.wantTeam {
+						t.Errorf("environment request teamId = %q, want discovered owner %q", got, tt.wantTeam)
+					}
+					_, _ = fmt.Fprint(w, `{"envs":[]}`)
+				default:
+					t.Errorf("unexpected path: %s", r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			res := &projectResource{client: client.New("token").WithBaseURL(server.URL).WithTeam(tt.configuredTeam)}
+			schemaResp := &resource.SchemaResponse{}
+			res.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+			if schemaResp.Diagnostics.HasError() {
+				t.Fatalf("schema diagnostics: %v", schemaResp.Diagnostics)
+			}
+			importResp := &resource.ImportStateResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+			res.ImportState(ctx, resource.ImportStateRequest{ID: tt.importID}, importResp)
+			if importResp.Diagnostics.HasError() {
+				t.Fatalf("import diagnostics: %v", importResp.Diagnostics)
+			}
+			assertProjectOwnership(t, importResp.State, tt.wantTeam)
+
+			var prior Project
+			if diags := importResp.State.Get(ctx, &prior); diags.HasError() {
+				t.Fatalf("get state diagnostics: %v", diags)
+			}
+			// Older bare-ID imports stored null even for team-owned projects.
+			prior.TeamID = toTeamID(tt.requestTeam)
+			if diags := importResp.State.Set(ctx, prior); diags.HasError() {
+				t.Fatalf("set prior state diagnostics: %v", diags)
+			}
+			readResp := &resource.ReadResponse{State: importResp.State}
+			res.Read(ctx, resource.ReadRequest{State: importResp.State}, readResp)
+			if readResp.Diagnostics.HasError() {
+				t.Fatalf("read diagnostics: %v", readResp.Diagnostics)
+			}
+			assertProjectOwnership(t, readResp.State, tt.wantTeam)
+		})
+	}
+}
+
+func assertProjectOwnership(t *testing.T, state tfsdk.State, wantTeam string) {
+	t.Helper()
+	var project Project
+	if diags := state.Get(context.Background(), &project); diags.HasError() {
+		t.Fatalf("get state diagnostics: %v", diags)
+	}
+	if project.ID.ValueString() != "prj_123" {
+		t.Errorf("id = %q, want prj_123", project.ID.ValueString())
+	}
+	want := types.StringNull()
+	if wantTeam != "" {
+		want = types.StringValue(wantTeam)
+	}
+	if !project.TeamID.Equal(want) {
+		t.Errorf("team_id = %s, want %s", project.TeamID, want)
+	}
+}

--- a/vercel/resource_project_protection_bypass.go
+++ b/vercel/resource_project_protection_bypass.go
@@ -379,6 +379,11 @@ func (r *projectProtectionBypassResource) ImportState(ctx context.Context, req r
 		return
 	}
 
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
+		return
+	}
+
 	bypass, err := r.client.GetProtectionBypass(ctx, projectID, teamID, secret)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/vercel/resource_project_rolling_release.go
+++ b/vercel/resource_project_rolling_release.go
@@ -324,7 +324,7 @@ func ConvertResponseToRollingRelease(response client.RollingReleaseInfo, plan *R
 	result := RollingReleaseInfo{
 		ID:        types.StringValue(response.ProjectID),
 		ProjectID: types.StringValue(response.ProjectID),
-		TeamID:    types.StringValue(response.TeamID),
+		TeamID:    toTeamID(response.TeamID),
 	}
 
 	// If disabled or advancementType is empty, check if we have stages to determine if it's configured
@@ -634,6 +634,11 @@ func (r *projectRollingReleaseResource) ImportState(ctx context.Context, req res
 			"Error importing project rolling release",
 			fmt.Sprintf("Invalid id '%s' specified. should be in format \"team_id/project_id\" or \"project_id\"", req.ID),
 		)
+		return
+	}
+
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
 		return
 	}
 

--- a/vercel/resource_project_route.go
+++ b/vercel/resource_project_route.go
@@ -679,6 +679,11 @@ func (r *projectRouteResource) ImportState(ctx context.Context, req resource.Imp
 		return
 	}
 
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
+		return
+	}
+
 	result, diags, err := readProjectRoute(ctx, r.client, routeID, projectID, teamID, ProjectRoute{}, ProjectRoutePosition{})
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/vercel/resource_project_tracing.go
+++ b/vercel/resource_project_tracing.go
@@ -255,6 +255,11 @@ func (r *projectTracingResource) ImportState(ctx context.Context, req resource.I
 		return
 	}
 
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
+		return
+	}
+
 	out, err := r.client.GetProjectTracing(ctx, projectID, teamID)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/vercel/resource_vcr_repository.go
+++ b/vercel/resource_vcr_repository.go
@@ -310,6 +310,11 @@ func (r *vcrRepositoryResource) ImportState(ctx context.Context, req resource.Im
 		return
 	}
 
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
+		return
+	}
+
 	res, err := r.client.GetVCRRepository(ctx, client.GetVCRRepositoryRequest{
 		TeamID:    teamID,
 		ProjectID: projectID,

--- a/vercel/resource_vcr_repository_permission.go
+++ b/vercel/resource_vcr_repository_permission.go
@@ -289,6 +289,11 @@ func (r *vcrRepositoryPermissionResource) ImportState(ctx context.Context, req r
 		return
 	}
 
+	teamID, ok = importProjectTeam(ctx, r.client, projectID, teamID, resp)
+	if !ok {
+		return
+	}
+
 	res, err := r.client.GetVCRRepositoryPermission(ctx, client.GetVCRRepositoryPermissionRequest{
 		TeamID:          teamID,
 		ProjectID:       projectID,

--- a/vercel/split.go
+++ b/vercel/split.go
@@ -3,6 +3,9 @@ package vercel
 import "strings"
 
 func splitInto2(id string) (firstID, secondID string, ok bool) {
+	if id == "" || strings.HasPrefix(id, "/") || strings.HasSuffix(id, "/") || strings.Contains(id, "//") {
+		return "", "", false
+	}
 	attributes := strings.Split(id, "/")
 	if len(attributes) != 2 {
 		return "", "", false
@@ -14,6 +17,9 @@ func splitInto2(id string) (firstID, secondID string, ok bool) {
 // splitInto2Or3 is a helper function for splitting an import ID into the corresponding parts.
 // It also validates whether the ID is in a correct format.
 func splitInto2Or3(id string) (teamID, firstID, secondID string, ok bool) {
+	if id == "" || strings.HasPrefix(id, "/") || strings.HasSuffix(id, "/") || strings.Contains(id, "//") {
+		return "", "", "", false
+	}
 	attributes := strings.Split(id, "/")
 	if len(attributes) == 2 {
 		return "", attributes[0], attributes[1], true
@@ -27,6 +33,9 @@ func splitInto2Or3(id string) (teamID, firstID, secondID string, ok bool) {
 // splitInto3Or4 is a helper function for splitting an import ID into the corresponding parts.
 // It also validates whether the ID is in a correct format.
 func splitInto3Or4(id string) (teamID, firstID, secondID, thirdID string, ok bool) {
+	if id == "" || strings.HasPrefix(id, "/") || strings.HasSuffix(id, "/") || strings.Contains(id, "//") {
+		return "", "", "", "", false
+	}
 	attributes := strings.Split(id, "/")
 	if len(attributes) == 3 {
 		return "", attributes[0], attributes[1], attributes[2], true
@@ -40,6 +49,9 @@ func splitInto3Or4(id string) (teamID, firstID, secondID, thirdID string, ok boo
 // splitInto1Or2 is a helper function for splitting an import ID into the corresponding parts.
 // It also validates whether the ID is in a correct format.
 func splitInto1Or2(id string) (teamID, firstID string, ok bool) {
+	if id == "" || strings.HasPrefix(id, "/") || strings.HasSuffix(id, "/") || strings.Contains(id, "//") {
+		return "", "", false
+	}
 	if strings.Contains(id, "/") {
 		attributes := strings.Split(id, "/")
 		if len(attributes) != 2 {

--- a/vercel/split_unit_test.go
+++ b/vercel/split_unit_test.go
@@ -1,0 +1,27 @@
+package vercel
+
+import "testing"
+
+func TestImportIDsRejectEmptyComponents(t *testing.T) {
+	for _, parser := range []struct {
+		name  string
+		parse func(string) bool
+		valid string
+	}{
+		{"two", func(id string) bool { _, _, ok := splitInto2(id); return ok }, "team/user"},
+		{"one or two", func(id string) bool { _, _, ok := splitInto1Or2(id); return ok }, "project"},
+		{"two or three", func(id string) bool { _, _, _, ok := splitInto2Or3(id); return ok }, "project/resource"},
+		{"three or four", func(id string) bool { _, _, _, _, ok := splitInto3Or4(id); return ok }, "project/repository/grantee"},
+	} {
+		t.Run(parser.name, func(t *testing.T) {
+			for _, id := range []string{"", "/", "/user", "team/", "/project/resource", "team//resource", "project/resource/", "team/project//grantee"} {
+				if parser.parse(id) {
+					t.Errorf("accepted import ID %q with an empty component", id)
+				}
+			}
+			if !parser.parse(parser.valid) {
+				t.Errorf("rejected valid ID %q", parser.valid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Preserve team ownership when importing existing Vercel resources. Bare project IDs now use the API's `accountId`, and response-owned resources retain the team returned by the API instead of overwriting it with an empty request scope.

Cover all 48 resources that support import. When a child API omits ownership, resolve it from the project, Edge Config store, access group, Blob store, KMS issuer, or DNS domain. Explicit import teams and provider defaults still scope requests; personal ownership remains null where supported. Required-team import formats remain required, and malformed IDs with empty components are rejected.

Unscoped child imports now require read access to their parent. Existing null state may require re-importing for resources whose discovery runs only during import. The new import guide describes ownership discovery and required scopes; this does not add import support to resources that previously lacked it.

Fixes #596. [ORC-5355](https://linear.app/vercel/issue/ORC-5355/bug-importing-project-with-bare-id-and-not-including-team-id-is-a).
